### PR TITLE
Group check

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ GLOBUS_APPLICATION_SECRET="<Your-Gateway-Service-API-Globus-App-Client-Secret>"
 # GLOBUS_GROUPS="<group-uuid-1> <group-uuid-2>"
 # Optional: Enforce specific Identity Provider usage (JSON string)
 # AUTHORIZED_IDPS='{"Your Institution Domain": "your-institution-uuid"}'
+# AUTHORIZED_GROUPS_PER_IDP='{"Institution Domain": "coma-separated list of group uuids"}'
 # Optional: Enforce Globus high assurance policies (space-separated UUIDs)
 # GLOBUS_POLICIES="<policy-uuid-1>"
 # Client ID and Secret of the Globus Service Account application

--- a/inference_gateway/settings.py
+++ b/inference_gateway/settings.py
@@ -71,6 +71,11 @@ AUTHORIZED_IDPS = json.loads(os.getenv("AUTHORIZED_IDPS", "{}"))
 AUTHORIZED_IDP_DOMAINS = list(AUTHORIZED_IDPS.keys())
 AUTHORIZED_IDP_UUIDS = list(AUTHORIZED_IDPS.values())
 
+# Extract list of allowed groups per identity providers
+AUTHORIZED_GROUPS_PER_IDP = json.loads(os.getenv("AUTHORIZED_GROUPS_PER_IDP", "{}"))
+for key, value in AUTHORIZED_GROUPS_PER_IDP.items():
+    AUTHORIZED_GROUPS_PER_IDP[key] = [v.strip() for v in value.split(",")]
+
 # THIS SHOULD BE CHANGED
 ALLOWED_HOSTS = ["*"]
 

--- a/resource_server_async/api.py
+++ b/resource_server_async/api.py
@@ -55,6 +55,9 @@ class GlobalAuth(HttpBearer):
         # Introspect the access token
         atv_response = validate_access_token(request)
 
+        # Add whether the access token got granted because of a special Globus Groups membership
+        access_log_data.authorized_groups = atv_response.idp_group_overlap_str
+
         # Raise an error if the access token if not valid or if the user is not authorized
         if not atv_response.is_valid:
             _ = await create_access_log(access_log_data, atv_response.error_message, atv_response.error_code)

--- a/utils/auth_utils.py
+++ b/utils/auth_utils.py
@@ -125,10 +125,9 @@ def _perform_token_introspection(bearer_token: str):
     except Exception as e:
         return None, [], f"Error: Could not create GroupsClient. {e}"
 
-    # Get the user's group memberships
+    # Get the list of user's group memberships
     try:
         user_groups_response = groups_client.get_my_groups()
-        # Convert to serializable list
         user_groups = [group["id"] for group in user_groups_response]
     except Exception as e:
         return None, [], f"Error: Could not recover user group memberships. {e}"
@@ -239,6 +238,34 @@ def check_session_info(introspection):
     return False, None, f"Error: Permission denied. Must authenticate with {settings.AUTHORIZED_IDP_DOMAINS}. Currently authenticated as {user_str}."
 
 
+# Check Session Info
+def check_groups_per_idp(user: UserPydantic, user_groups: List[str]):
+    """
+        Make sure the user is part of an authorized Globus Group (if any)
+        associated with a given identity provider.
+    """
+
+    # Extract the identity provider's UUID
+    idp_domain = next((k for k, v in settings.AUTHORIZED_IDPS.items() if v == user.idp_id), None)
+    if idp_domain is None:
+        return False, "Error: Could not check groups per IdP, user.idp_id did not match any AUTHORIZED_IDPS values."
+    
+    # If there is a Globus Group check tied to this identity provider ...
+    if idp_domain in settings.AUTHORIZED_GROUPS_PER_IDP:
+
+        # Error if the user is a member of any authorized Globus Groups
+        group_overlap = set(user_groups) & set(settings.AUTHORIZED_GROUPS_PER_IDP[idp_domain])
+        if len(group_overlap) == 0:
+            return False, f"Error: Permission denied. User ({user.name} - {user.username}) not part of the Globus Groups applied for {user.idp_name}."
+        
+        # Grant request if user is part of at least one authorized Globus Groups
+        else:
+            return True, "" 
+
+    # Grant request if no group restriction was found
+    return True, ""
+
+
 # Validate access token sent by user
 def validate_access_token(request):
     """This function returns an instance of the ATVResponse pydantic data structure."""
@@ -282,6 +309,11 @@ def validate_access_token(request):
         successful, error_message = check_globus_policies(introspection)
         if not successful:
             return ATVResponse(is_valid=False, error_message=error_message, error_code=403)
+        
+    # Make sure the user is part of a per-IdP authorized group (if any)
+    successful, error_message = check_groups_per_idp(user, user_groups)
+    if not successful:
+        return ATVResponse(is_valid=False, error_message=error_message, error_code=403)
 
     # Make sure the authenticated user is at least in one of the allowed Globus Groups
     if settings.NUMBER_OF_GLOBUS_GROUPS > 0:

--- a/utils/pydantic_models/db_models.py
+++ b/utils/pydantic_models/db_models.py
@@ -19,6 +19,7 @@ class AccessLogPydantic(BaseModel):
     origin_ip: Optional[str] = Field(default=None)
     status_code: Optional[str] = Field(default=None)
     error: Optional[str] = Field(default=None)
+    authorized_groups: Optional[str] = Field(default=None)
 
 class RequestLogPydantic(BaseModel):
     id: str


### PR DESCRIPTION
Adding group check applied per identity provider. The additional .env variable is:

# Key = IDP domain, value = coma-seperated list of Group UUIDs
AUTHORIZED_GROUPS_PER_IDP='
{
    "domain": "group-uuid-1, group-uuid-2"
}
'

If user authenticates with a domain that is in AUTHORIZED_GROUPS_PER_IDP, it will do a Group check on top of the HA policy. If the request is granted, the groups that were used to gain access will be recorded in AccessLog.authorized_groups.

If the user authenticates with a domain that is **not** in AUTHORIZED_GROUPS_PER_IDP, only the HA policy will be applied.