### PR TITLE
added user group uuid in the whoami response

### DIFF
--- a/resource_server_async/views.py
+++ b/resource_server_async/views.py
@@ -85,6 +85,7 @@ async def whoami(request):
             id=request.auth.id,
             name=request.auth.name,
             username=request.auth.username,
+            user_group_uuids=request.user_group_uuids,
             idp_id=request.auth.idp_id,
             idp_name=request.auth.idp_name,
             auth_service=request.auth.auth_service

--- a/utils/auth_utils.py
+++ b/utils/auth_utils.py
@@ -181,7 +181,7 @@ def check_globus_groups(user_groups):
     
 
 # Check Session Info
-def check_session_info(introspection):
+def check_session_info(introspection, user_groups):
     """
         Look into the session_info field of the token introspection
         and check whether the authentication was made through one 
@@ -211,6 +211,7 @@ def check_session_info(introspection):
                                 id=identity["sub"],
                                 name=identity["name"],
                                 username=identity["username"],
+                                user_group_uuids=user_groups,
                                 idp_id=identity["identity_provider"],
                                 idp_name=identity["identity_provider_display_name"],
                                 auth_service=AuthService.GLOBUS.value
@@ -303,7 +304,7 @@ def validate_access_token(request):
         return ATVResponse(is_valid=False, error_message="Error: Access token expired.", error_code=401)
     
     # Make sure the authentication was made by an authorized identity provider
-    successful, user, error_message = check_session_info(introspection)
+    successful, user, error_message = check_session_info(introspection, user_groups)
     if not successful:
         return ATVResponse(is_valid=False, error_message=error_message, error_code=403)
 

--- a/utils/pydantic_models/db_models.py
+++ b/utils/pydantic_models/db_models.py
@@ -1,11 +1,12 @@
 from datetime import datetime
 from pydantic import BaseModel, Field
-from typing import Any, Optional
+from typing import Any, Optional, List
 
 class UserPydantic(BaseModel):
     id: str
     name: str
     username: str
+    user_group_uuids: List[str]
     idp_id: str
     idp_name: str
     auth_service: str


### PR DESCRIPTION
Adding user group UUIDs in the whoami response so that we can do additional auth checks on the webui.
We do not record this in the database since globus group affiliations are dynamic and are subject to change with time.