### PR TITLE
Rate limit

### DIFF
--- a/inference_gateway/settings.py
+++ b/inference_gateway/settings.py
@@ -43,6 +43,9 @@ GLOBUS_GROUP_MANAGER_SECRET = os.getenv("GLOBUS_GROUP_MANAGER_SECRET", "")
 ENABLE_BATCHES = os.getenv("ENABLE_BATCHES", False) == 'True'
 MAX_BATCHES_PER_USER = int(os.getenv("MAX_BATCHES_PER_USER", 1))
 
+# Rate limit (req/s) per user accross the board
+RATE_LIMIT_PER_SEC_PER_USER = int(os.getenv("RATE_LIMIT_PER_SEC_PER_USER", 10))
+
 # Django debug on/off switch
 DEBUG = os.getenv("DEBUG", "False").lower() in ("true", "1", "t")
 

--- a/resource_server_async/utils.py
+++ b/resource_server_async/utils.py
@@ -55,6 +55,28 @@ class ResourceServerError(Exception):
     pass
 
 
+# Is cached
+def is_cached(key: str, create_empty: bool = False, ttl: int = 30) -> bool:
+    """
+        Returns True if key exists in the cache, False otherwise.
+        If create_empty=True, a non-existing key will be created with a "" value (function will still returns False).
+    """
+
+    # If the key does not exist ...
+    if cache.get(key) is None:
+
+        # Create an empty entry if needed
+        if create_empty:
+            cache.set(key, "", ttl)
+
+        # Return False since the key did not exist at first
+        return False
+    
+    # Return True if the key already exists
+    else:
+        return True
+                
+
 # Validate cluster and framework
 def validate_cluster_framework(cluster: str, framework: str):
 


### PR DESCRIPTION
* Adjusting rate limit per authenticated user
* Adding request.user light object to make sure Ninja Throttles see authenticated users
* Added re-usable function to check if something is in the cache
* Bypass database operations for repeating Auth errors that are the same
NOTE: did not do it here, but we could in the future re-use the same logic for all kinds of errors.