### PR TITLE
adjusted policy timeout error message

### DIFF
--- a/utils/auth_utils.py
+++ b/utils/auth_utils.py
@@ -115,11 +115,11 @@ def check_globus_policies(introspection):
         if policies.get("evaluation",False) == False:
             error_message = "Error: Permission denied from internal policies. "
             error_message += "This is likely due to a high-assurance timeout. "
-            error_message += "Please try to re-authenticate with the following command: "
+            error_message += "Please logout by visiting https://app.globus.org/logout, "
+            error_message += "and re-authenticate with the following command: "
             error_message += "'python3 inference_auth_token.py authenticate --force'. "
-            error_message += "If this is due to an unauthorized identity provider, "
-            error_message += "please logout by visiting https://app.globus.org/logout, "
-            error_message += f"and re-authenticate with {settings.AUTHORIZED_IDP_NAMES}."
+            error_message += "Make sure you authenticate with an authorized identity provider: "
+            error_message += f"{settings.AUTHORIZED_IDP_NAMES}."
             return False, error_message
 
     # Return True if the user met all of the policies requirements


### PR DESCRIPTION
Moving the https://app.globus.org/logout statement upfront as part of the "forced" re-authentication process.