### PR TITLE
Cached endpoint status query for 30 seconds

### DIFF
--- a/resource_server/utils.py
+++ b/resource_server/utils.py
@@ -116,3 +116,20 @@ def get_compute_executor(endpoint_id=None, client=None, amqp_port=443):
     # Create Compute Executor
     return gce
 
+
+# Get endpoint status
+@cached(cache=TTLCache(maxsize=1024, ttl=30))
+def get_endpoint_status(endpoint_uuid=None, client=None, endpoint_slug=None):
+    """
+    Query the status of a Globus Compute endpoint. It caches the 
+    result for 30 seconds to avoid generating a too-many-request
+    from Globus services when sereval incoming requests target 
+    an endpoint that is offline.
+    """
+
+    try:
+        return client.get_endpoint_status(endpoint_uuid)
+    except globus_sdk.GlobusAPIError as e:
+        return f"Error: Cannot access the status of endpoint {endpoint_slug}: {e}"
+    except Exception as e:
+        return f"Error: Cannot access the status of endpoint {endpoint_slug}: {e}"


### PR DESCRIPTION
This is to avoid generating Globus too-many-request errors when query the Compute endpoint status too many times. This happens when several concurrent requests are sent to the server targeting an endpoint that is offline.