### PR TITLE
Executor recovery

### DIFF
--- a/utils/globus_utils.py
+++ b/utils/globus_utils.py
@@ -102,7 +102,7 @@ async def submit_and_get_result(gce, endpoint_uuid, function_uuid, resources_rea
     except Exception as e:
         if "is shutdown" in str(e):
             executor_cache.clear()
-            time.sleep(1)
+            time.sleep(2)
         return None, None, f"Error: Could not start the Globus Compute task: {e}", 500
 
     # Wait for the Globus Compute result using asyncio and coroutine


### PR DESCRIPTION
This will remove the executor from the cache if the executor becomes shut down. The next request will thereafter re-build the executor from scratch and cache the new version. I included a synchronous 2 second sleep in case people generate the error in a loop (or while multi-threading). We do not want a new Executor to be created too frequently, otherwise we may encounter some rate limit imposed by Globus, which would cause further problems.