### PR TITLE
Auth IdP streamlined + error message edit 

### DIFF
--- a/inference_gateway/apps.py
+++ b/inference_gateway/apps.py
@@ -20,14 +20,11 @@ class AuthCheckConfig(AppConfig):
             raise ImproperlyConfigured("Only one Globus High Assurance Policy must be used.")
         
         # Make sure the authorization safety net is in place
-        if len(settings.AUTHORIZED_IDP_DOMAINS) == 0 or len(settings.AUTHORIZED_IDP_UUIDS) == 0:
-            raise ImproperlyConfigured("AUTHORIZED_IDP_DOMAINS and AUTHORIZED_IDP_UUIDS must be defined.")
+        if len(settings.AUTHORIZED_IDP_DOMAINS) == 0:
+            raise ImproperlyConfigured("AUTHORIZED_IDP_DOMAINS must be defined.")
         for idp_name in settings.AUTHORIZED_IDP_DOMAINS:
             if len(idp_name) == 0:
                 raise ImproperlyConfigured("AUTHORIZED_IDP_DOMAINS cannot be empty.")
-        for idp_uuid in settings.AUTHORIZED_IDP_UUIDS:
-            if len(idp_uuid) == 0:
-                raise ImproperlyConfigured("AUTHORIZED_IDP_UUIDS cannot be empty.")
             
         # Recover the Globus policy
         client = globus_sdk.ConfidentialAppAuthClient(settings.POLARIS_ENDPOINT_ID, settings.POLARIS_ENDPOINT_SECRET)

--- a/inference_gateway/settings.py
+++ b/inference_gateway/settings.py
@@ -104,9 +104,7 @@ GLOBUS_EXECUTOR_API_BURST_WINDOW_S = int(os.getenv("GLOBUS_EXECUTOR_API_BURST_WI
 GLOBUS_MANAGEMENT_TASK_GROUP_ID = os.getenv("GLOBUS_MANAGEMENT_TASK_GROUP_ID", None)
 
 # Extract allowed identity providers
-AUTHORIZED_IDPS = json.loads(os.getenv("AUTHORIZED_IDPS", "{}"))
-AUTHORIZED_IDP_DOMAINS = list(AUTHORIZED_IDPS.keys())
-AUTHORIZED_IDP_UUIDS = list(AUTHORIZED_IDPS.values())
+AUTHORIZED_IDP_DOMAINS = textfield_to_strlist(os.getenv("AUTHORIZED_IDP_DOMAINS", ""))
 
 # Extract list of allowed groups per identity providers
 AUTHORIZED_GROUPS_PER_IDP = json.loads(os.getenv("AUTHORIZED_GROUPS_PER_IDP", "{}"))

--- a/utils/auth_utils.py
+++ b/utils/auth_utils.py
@@ -216,28 +216,31 @@ def check_session_info(introspection, user_groups):
         # This array is used to log un-authorized attempts
         session_info_idp_ids = []
 
-        # If there is an authorized authentication (or if no AUTHORIZED_IDP_UUIDS was provided) ...
-        for _, auth in introspection["session_info"]["authentications"].items():
-            session_info_idp_ids.append(auth["idp"])
-            if auth["idp"] in settings.AUTHORIZED_IDP_UUIDS or len(settings.AUTHORIZED_IDP_UUIDS) == 0:
+        # For each active authentication session ...
+        session_info_identities = []
+        for session_idp in [auth["idp"] for auth in introspection["session_info"]["authentications"].values()]:
 
-                # Find the user info linked to the authorized identity provider
-                for identity in introspection["identity_set_detail"]:
-                    if auth["idp"] == identity["identity_provider"]:
+            # Recover the domain (e.g. anl.gov) tied to the active session
+            identity = next((i for i in introspection["identity_set_detail"] if i["identity_provider"] == session_idp))
+            session_domain = identity["username"].split("@")[1]
+            session_info_identities.append(identity)
 
-                        # Create the User object from the Globus introspection
-                        try:
-                            user = UserPydantic(
-                                id=identity["sub"],
-                                name=identity["name"],
-                                username=identity["username"],
-                                user_group_uuids=user_groups,
-                                idp_id=identity["identity_provider"],
-                                idp_name=identity["identity_provider_display_name"],
-                                auth_service=AuthService.GLOBUS.value
-                            )
-                        except Exception as e:
-                            return False, None, f"Error: Could not create User object: {e}"
+            # If the domain is authorized by the service ...
+            if session_domain in settings.AUTHORIZED_IDP_DOMAINS:
+
+                # Create the User object from the Globus introspection
+                try:
+                    user = UserPydantic(
+                        id=identity["sub"],
+                        name=identity["name"],
+                        username=identity["username"],
+                        user_group_uuids=user_groups,
+                        idp_id=identity["identity_provider"],
+                        idp_name=identity["identity_provider_display_name"],
+                        auth_service=AuthService.GLOBUS.value
+                    )
+                except Exception as e:
+                    return False, None, f"Error: Could not create User object: {e}"
 
                 # Return successful check along with user details
                 return True, user, ""
@@ -249,9 +252,8 @@ def check_session_info(introspection, user_groups):
     # If user not authorized, extract user details for error message
     try:
         user_str = []
-        for identity in introspection["identity_set_detail"]:
-            if identity["identity_provider"] in session_info_idp_ids:
-                user_str.append(f"{identity['name']} ({identity['username']})")
+        for identity in session_info_identities:
+            user_str.append(f"{identity['name']} ({identity['username']})")
         user_str = ", ".join(user_str)
         if len(user_str) == 0:
             user_str = "Unknown (no active session found)"
@@ -278,10 +280,11 @@ def check_groups_per_idp(user: UserPydantic, user_groups: List[str]):
         Returns: True/False if granted or not, error_message, group_overlap
     """
 
-    # Extract the identity provider's UUID
-    idp_domain = next((k for k, v in settings.AUTHORIZED_IDPS.items() if v == user.idp_id), None)
-    if idp_domain is None:
-        return False, "Error: Could not check groups per IdP, user.idp_id did not match any AUTHORIZED_IDPS values.", None
+    # Extract the user's IdP domain
+    try:
+        idp_domain = user.username.split("@")[1]
+    except:
+        return False, "Error: Could not extract IdP domain from user.username.split('@')[1].", None
     
     # If there is a Globus Group check tied to this identity provider ...
     if idp_domain in settings.AUTHORIZED_GROUPS_PER_IDP:


### PR DESCRIPTION
- Now we do not rely on IdP UUID (which according to Globus can change over time), we only rely on the IdP domain extracted from the username field. This also helps in adding new labs in our policy, since sometime it's not obvious to find their IdP UUID, but it's very easy to just add the domain
- Modified the error message when users loose their session so that they are informed to logout from Globus and re-authenticate with "--force"