### PR TITLE
adding .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.env
+.env.*
+.venv/


### PR DESCRIPTION
add .dockerignore so that .env secrets don't get accidentally baked into the docker images.