### PR TITLE
fixed virtual env issue with cron job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 __pycache__/
 .DS_Store
 .env
-cron_logs.txt
+update_batch_status_error.log
+update_batch_status_output.log
 
 # VS code
 .vscode/

--- a/cron_jobs/README.md
+++ b/cron_jobs/README.md
@@ -8,9 +8,9 @@ On the VM, as the `webportal` user, add a crontab with the following command:
 ```bash
 crontab -e
 ```
-and include the following line to execute the update command every minute:
+and include the following line to execute the update command every 10 minutes:
 ```bash
-*/1 * * * * /home/webportal/inference-gateway/cron_jobs/update_batch_status.sh
+*/10 * * * * /home/webportal/inference-gateway/cron_jobs/update_batch_status.sh >> /home/webportal/inference-gateway/cron_jobs/update_batch_status_output.log 2>> /home/webportal/inference-gateway/cron_jobs/update_batch_status_error.log
 ```
 
 Make sure you set execution permission:

--- a/cron_jobs/update_batch_status.sh
+++ b/cron_jobs/update_batch_status.sh
@@ -1,6 +1,5 @@
-cd /home/webportal/inference-gateway
-source .venv/bin/activate
-echo "-------------------" >> /home/webportal/inference-gateway/cron_jobs/cron_logs.txt
-date '+%d/%m/%Y_%H:%M:%S' >> /home/webportal/inference-gateway/cron_jobs/cron_logs.txt
-echo "executing update_batch_status" >> /home/webportal/inference-gateway/cron_jobs/cron_logs.txt
-python3 manage.py update_batch_status
+echo "-------------------" >> /home/webportal/inference-gateway/cron_jobs/update_batch_status_output.log
+date '+%d/%m/%Y_%H:%M:%S' >> /home/webportal/inference-gateway/cron_jobs/update_batch_status_output.log
+echo "-------------------" >> /home/webportal/inference-gateway/cron_jobs/update_batch_status_error.log
+date '+%d/%m/%Y_%H:%M:%S' >> /home/webportal/inference-gateway/cron_jobs/update_batch_status_error.log
+/home/webportal/inference-gateway/.venv/bin/python /home/webportal/inference-gateway/manage.py update_batch_status


### PR DESCRIPTION
The virtual environment (source .venv/bin/activate) was not properly loaded when using crontab. The solution was to call the python executable using the full path, pointing to the virtual env. Also added standard output and error log files in order to better monitor the cron activities.