### PR TITLE
Integrate SAM3

### DIFF
--- a/.github/workflows/django_tests.yml
+++ b/.github/workflows/django_tests.yml
@@ -63,9 +63,6 @@ jobs:
         run: |
           echo "Current branch: $(git branch --show-current)"
 
-      - name: Check Python syntax
-        uses: cclauss/Find-Python-syntax-errors-action@v0.2.0
-
       - name: Install Python
         uses: actions/setup-python@v6
         with:
@@ -75,6 +72,10 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+
+      - name: Check Python syntax
+        run: |
+          uvx ruff check --select F821 --ignore F821 --target-version py312 .
 
       - name: Setup Django environment
         working-directory: ${{ env.WORKING_DIRECTORY }}

--- a/alcf_ai/README.md
+++ b/alcf_ai/README.md
@@ -1,0 +1,185 @@
+# ALCF AI Inference Services SDK
+
+This package provides Python client and CLI tools to facilitate usage of the ALCF AI Inference services.
+
+## Command Line Usage
+
+### Quick Start
+
+```bash
+# Log in with Globus:
+uvx alcf-ai auth login
+
+# Chat with a model
+# The default --model is meta-llama/Llama-4-Scout-17B-16E-Instruct
+uvx alcf-ai chat "How do I know Pi is irrational? Be concise."
+```
+
+### Auth
+
+```bash
+# Login for Inference Service only:
+uvx alcf-ai auth login
+
+# Login for Inference+Globus data transfers
+# (append :data_access only if required for your collection)
+SOURCE_COLLECTION="your globus collection UUID"
+uvx alcf-ai auth login --authorize-transfers $SOURCE_COLLECTION:data_access
+
+# Get an access token to use externally:
+token=$(uvx alcf-ai auth get-access-token)
+curl -H "Authorization: Bearer $token" https://inference-api.alcf.anl.gov/resource_server/list-endpoints | jq
+```
+
+### Discovering Models
+
+To list the models and corresponding API endpoints that are currently available, use:
+
+```bash
+uvx alcf-ai ls-endpoints
+```
+
+To view the status of models that are currently hot or starting up on a cluster, use:
+
+```bash
+# Can substitute "sophia" with "metis"
+uvx alcf-ai ls-jobs sophia
+```
+
+### Chat with an LLM
+
+```bash
+# See detailed options:
+uvx alcf-ai chat --help
+
+# For example:
+uvx alcf-ai chat --model google/gemma-4-31B-it --stream --temp 0.3 --max-tokens 100 "What is KL divergence? Answer in less than 75 words."
+```
+
+### Segment images with SAM3
+
+You can segment your images with the [Meta SAM3](https://github.com/facebookresearch/sam3) model.  
+
+Send a single image URI plus prompt in for segmentation:
+
+```bash
+uvx alcf-ai sam3 submit-image \
+  https://raw.githubusercontent.com/masalim2/sam3-service/refs/heads/main/examples/images/groceries.jpg \
+  "Baguette" \
+  --save-preview ~/test-baguettes.png
+```
+
+#### Batch Processing
+
+For high-throughput, preprocess and bundle your images and prompts in the [WebDataset format](https://github.com/webdataset/webdataset)
+using the built-in CLI tool:
+
+```bash
+# Bundle all .tiff files in directory with 3 prompts Creates WebDataset tar
+# files in --output-dir, with 100 images per .tar.
+alcf-ai sam3 create-webdataset \
+   /path/to/tiff-stack \
+   .tiff \
+    "Phloem Fibers" "Hydrated Xylem vessels" "Air-based Pith cells" \
+    --output-dir test-wds --shard-size=100 --num-workers=4
+```
+
+If the dataset is on a Globus Collection, you can authorize the CLI to send them
+to the inference service:
+
+```bash
+# Look up the UUID of your collection:
+SOURCE_COLLECTION="your globus collection UUID"
+
+# Append ":data_access" if this scope is required:
+uvx alcf-ai auth login --authorize-transfers $SOURCE_COLLECTION:data_access
+```
+
+Then use the tool to drive data staging and batch inference:
+
+```bash
+SAM3_FINETUNE=/eagle/inference_service/sam3-service/weights/synaps-i
+SECONDS=0
+
+for f in test-wds/*.tar
+do
+uvx alcf-ai sam3 submit-batch $SOURCE_COLLECTION $f --weights-dir-override $SAM3_FINETUNE >> batch-inference.log 2>&1 &
+done
+wait
+echo "Completed in $SECONDS seconds."
+```
+
+You can preview the segmentation results in a batch by passing the paths to the input and result tar files:
+
+```bash
+uvx  alcf-ai sam3 preview-batch-results shard-00004.tar shard-00004.results.tar
+```
+
+
+## SDK Usage
+
+You can use `pip install alcf-ai` or `uv run --with-alcf python` to add the SDK to your environment:
+
+```bash
+uv run --with alcf-ai python
+```
+
+### OpenAI Client
+
+Use `alcf_ai.InferenceClient` to construct an OpenAI client for any ALCF-backed
+cluster.  This reuses your auth and ensures that requests are sent to the right
+URL:
+
+```python
+from alcf_ai import InferenceClient
+from rich import print
+
+# Automatically uses cached refresh tokens from previous login:
+client = InferenceClient()
+
+# Programmatically discover endpoints:
+print(client.list_endpoints()["clusters"]["sophia"])
+
+# Get an OpenAI API client for an ALCF cluster:
+oai = client.clusters("sophia").openai
+print(
+    oai.chat.completions.create(
+        model="openai/gpt-oss-120b",
+        messages=[{"role": "user", "content": "Hello there!"}],
+    )
+)
+```
+
+### Data Movement and SAM3
+
+You can use the same `InferenceClient` to move data in and out of a Globus Guest
+Collection that's managed by the service.  Your data is stored in an ephemeral
+staging subdirectory, with ACLs that grant *only your* Globus identity
+read/write access to it.
+
+```python
+from alcf_ai import InferenceClient
+from alcf_ai.auth import STAGING_COLLECTION_ROOT
+client = InferenceClient()
+
+dataset_path = Path("/path/to/my-dataset.tar")
+collection_id="globus collection uuid"
+
+# Stage in data:
+stagein = client.stage_in(collection_id, dataset_path, dataset_path.name)
+
+# Submit SAM3 inference:
+resp = client.sam3.submit_batch(
+    STAGING_COLLECTION_ROOT + str(stagein.destination_path)
+)
+
+# Wait for inference:
+result = client.sam3.poll_task_result(resp.task_id)
+
+# Copy results back:
+client.stage_out(
+    collection_id,
+    Path(result.result_path).name,
+    dataset_path.with_suffix(".results.tar"),
+)
+```

--- a/alcf_ai/pyproject.toml
+++ b/alcf_ai/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+name = "alcf-ai"
+version = "0.3.0"
+description = "ALCF Inference Gateway SDK"
+authors = [{ name = "Misha Salim", email = "msalim@anl.gov" }]
+requires-python = ">=3.12"
+readme = "README.md"
+dependencies = [
+    "httpx",
+    "numpy",
+    "rich",
+    "typer",
+    "globus-sdk>=3.65.0,<4",
+    "openai",
+    "matplotlib",
+    "Pillow",
+    "tifffile",
+    "smart-open",
+]
+
+[project.scripts]
+alcf-ai = "alcf_ai:cli"
+
+[build-system]
+requires = ["uv_build<0.10.0"]
+build-backend = "uv_build"
+
+[tool.ruff]
+line-length = 88
+target-version = "py312"

--- a/alcf_ai/src/alcf_ai/__init__.py
+++ b/alcf_ai/src/alcf_ai/__init__.py
@@ -1,0 +1,4 @@
+from .cli import cli
+from .client import InferenceClient
+
+__all__ = ["cli", "InferenceClient"]

--- a/alcf_ai/src/alcf_ai/auth.py
+++ b/alcf_ai/src/alcf_ai/auth.py
@@ -1,0 +1,219 @@
+import sys
+import time
+from datetime import timedelta
+from enum import Enum
+from pathlib import Path
+
+import globus_sdk
+import globus_sdk.gare
+from globus_sdk.authorizers import GlobusAuthorizer
+from globus_sdk.scopes import GCSCollectionScopeBuilder, TransferScopes
+from typer import Option, Typer
+
+
+class InferenceAuthError(Exception):
+    """
+    Error during Inference authentication
+    """
+
+
+class TimeUnit(str, Enum):
+    auto = "auto"
+    seconds = "seconds"
+    minutes = "minutes"
+    hours = "hours"
+
+
+# Globus UserApp name
+APP_NAME = "inference_app"
+
+# Public inference auth client
+AUTH_CLIENT_ID = "58fdd3bc-e1c3-4ce5-80ea-8d6b87cfb944"
+
+# Inference gateway API scope
+GATEWAY_CLIENT_ID = "681c10cc-f684-4540-bcd7-0b4df3bc26ef"
+GATEWAY_SCOPE = f"https://auth.globus.org/scopes/{GATEWAY_CLIENT_ID}/action_all"
+
+TOKENS_PATH = Path.home() / f".globus/app/{AUTH_CLIENT_ID}/{APP_NAME}/tokens.json"
+
+# Globus authorizer parameters to point to specific identity providers
+GA_PARAMS = globus_sdk.gare.GlobusAuthorizationParameters(
+    session_required_policies=["83732ff2-9c42-4548-b5ce-17e498c84f6a"]
+)
+
+# inference_data_staging Globus Guest Collection:
+TRANSFER_RESOURCE_SERVER = TransferScopes.resource_server
+STAGING_COLLECTION_ID = "96c7390b-a3e8-4dd4-a327-1af7d143283e"
+STAGING_COLLECTION_ROOT = "/eagle/IRIBeta/inference_data_staging/"
+
+_collection_opt = Option(
+    None,
+    "--authorize-transfers",
+    help=(
+        "A Globus collection UUID to authorize transfers against.  "
+        "When provided, login will request scopes "
+        f"for data transfers between this collection and the inference service data staging "
+        f"collection ({STAGING_COLLECTION_ID}). Append :data_access to the "
+        "UUID to request the data_access dependency if needed."
+    ),
+)
+
+
+# Error handler to guide user through specific identity providers
+class DomainBasedErrorHandler:
+    def __call__(self, app, error):
+        print(f"Encountered error '{error}', initiating login...")
+        app.login(auth_params=GA_PARAMS)
+
+
+def _build_scope_requirements(
+    transfer_collection_id: str | None = None,
+) -> dict:
+    """
+    Build the scope_requirements dict for the UserApp.
+
+    Always includes the gateway scope. When transfer_collection_id is provided,
+    transfer scopes are added, optionally with the data_access dependency.
+    """
+    scopes: dict = {
+        GATEWAY_CLIENT_ID: [GATEWAY_SCOPE],
+    }
+
+    if transfer_collection_id is not None:
+        transfer_scope = TransferScopes.make_mutable("all")
+
+        if transfer_collection_id.endswith(":data_access"):
+            transfer_collection_id = transfer_collection_id.split(":")[0]
+            data_access = GCSCollectionScopeBuilder(
+                transfer_collection_id
+            ).make_mutable("data_access", optional=True)
+            transfer_scope.add_dependency(data_access)
+
+        scopes[TRANSFER_RESOURCE_SERVER] = [transfer_scope]
+
+    return scopes
+
+
+def build_user_app(transfer_collection_id: str | None = None) -> globus_sdk.UserApp:
+    return globus_sdk.UserApp(
+        APP_NAME,
+        client_id=AUTH_CLIENT_ID,
+        scope_requirements=_build_scope_requirements(transfer_collection_id),
+        config=globus_sdk.GlobusAppConfig(
+            request_refresh_tokens=True,
+            token_validation_error_handler=DomainBasedErrorHandler(),
+        ),
+    )
+
+
+def get_inference_authorizer() -> GlobusAuthorizer:
+    """
+    Get Authorizer for Inference gateway
+    """
+    app = build_user_app()
+    return app.get_authorizer(GATEWAY_CLIENT_ID)
+
+
+def get_transfer_authorizer(transfer_collection_id: str) -> GlobusAuthorizer:
+    """
+    Get Authorizer for Globus Transfer
+    """
+    app = build_user_app(transfer_collection_id)
+    return app.get_authorizer(TRANSFER_RESOURCE_SERVER)
+
+
+def format_timedelta(td: timedelta, units: TimeUnit = TimeUnit.auto) -> str:
+    total = td.total_seconds()
+    if units == "seconds":
+        return f"{total:.2f}"
+    if units == "minutes":
+        return f"{total / 60:.2f}"
+    if units == "hours":
+        return f"{total / 3600:.2f}"
+
+    days, rem = divmod(int(total), 86400)
+    hours, rem = divmod(rem, 3600)
+    minutes, seconds = divmod(rem, 60)
+    parts = []
+
+    if days:
+        parts.append(f"{days}d")
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes:
+        parts.append(f"{minutes}m")
+    if seconds or not parts:
+        parts.append(f"{seconds}s")
+    return " ".join(parts)
+
+
+# Get time until token expiration
+def get_time_until_token_expiration() -> timedelta:
+    """
+    Returns the time until the access token expires, in units of
+    seconds, minutes, or hours. Negative times reveal that the token
+    is expired already.
+    """
+
+    # Get authorizer object
+    auth = get_inference_authorizer()
+
+    # Gather the time difference between now and the expiration time (both Unix timestamps)
+    now = time.time()
+    return timedelta(seconds=auth.expires_at - now)
+
+
+cli = Typer(no_args_is_help=True)
+
+
+@cli.command()
+def login(authorize_transfers: str | None = _collection_opt) -> None:
+    """
+    Log in with Globus. Stores credentials in your home directory.
+    """
+    app = build_user_app(authorize_transfers)
+    app.login(auth_params=GA_PARAMS)
+
+
+@cli.command()
+def get_access_token() -> None:
+    """
+    Fetch an access token for the inference API.
+
+    Automatically utilizes locally cached tokens, refreshing the access token if
+    necessary, and returns a valid access token. If there is no token stored in
+    the home directory, or if the refresh token is expired following 6 months of
+    inactivity, an authentication will be triggered.
+    """
+    # Make sure tokens exist
+    # This is important otherwise the CLI will print more than just the access token
+    if not TOKENS_PATH.is_file():
+        raise InferenceAuthError(
+            "Access token does not exist. "
+            f'Please authenticate by running "{sys.argv[0]} login".'
+        )
+
+    # Get authorizer object and authenticate if need be
+    auth = get_inference_authorizer()
+
+    # Make sure the stored access token if valid, and refresh otherwise
+    auth.ensure_valid_token()
+
+    # Return the access token
+    print(auth.access_token)
+
+
+@cli.command()
+def get_token_expiration(units: TimeUnit = TimeUnit.auto) -> None:
+    """
+    Show how much time remains until the token expires.
+    """
+    # Make sure tokens exist
+    # This is important otherwise the CLI will print more than just the access token
+    if not TOKENS_PATH.is_file():
+        raise InferenceAuthError(
+            "Access token does not exist. "
+            'Please authenticate by running "python3 inference_auth_token.py authenticate".'
+        )
+
+    print(format_timedelta(get_time_until_token_expiration(), units=units))

--- a/alcf_ai/src/alcf_ai/cli.py
+++ b/alcf_ai/src/alcf_ai/cli.py
@@ -1,0 +1,121 @@
+import logging
+from typing import TypedDict
+
+import typer
+from rich import print
+from rich.console import Console
+from rich.logging import RichHandler
+from rich.markdown import Markdown
+from typer import Typer
+
+from .auth import cli as auth_cli
+from .client import InferenceClient
+from .sam3 import cli as sam3_cli
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+
+class CliState(TypedDict, total=False):
+    client: InferenceClient
+
+
+cli = Typer(no_args_is_help=True)
+_cli_state: CliState = {}
+
+cli.add_typer(auth_cli, name="auth", help="Login and get access tokens")
+cli.add_typer(sam3_cli, name="sam3", help="Use the SAM3 image segmentation service")
+
+
+@cli.callback()
+def main(
+    base_url: str = "https://inference-api.alcf.anl.gov/resource_server/",
+) -> None:
+    """
+    Inference Gateway CLI
+    """
+    logging.basicConfig(
+        level="INFO", format="%(name)s:%(lineno)d %(message)s", handlers=[RichHandler()]
+    )
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    _cli_state["client"] = InferenceClient(base_url)
+    logger.info(f"Using client: {_cli_state['client']}")
+
+
+@cli.command()
+def ls_endpoints() -> None:
+    """
+    List all endpoints available across clusters
+    """
+    client = _cli_state["client"]
+    print(client.list_endpoints())
+
+
+@cli.command()
+def ls_jobs(cluster: str) -> None:
+    """
+    List ongoing jobs for a cluster
+    """
+    client = _cli_state["client"]
+
+    jobs = client.clusters(cluster).get_jobs()
+    console.print(jobs)
+
+
+@cli.command()
+def chat(
+    prompt: str = typer.Argument(..., help="The prompt to send"),
+    model: str = typer.Option(
+        "meta-llama/Llama-4-Scout-17B-16E-Instruct", "--model", "-m"
+    ),
+    stream: bool = typer.Option(True, "--stream/--no-stream", "-s/-S"),
+    temperature: float = typer.Option(0.7, "--temp", "-t"),
+    max_tokens: int = typer.Option(1024, "--max-tokens", "-n"),
+    cluster: str = typer.Option("sophia", "--cluster", "-c"),
+):
+    """Send a prompt to an LLM and print the response."""
+    client = _cli_state["client"]
+    oai = client.clusters(cluster).openai
+
+    if stream:
+        collected = []
+        with console.status("[dim]Thinking…[/dim]", spinner="dots"):
+            response = oai.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=temperature,
+                max_tokens=max_tokens,
+                stream=True,
+            )
+
+        for chunk in response:
+            if chunk.choices and chunk.choices[0].delta.content:
+                token = chunk.choices[0].delta.content
+                console.print(token, end="", highlight=False)
+                collected.append(token)
+
+        if not collected:
+            console.print(str(response))
+
+        console.print()  # final newline
+    else:
+        with console.status("[dim]Thinking…[/dim]", spinner="dots"):
+            response = oai.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+        text = response.choices[0].message.content
+        console.print(Markdown(text))
+
+
+@cli.command()
+def version():
+    from importlib.metadata import version
+
+    print(version("alcf-ai"))
+
+
+if __name__ == "__main__":
+    cli()

--- a/alcf_ai/src/alcf_ai/client.py
+++ b/alcf_ai/src/alcf_ai/client.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+from typing import Any
+
+from httpx import Auth, Client, Request, Timeout
+from pydantic import BaseModel
+
+from .auth import get_inference_authorizer
+from .resources import ClusterResource, Sam3Resource
+from .transfer import TransferResult, run_globus_transfer
+
+
+class AutoGlobusAuth(Auth):
+    def auth_flow(self, request: Request):
+        auth = get_inference_authorizer()
+        auth.ensure_valid_token()
+        assert auth.access_token, "Empty access token"
+
+        request.headers["Authorization"] = f"Bearer {auth.access_token}"
+        yield request
+
+
+class StagingAreaResponse(BaseModel):
+    collection_id: str
+    path: str
+
+
+class InferenceClient(Client):
+    def __init__(
+        self,
+        base_url: str = "https://inference-api.alcf.anl.gov/resource_server/",
+        timeout: Timeout = Timeout(10.0, read=30.0),
+    ) -> None:
+        super().__init__(
+            auth=AutoGlobusAuth(),
+            base_url=base_url,
+            timeout=timeout,
+        )
+        self._resources = {}
+        self._staging_area = None
+
+    def __repr__(self) -> str:
+        return f"InferenceClient({self.base_url})"
+
+    def clusters(self, name: str) -> "ClusterResource":
+        key = f"cluster:{name}"
+        return self._resources.setdefault(key, ClusterResource(name, self))
+
+    @property
+    def sam3(self) -> "Sam3Resource":
+        return self._resources.setdefault(
+            "sam3", Sam3Resource("sophia/sam3service", self)
+        )
+
+    def list_endpoints(self) -> dict[str, Any]:
+        resp = self.get("list-endpoints")
+        resp.raise_for_status()
+        return resp.json()
+
+    def ensure_staging_area(self) -> StagingAreaResponse:
+        resp = self.put("data/staging")
+        resp.raise_for_status()
+        return StagingAreaResponse.model_validate(resp.json())
+
+    def stage_in(self, from_collection_id: str, src: Path, dst: Path) -> TransferResult:
+        if self._staging_area is None:
+            self._staging_area = self.ensure_staging_area()
+
+        src = Path(src)
+        dst = Path(dst)
+        if dst.is_absolute():
+            raise ValueError(
+                f"Destination path must be relative to staging area; got absolute path: {dst}"
+            )
+        dst = Path(self._staging_area.path) / dst
+
+        return run_globus_transfer(
+            source_collection_id=from_collection_id,
+            source_path=src.as_posix(),
+            destination_collection_id=self._staging_area.collection_id,
+            destination_path=dst.as_posix(),
+        )
+
+    def stage_out(self, to_collection_id: str, src: Path, dst: Path) -> TransferResult:
+        if self._staging_area is None:
+            self._staging_area = self.ensure_staging_area()
+
+        src = Path(src)
+        dst = Path(dst)
+        if src.is_absolute():
+            raise ValueError(
+                f"Source path must be relative to staging area; got absolute path: {src}"
+            )
+        src = Path(self._staging_area.path) / src
+
+        return run_globus_transfer(
+            source_collection_id=self._staging_area.collection_id,
+            source_path=Path(src).as_posix(),
+            destination_collection_id=to_collection_id,
+            destination_path=Path(dst).as_posix(),
+        )

--- a/alcf_ai/src/alcf_ai/resources/__init__.py
+++ b/alcf_ai/src/alcf_ai/resources/__init__.py
@@ -1,0 +1,4 @@
+from .cluster import ClusterResource
+from .sam3 import Sam3Resource
+
+__all__ = ["ClusterResource", "Sam3Resource"]

--- a/alcf_ai/src/alcf_ai/resources/cluster.py
+++ b/alcf_ai/src/alcf_ai/resources/cluster.py
@@ -1,0 +1,21 @@
+from functools import cached_property
+
+from openai import OpenAI
+
+from .resource import ClientResource
+
+
+class ClusterResource(ClientResource):
+    def get_jobs(self) -> None:
+        resp = self._client.get(f"/{self.name}/jobs")
+        resp.raise_for_status()
+        return resp.json()
+
+    @cached_property
+    def openai(self) -> OpenAI:
+        framework = "vllm" if self.name == "sophia" else "api"
+        return OpenAI(
+            api_key="unused",
+            base_url=f"{self._client.base_url}{self.name}/{framework}/v1",
+            http_client=self._client,
+        )

--- a/alcf_ai/src/alcf_ai/resources/resource.py
+++ b/alcf_ai/src/alcf_ai/resources/resource.py
@@ -1,0 +1,13 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from alcf_ai.client import InferenceClient
+
+
+class ClientResource:
+    def __init__(self, name: str, client: "InferenceClient") -> None:
+        self.name = name
+        self._client = client
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(name={self.name})"

--- a/alcf_ai/src/alcf_ai/resources/sam3.py
+++ b/alcf_ai/src/alcf_ai/resources/sam3.py
@@ -1,0 +1,150 @@
+import base64
+import logging
+import gzip
+import time
+from io import BytesIO
+from pathlib import Path
+from typing import Annotated, Any, Literal
+
+import numpy as np
+import numpy.typing as npt
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+)
+
+from .resource import ClientResource
+
+NDArray = npt.NDArray[Any]
+logger = logging.getLogger(__name__)
+
+
+def to_ndarray(obj: Any) -> NDArray:
+    """
+    Load .npy array from gzipped and base64 encoded string.
+    """
+    if isinstance(obj, str):
+        obj = base64.b64decode(obj)
+
+    if isinstance(obj, bytes):
+        if obj[:2] == b"\x1f\x8b":
+            return np.load(BytesIO(gzip.decompress(obj)), allow_pickle=False)
+        else:
+            return np.load(BytesIO(obj), allow_pickle=False)
+
+    if isinstance(obj, np.ndarray):
+        return obj
+
+    raise ValueError(f"Expected str, bytes, or ndarray; got {type(obj)}")
+
+
+CompressedNDArray = Annotated[
+    NDArray,
+    BeforeValidator(to_ndarray),
+]
+
+
+class Sam3Request(BaseModel):
+    inference_type: Literal["single-image", "batch"]
+    data_uri: str
+    single_image_prompt: str | None = None
+    weights_dir_override: Path | None = None
+
+
+class Sam3ImageResult(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    input_image: str
+    prompt: dict[str, Any]
+    boxes: list[list[float]]
+    scores: list[float]
+    labelmap_npy: CompressedNDArray
+
+    @property
+    def num_objects(self) -> int:
+        return len(self.scores)
+
+
+class Sam3BatchResult(BaseModel):
+    result_path: str
+    runtime_info: dict[str, Any] | None = None
+
+
+class SubmitTaskResponse(BaseModel):
+    task_id: str
+
+
+class Sam3Resource(ClientResource):
+    class TaskPending(Exception): ...
+
+    def submit_image(
+        self, image_uri: str, prompt: str, weights_dir_override: Path | None = None
+    ) -> SubmitTaskResponse:
+        """
+        Submit a single image+prompt for SAM3 inference. `image_uri` is loaded
+        using smart_open.open() on the target cluster and therefore supports
+        local file paths in addition to https and s3 URIs.
+        """
+        payload = Sam3Request(
+            inference_type="single-image",
+            data_uri=image_uri,
+            single_image_prompt=prompt,
+            weights_dir_override=weights_dir_override,
+        )
+        resp = self._client.post(f"{self.name}/process", json=payload.model_dump())
+        resp.raise_for_status()
+        return SubmitTaskResponse.model_validate(resp.json())
+
+    def submit_batch(
+        self, tar_path: str, weights_dir_override: Path | None = None
+    ) -> SubmitTaskResponse:
+        """
+        Submit a batched inference request, providing the path to a WebDataset
+        structured tar file containing the images and prompts.
+        """
+        payload = Sam3Request(
+            inference_type="batch",
+            data_uri=tar_path,
+            single_image_prompt=None,
+            weights_dir_override=weights_dir_override,
+        )
+        resp = self._client.post(
+            f"{self.name}/process", json=payload.model_dump(mode="json")
+        )
+        resp.raise_for_status()
+        return SubmitTaskResponse.model_validate(resp.json())
+
+    def get_task_result(self, task_id: str) -> Sam3ImageResult | Sam3BatchResult:
+        """
+        Get the result of a submitted SAM3 inference task. Raises
+        Sam3Resource.TaskPending if the inference has not yet finished.
+        """
+        resp = self._client.get(f"{self.name}/tasks/{task_id}")
+
+        if resp.status_code == 400 and b"pending" in resp.content:
+            raise Sam3Resource.TaskPending
+        elif resp.status_code >= 400:
+            resp.raise_for_status()
+
+        result = resp.json().get("result")
+        if result and "scores" in result:
+            return Sam3ImageResult.model_validate(result)
+        elif result and "result_path" in result:
+            return Sam3BatchResult.model_validate(result)
+
+        raise RuntimeError(f"Unexpected SAM3 Inference response: {resp}")
+
+    def poll_task_result(
+        self, task_id: str, timeout: int = 300
+    ) -> Sam3ImageResult | Sam3BatchResult:
+        """
+        Poll on the SAM3 inference task for up to `timeout` seconds.
+        """
+        start = time.monotonic()
+        while time.monotonic() - start < timeout:
+            try:
+                return self.get_task_result(task_id)
+            except Sam3Resource.TaskPending:
+                logger.info(f"Inference {task_id=} still pending...")
+                time.sleep(5)
+        raise TimeoutError(f"{task_id=} not finished in {timeout=}")

--- a/alcf_ai/src/alcf_ai/sam3.py
+++ b/alcf_ai/src/alcf_ai/sam3.py
@@ -1,0 +1,391 @@
+import io
+import json
+import logging
+import tarfile
+from concurrent.futures import ProcessPoolExecutor, wait
+from io import BytesIO
+from math import ceil
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+import requests
+import smart_open
+import typer
+from PIL.Image import Image, fromarray, open as imopen
+
+from .resources.sam3 import Sam3ImageResult
+from .auth import STAGING_COLLECTION_ROOT
+
+NDArray = npt.NDArray[Any]
+
+logger = logging.getLogger(__name__)
+
+cli = typer.Typer(no_args_is_help=True)
+
+NDArray = npt.NDArray[Any]
+
+COLORS = np.array(
+    [
+        [0.9181167412189333, 0.15919377061073092, 0.11266724590330243],
+        [0.2426219269955917, 0.48112269889334175, 0.6300907349521442],
+        [0.6801395198918061, 0.8243199236330475, 0.1774045944122353],
+        [0.49107573382331965, 0.12463080139992075, 0.6454314740086482],
+        [0.6987104631708523, 0.5937358967283586, 0.3546217817852228],
+        [0.5019010773320838, 0.11971558737792043, 0.28576675725477],
+        [0.29243644808061936, 0.9238077273791944, 0.6538220475380706],
+        [0.2586205918865394, 0.9470123824979256, 0.14729039742890707],
+        [0.5550243221210623, 0.5246700043349789, 0.6434082461812896],
+        [0.451148867503468, 0.3717198279094181, 0.6157734521389989],
+        [0.20944722494667917, 0.08279581671195499, 0.2551450164828858],
+        [0.22621543260836652, 0.17443115982799293, 0.8931335183945011],
+        [0.2151999962505184, 0.7196045516977536, 0.7610355803084937],
+        [0.16802189556009375, 0.5235718347378724, 0.10018495359215421],
+        [0.923169872253808, 0.17919414345005819, 0.6756018070768858],
+        [0.6398636341016658, 0.26039053450112304, 0.12587290510733998],
+        [0.883578524489999, 0.1258989287053571, 0.9381302231143882],
+        [0.34475212142314654, 0.2476343873941264, 0.16974966534928532],
+        [0.2215159259189658, 0.3735720552568507, 0.8860350713062034],
+        [0.65092947010467, 0.8755035668138884, 0.8467078897265947],
+    ]
+)
+
+
+def add_member(tf: tarfile.TarFile, filename: str, buf: BytesIO) -> None:
+    info = tarfile.TarInfo(filename)
+    buf.seek(0, io.SEEK_END)
+    info.size = buf.tell()
+
+    buf.seek(0)
+    tf.addfile(info, buf)
+
+
+def quantile_norm(image: NDArray | Image) -> NDArray:
+    """
+    Converts floating dtype images to uint8-quantized npy format with a channel
+    dimension.
+
+    SAM3 preprocessing expects 1 or 3 channel dims and will squash intensities
+    in a smaller dynamic range.
+    """
+    if isinstance(image, Image):
+        if image.mode == "RGBA":
+            image = image.convert("RGB")
+        image = np.array(image)
+
+    # Vision models expect a color channel:
+    if image.ndim == 2:
+        image = image[np.newaxis, :, :]
+
+    assert image.ndim == 3
+
+    # If floating dtype, normalize and clamp pixel intensities such that
+    # the 1st percentile is 0 and 99th percentile is 255
+
+    # N.B. this is required to get any results out of float32 TIFFs but can
+    # become a CPU-intensive bottleneck. Handle it here to be robust, but
+    # suggest quantizing on the client to cut the size down BEFORE
+    # sending over the network!
+
+    # Also, clients may wish to use the intensity range over an entire volume,
+    # not per-slice, which can only be done by computing percentiles ahead of
+    # time.
+    if not np.issubdtype(image.dtype, np.integer):
+        lo, hi = np.percentile(image, (1, 99))
+        image = np.clip((image - lo) / (hi - lo), 0, 1)
+        image = (image * 255).astype(np.uint8)
+
+    return image
+
+
+def plot_bbox(
+    img_height,
+    img_width,
+    box,
+    box_format="XYXY",
+    relative_coords=True,
+    color="r",
+    linestyle="solid",
+    text=None,
+    ax=None,
+):
+    import matplotlib.pyplot as plt
+    import matplotlib.patches as patches
+
+    if box_format == "XYXY":
+        x, y, x2, y2 = box
+        w = x2 - x
+        h = y2 - y
+    elif box_format == "XYWH":
+        x, y, w, h = box
+    elif box_format == "CxCyWH":
+        cx, cy, w, h = box
+        x = cx - w / 2
+        y = cy - h / 2
+    else:
+        raise RuntimeError(f"Invalid box_format {box_format}")
+
+    if relative_coords:
+        x *= img_width
+        w *= img_width
+        y *= img_height
+        h *= img_height
+
+    if ax is None:
+        ax = plt.gca()
+    rect = patches.Rectangle(
+        (x, y),
+        w,
+        h,
+        linewidth=1.5,
+        edgecolor=color,
+        facecolor="none",
+        linestyle=linestyle,
+    )
+    ax.add_patch(rect)
+    if text is not None:
+        facecolor = "w"
+        ax.text(
+            x,
+            y - 5,
+            text,
+            color=color,
+            fontsize=8,
+            bbox={"facecolor": facecolor, "alpha": 0.75, "pad": 2},
+        )
+
+
+def to_pil(arr: NDArray) -> Image:
+    # Handle dtype first
+    if arr.dtype != np.uint8:
+        arr = arr.astype(np.uint8)
+
+    if arr.ndim == 2:
+        return fromarray(arr)  # (H, W) grayscale
+
+    if arr.ndim == 3:
+        # Channel-first heuristic: first dim is small AND last dim is large
+        if arr.shape[0] in (1, 3, 4) and arr.shape[2] not in (1, 3, 4):
+            arr = arr.transpose(1, 2, 0)
+
+        # Squeeze single-channel
+        if arr.shape[-1] == 1:
+            arr = arr.squeeze(-1)
+
+        return fromarray(arr)
+
+    raise ValueError(f"Unexpected array shape: {arr.shape}")
+
+
+def preview_sam3_result(arr: NDArray, result: Sam3ImageResult, path: Path):
+    from matplotlib.colors import to_rgb
+    import matplotlib.pyplot as plt
+
+    plt.figure(figsize=(12, 8))
+
+    image = to_pil(arr)
+    width, height = image.size
+    plt.imshow(image, cmap="gray")
+
+    labelmap = result.labelmap_npy
+    assert labelmap.shape == (height, width), f"{labelmap.shape=} {image.size=}"
+    overlay = np.zeros((height, width, 4), dtype=np.float32)
+
+    for i in range(result.num_objects):
+        color = COLORS[i % len(COLORS)]
+
+        mask = labelmap == (i + 1)
+        rgb = to_rgb(color)
+        overlay[mask, :3] = rgb
+        overlay[mask, 3] = 0.5
+
+        plot_bbox(
+            height,
+            width,
+            result.boxes[i],
+            text=None,
+            box_format="XYXY",
+            color=color,
+            relative_coords=False,
+        )
+
+    ax = plt.gca()
+    ax.imshow(overlay)
+    plt.savefig(path)
+    plt.close()
+
+
+def load_image(img_path: Path) -> NDArray:
+    import tifffile
+
+    if img_path.suffix in (".tif", ".tiff"):
+        image = tifffile.imread(img_path)
+    else:
+        image = imopen(img_path)
+    return quantile_norm(image)
+
+
+def to_npy(arr: NDArray) -> BytesIO:
+    buf = BytesIO()
+    np.save(buf, arr)
+    buf.seek(0)
+    return buf
+
+
+def write_wds_shard(
+    tar_path: Path, image_paths: list[Path], text_prompts: list[str]
+) -> None:
+    """
+    Create a tar (aka WebDataset) of paired .npy/.json prompts to SAM3.
+    """
+    prompt_json = BytesIO(
+        json.dumps({"prompts": [{"text": tp} for tp in text_prompts]}).encode()
+    )
+
+    logger.info(f"Writing {len(image_paths)} images to shard: {tar_path}")
+    with tarfile.open(tar_path, mode="w") as writer:
+        for path in sorted(image_paths):
+            add_member(writer, path.with_suffix(".npy").name, to_npy(load_image(path)))
+            add_member(writer, path.with_suffix(".json").name, prompt_json)
+
+
+@cli.command()
+def submit_batch(
+    collection_id: str, dataset_path: Path, weights_dir_override: Path | None = None
+) -> None:
+    """
+    Submit a WebDataset-structured tar file for batch inference.
+    """
+    from .cli import _cli_state
+
+    client = _cli_state["client"]
+
+    dataset_path = dataset_path.expanduser().resolve()
+    assert dataset_path.is_file()
+
+    logger.info(f"Staging in {dataset_path}")
+    stagein = client.stage_in(collection_id, dataset_path, dataset_path.name)
+    logger.info(f"Stage in complete: {stagein}")
+
+    logger.info("Sending inference request...")
+    resp = client.sam3.submit_batch(
+        STAGING_COLLECTION_ROOT + str(stagein.destination_path),
+        weights_dir_override=weights_dir_override,
+    )
+
+    logger.info(f"Polling on inference task {resp.task_id!r}...")
+    result = client.sam3.poll_task_result(resp.task_id)
+    logger.info(f"Inference completed: {result}")
+
+    logger.info(f"Staging out result file: {result.result_path}")
+    stageout = client.stage_out(
+        collection_id,
+        Path(result.result_path).name,
+        dataset_path.with_suffix(".results.tar"),
+    )
+    logger.info(f"Stage out complete: {stageout}")
+
+
+@cli.command()
+def submit_image(
+    image_uri: str,
+    prompt: str,
+    save_preview: Path | None = None,
+) -> None:
+    from .cli import _cli_state
+
+    client = _cli_state["client"]
+    logger.info("Sending request...")
+
+    if "://" not in image_uri:
+        image_uri = "file://" + Path(image_uri).resolve().as_posix()
+
+    resp = client.sam3.submit_image(image_uri, prompt)
+    result: Sam3ImageResult = client.sam3.poll_task_result(resp.task_id)
+    logger.info(result.model_dump(exclude={"labelmap_npy"}))
+
+    if save_preview and result.num_objects > 0:
+        logger.info("Generating local preview of segmentation results...")
+        with smart_open.open(image_uri, "rb") as fp:
+            image = quantile_norm(imopen(fp))
+            preview_sam3_result(image, result, save_preview)
+            logger.info(f"Saved segmentation result preview to {save_preview}")
+
+
+@cli.command()
+def preview_batch_results(input_tar: Path, result_tar: Path) -> None:
+    preview_dir = result_tar.with_suffix(".preview")
+    preview_dir.mkdir(exist_ok=True)
+
+    with tarfile.open(result_tar) as tf, tarfile.open(input_tar) as img_tf:
+        jsons = [f.name for f in tf if f.isfile() and f.name.endswith(".json")]
+        for fname in jsons:
+            assert (result_fp := tf.extractfile(fname)) is not None
+
+            result = json.load(result_fp)
+
+            if result["num_objects"] < 1:
+                logger.info(f"Skipping {fname}: no objects detected.")
+                continue
+
+            assert (img_fp := img_tf.extractfile(result["input_image"])) is not None
+            image = quantile_norm(np.load(BytesIO(img_fp.read())))
+
+            assert (
+                label_fp := tf.extractfile(fname.replace(".json", ".labels.npy"))
+            ) is not None
+            labelmap = np.load(BytesIO(label_fp.read()))
+
+            result = Sam3ImageResult(**result, labelmap_npy=labelmap)
+
+            png_path = preview_dir / Path(fname).with_suffix(".png").name
+            logger.info(f"Generating preview: {png_path.name} ...")
+
+            preview_sam3_result(image, result, png_path)
+            logger.info(f"Saved preview: {png_path}")
+
+
+@cli.command()
+def create_webdataset(
+    image_dir: Path,
+    image_ext: str,
+    text_prompts: list[str],
+    *,
+    output_dir: Path | None = None,
+    shard_size: int = 100,
+    num_workers: int = 4,
+) -> None:
+    """
+    Bundle images+text prompts into WebDataset tar archives.
+    Example:
+    sam3-service create-webdataset ./images/ .tiff "granule" "white shape"
+    """
+    if output_dir is None:
+        output_dir = image_dir.with_name(f"{image_dir.name}-webdataset-shards")
+
+    output_dir = Path(output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    image_ext = image_ext.strip(".")
+    source_paths = list(Path(image_dir).glob(f"*.{image_ext}"))
+    if not source_paths:
+        raise RuntimeError(f"No '.{image_ext}' files found in {image_dir}")
+
+    assert len(text_prompts) > 0
+
+    num_shards = ceil(len(source_paths) / shard_size)
+    shards = [
+        source_paths[i * shard_size : (i + 1) * shard_size] for i in range(num_shards)
+    ]
+
+    logger.info(f"Writing {num_shards=} using {num_workers=}")
+    with ProcessPoolExecutor(max_workers=num_workers) as pool:
+        futs = []
+        for i, shard in enumerate(shards):
+            tar_path = output_dir / f"shard-{i:05d}.tar"
+            futs.append(pool.submit(write_wds_shard, tar_path, shard, text_prompts))
+
+        logger.info("Waiting for shard writes to finish...")
+        wait(futs)
+        logger.info("Done!")

--- a/alcf_ai/src/alcf_ai/transfer.py
+++ b/alcf_ai/src/alcf_ai/transfer.py
@@ -1,0 +1,101 @@
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+import globus_sdk
+
+from .auth import STAGING_COLLECTION_ID, get_transfer_authorizer
+
+
+class TransferError(Exception):
+    """Transfer task failed."""
+
+
+class TransferTimeout(TransferError):
+    """Transfer task did not complete within the allowed time."""
+
+
+@dataclass
+class TransferResult:
+    task_id: str
+    bytes_transferred: int
+    elapsed_seconds: float
+    effective_gbps: float
+    source_collection_id: str
+    source_path: str
+    destination_collection_id: str
+    destination_path: str
+
+
+def run_globus_transfer(
+    source_collection_id: str,
+    source_path: str,
+    destination_collection_id: str,
+    destination_path: str,
+    *,
+    timeout: int = 300,
+    polling_interval: int = 5,
+    verify_checksum: bool = False,
+) -> TransferResult:
+    """
+    Submit a Globus Transfer task and block until it completes.
+    """
+    auth_collection_id = (
+        source_collection_id
+        if source_collection_id != STAGING_COLLECTION_ID
+        else destination_collection_id
+    )
+    auth = get_transfer_authorizer(auth_collection_id)
+    tc = globus_sdk.TransferClient(authorizer=auth)
+
+    tdata = globus_sdk.TransferData(
+        source_endpoint=source_collection_id,
+        destination_endpoint=destination_collection_id,
+        label=f"transfer {source_path}",
+        verify_checksum=verify_checksum,
+    )
+    tdata.add_item(source_path, destination_path)
+
+    submit_result = tc.submit_transfer(tdata)
+    task_id = submit_result["task_id"]
+
+    completed = tc.task_wait(
+        task_id,
+        timeout=timeout,
+        polling_interval=max(1, polling_interval),
+    )
+
+    task = tc.get_task(task_id)
+    status = task["status"]
+
+    if not completed:
+        raise TransferTimeout(f"Task {task_id} still {status} after {timeout}s")
+
+    if status == "FAILED":
+        fatal = task.get("fatal_error") or {}
+        raise TransferError(
+            f"Task {task_id} failed: "
+            f"{fatal.get('description', task.get('nice_status', 'unknown error'))}"
+        )
+
+    if status != "SUCCEEDED":
+        raise TransferError(f"Task {task_id} ended with unexpected status: {status}")
+
+    bytes_transferred = task["bytes_transferred"]
+    effective_bps = task.get("effective_bytes_per_second", 0)
+    effective_gbps = effective_bps / 1e9
+
+    request_time = datetime.fromisoformat(task["request_time"])
+    completion_time = datetime.fromisoformat(task["completion_time"])
+    elapsed = (completion_time - request_time).total_seconds()
+
+    return TransferResult(
+        task_id=task_id,
+        bytes_transferred=bytes_transferred,
+        elapsed_seconds=elapsed,
+        effective_gbps=effective_gbps,
+        source_collection_id=source_collection_id,
+        source_path=source_path,
+        destination_collection_id=destination_collection_id,
+        destination_path=destination_path,
+    )

--- a/deploy/pg-docker.sh
+++ b/deploy/pg-docker.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+set -eu
+docker run --name inference-gateway-db -e POSTGRES_PASSWORD=dataportaldevpwd123 -e POSTGRES_USER=dataportaldev -e POSTGRES_DB=postgres -p 5432:5432 -d postgres

--- a/fixtures/clusters.json
+++ b/fixtures/clusters.json
@@ -6,7 +6,7 @@
             "cluster_name": "sophia",
             "cluster_adapter": "resource_server_async.clusters.globus_compute.GlobusComputeCluster",
             "frameworks": [
-                "vllm"
+                "vllm", "sam3service"
             ],
             "openai_endpoints": [
                 "chat/completions",

--- a/fixtures/new_endpoints.json
+++ b/fixtures/new_endpoints.json
@@ -838,5 +838,21 @@
            "function_uuid": "31acd824-edf6-4f53-933c-63b3b75bdbea"
        }
      }
-   }
+   },
+   {
+        "model": "resource_server_async.endpoint",
+        "pk": 53,
+        "fields": {
+            "endpoint_slug": "sophia-sam3service-sam3",
+            "cluster": "sophia",
+            "framework": "sam3service",
+            "model": "sam3",
+            "endpoint_adapter": "resource_server_async.endpoints.globus_compute.GlobusComputeEndpoint",
+            "config": {
+                "api_port": 8000,
+                "endpoint_uuid": "6699c6a0-2ce3-4798-b85c-3e65d93b68dd",
+                "function_uuid": "c5653f2c-98c8-4dd3-800d-ef7439c7e140"
+            }
+        }
+    }
 ]

--- a/inference_gateway/settings.py
+++ b/inference_gateway/settings.py
@@ -388,6 +388,9 @@ METIS_STATUS_URL = os.environ.get(
 # Each endpoint UUID in Metis status maps to its own API key
 METIS_API_TOKENS = os.environ.get("METIS_API_TOKENS", "{}")
 
+# inference_data_staging Globus Guest Collection:
+DATA_STAGING_GLOBUS_COLLECTION_ID = "96c7390b-a3e8-4dd4-a327-1af7d143283e"
+
 
 # --- Optional: Grafana Admin Credentials (for Docker setup) ---
 # GF_SECURITY_ADMIN_USER=admin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inference-gateway-backend"
-version = "0.1.0"
+version = "0.2.0"
 description = ""
 authors = [{ name = "Benoit Cote", email = "bcote@anl.gov" }]
 requires-python = "==3.12.6"
@@ -20,7 +20,7 @@ dependencies = [
     "certifi==2025.10.5",
     "cffi==2.0.0 ; platform_python_implementation != 'PyPy'",
     "charset-normalizer==3.4.4",
-    "click==8.3.0",
+    "click",
     "colorama==0.4.6",
     "cryptography==46.0.3",
     "csscompressor==0.9.5",
@@ -80,7 +80,7 @@ dependencies = [
     "sqlparse==0.5.3",
     "tblib==1.7.0",
     "texttable==1.7.0",
-    "typer>=0.12.5,<0.13",
+    "typer",
     "typing-extensions==4.15.0",
     "typing-inspection==0.4.2",
     "tzdata==2025.2 ; sys_platform == 'win32'",
@@ -89,7 +89,6 @@ dependencies = [
     "uvicorn>=0.30.6,<0.31",
     "watchdog==6.0.0",
     "websockets>=13.1,<14",
-
     # Documentation dependencies
     "mkdocs-get-deps==0.2.0",
     "mkdocs-material-extensions==1.3.1",
@@ -97,7 +96,14 @@ dependencies = [
     "mkdocs-minify-plugin>=0.8.0,<0.9",
     "mkdocs>=1.5.0",
     "pymdown-extensions>=10.0",
+    "alcf-ai",
 ]
+
+[tool.uv.sources]
+alcf-ai = { workspace = true }
+
+[tool.uv.workspace]
+members = ["alcf_ai/"]
 
 [tool.uv.build-backend]
 module-name = [
@@ -105,6 +111,7 @@ module-name = [
     "resource_server_async",
     "dashboard_async",
     "utils",
+    "alcf_ai",
 ]
 module-root = ""
 namespace = true

--- a/resource_server_async/endpoints/endpoint.py
+++ b/resource_server_async/endpoints/endpoint.py
@@ -14,8 +14,12 @@ class BaseModelWithError(BaseModel):
     error_code: Optional[int] = Field(default=None)
 
 
+class SubmitTaskAsyncResponse(BaseModelWithError):
+    task_id: Optional[str] = Field(default=None)
+
+
 class SubmitTaskResponse(BaseModelWithError):
-    result: Optional[str] = Field(default=None)
+    result: Any = Field(default=None)
     task_id: Optional[str] = Field(default=None)
 
 

--- a/resource_server_async/endpoints/globus_compute.py
+++ b/resource_server_async/endpoints/globus_compute.py
@@ -24,12 +24,15 @@ from resource_server_async.endpoints.endpoint import (
     BaseEndpoint,
     BaseModelWithError,
     SubmitTaskResponse,
+    SubmitTaskAsyncResponse,
     SubmitStreamingTaskResponse,
     SubmitBatchResponse,
     GetBatchStatusResponse,
 )
 from resource_server_async.models import BatchLog
 from utils.pydantic_models.batch import BatchStatusEnum
+from globus_compute_sdk import Executor
+from globus_compute_sdk.errors import TaskPending
 import logging
 
 log = logging.getLogger(__name__)
@@ -45,6 +48,15 @@ class GlobusComputeEndpointConfig(BaseModel):
     function_uuid: str
     batch_endpoint_uuid: Optional[str] = Field(default=None)
     batch_function_uuid: Optional[str] = Field(default=None)
+
+
+class EndpointError(Exception):
+    def __init__(self, error_message: str, error_code: int) -> None:
+        self.error_message = error_message
+        self.error_code = error_code
+
+    def __repr__(self):
+        return f"EndpointError(error_code={self.error_code}, error_message={self.error_message})"
 
 
 # Globus Compute implementation of a BaseEndpoint
@@ -66,6 +78,7 @@ class GlobusComputeEndpoint(BaseEndpoint):
     ):
         # Validate endpoint configuration
         self.__config = GlobusComputeEndpointConfig(**config)
+        self._client_lock = asyncio.Lock()
 
         # Initialize the rest of the common attributes
         super().__init__(
@@ -148,27 +161,37 @@ class GlobusComputeEndpoint(BaseEndpoint):
         # Return endpoint status
         return GetEndpointStatusResponse(status=endpoint_status)
 
-    # Submit task
-    async def submit_task(self, data: dict) -> SubmitTaskResponse:
-        """Submits a single interactive task to the compute resource."""
-
+    async def prepare_executor(self, for_batch: bool = False) -> Executor:
         # Get Globus Compute client and executor
         try:
             gcc = globus_utils.get_compute_client_from_globus_app()
             gce = globus_utils.get_compute_executor(client=gcc)
         except Exception as e:
-            return SubmitTaskResponse(error_message=str(e), error_code=500)
+            raise EndpointError(error_code=500, error_message=str(e)) from e
 
         # Check endpoint status
-        response = await self.get_endpoint_status(gcc=gcc, check_managers=True)
+        response = await self.get_endpoint_status(
+            gcc=gcc, check_managers=True, for_batch=for_batch
+        )
         if response.error_message:
-            return SubmitTaskResponse(
-                error_code=response.error_code, error_message=response.error_message
+            raise EndpointError(
+                error_code=response.error_code,
+                error_message=str(response.error_message),
             )
+
+        return gce
+
+    # Submit task
+    async def submit_task(self, data: dict) -> SubmitTaskResponse:
+        """Submits a single interactive task to the compute resource."""
+        try:
+            gce = await self.prepare_executor()
+        except EndpointError as e:
+            return SubmitTaskResponse(error_message=e, error_code=e.error_code)
 
         # Add API port to the input data
         try:
-            data["model_params"]["api_port"] = self.config.api_port
+            data.setdefault("model_params", {})["api_port"] = self.config.api_port
         except Exception as e:
             remove_endpoint_from_cache(self.endpoint_slug)
             return SubmitTaskResponse(
@@ -197,6 +220,50 @@ class GlobusComputeEndpoint(BaseEndpoint):
         # Return the successful result
         return SubmitTaskResponse(result=result, task_id=task_id)
 
+    async def submit_task_async(
+        self, data: dict[str, Any], endpoint_config: dict[str, Any] | None = None
+    ) -> SubmitTaskAsyncResponse:
+        try:
+            gce = await self.prepare_executor()
+        except EndpointError as e:
+            return SubmitTaskAsyncResponse(error_message=e, error_code=e.error_code)
+
+        gcc = gce.client
+        batch = gcc.create_batch(user_endpoint_config=endpoint_config)
+        batch.add(self.config.function_uuid, args=[data])
+
+        async with self._client_lock:
+            r = await asyncio.to_thread(
+                gcc.batch_run, endpoint_id=self.config.endpoint_uuid, batch=batch
+            )
+
+        task_id = r["tasks"][self.config.function_uuid][0]
+        return SubmitTaskAsyncResponse(task_id=task_id)
+
+    async def get_task_result(self, task_id: str) -> SubmitTaskResponse:
+        try:
+            gce = await self.prepare_executor()
+        except EndpointError as e:
+            return SubmitTaskResponse(error_message=e, error_code=e.error_code)
+
+        gcc = gce.client
+
+        try:
+            async with self._client_lock:
+                result = await asyncio.to_thread(gcc.get_result, task_id)
+        except TaskPending:
+            return SubmitTaskResponse(
+                error_message="Task is still pending, try again soon.",
+                error_code=400,
+                task_id=task_id,
+            )
+        except Exception as e:
+            return SubmitTaskResponse(
+                error_message=f"Task failed: {str(e)}", error_code=500, task_id=task_id
+            )
+        else:
+            return SubmitTaskResponse(result=result, task_id=task_id)
+
     # Submit streaming task
     async def submit_streaming_task(
         self, data: dict, request_log_id: str
@@ -224,18 +291,13 @@ class GlobusComputeEndpoint(BaseEndpoint):
         try:
             # Assign endpoint UUID to the executor (same as submit_and_get_result)
             try:
-                gcc = globus_utils.get_compute_client_from_globus_app()
-                gce = globus_utils.get_compute_executor(client=gcc)
-            except Exception as e:
-                return SubmitStreamingTaskResponse(error_message=str(e), error_code=500)
-            gce.endpoint_id = self.config.endpoint_uuid
-
-            # Check endpoint status
-            response = await self.get_endpoint_status(gcc=gcc)
-            if response.error_message:
+                gce = await self.prepare_executor()
+            except EndpointError as e:
                 return SubmitStreamingTaskResponse(
-                    error_message=response.error_message, error_code=response.error_code
+                    error_message=e.error_message, error_code=e.error_code
                 )
+
+            gce.endpoint_id = self.config.endpoint_uuid
 
             # Submit Globus Compute task and collect the future object (same as submit_and_get_result)
             future = gce.submit_to_registered_function(
@@ -442,23 +504,14 @@ class GlobusComputeEndpoint(BaseEndpoint):
     ) -> SubmitBatchResponse:
         """Submits a batch job to the compute resource."""
 
-        # Get Globus Compute client (using the endpoint identity)
         try:
-            gcc = globus_utils.get_compute_client_from_globus_app()
-        except Exception as e:
+            gce = await self.prepare_executor(for_batch=True)
+        except EndpointError as e:
             return SubmitBatchResponse(
-                error_message=f"Error: Could not get the Globus Compute client: {e}",
-                error_code=500,
+                error_message=e.error_message, error_code=e.error_code
             )
 
-        # Check endpoint status
-        response = await self.get_endpoint_status(
-            gcc=gcc, check_managers=True, for_batch=True
-        )
-        if response.error_message:
-            return SubmitBatchResponse(
-                error_message=response.error_message, error_code=response.error_code
-            )
+        gcc = gce.client
 
         # Prepare input parameter for the compute tasks
         # NOTE: This is already in list format in case we submit multiple tasks per batch
@@ -491,9 +544,12 @@ class GlobusComputeEndpoint(BaseEndpoint):
 
         # Submit batch to Globus Compute and update batch status if submission is successful
         try:
-            batch_response = gcc.batch_run(
-                endpoint_id=self.config.batch_endpoint_uuid, batch=batch
-            )
+            async with self._client_lock:
+                batch_response = await asyncio.to_thread(
+                    gcc.batch_run,
+                    endpoint_id=self.config.batch_endpoint_uuid,
+                    batch=batch,
+                )
         except Exception as e:
             return SubmitBatchResponse(
                 error_message=f"Error: Could not submit the Globus Compute batch: {e}",

--- a/resource_server_async/schemas/sam3.py
+++ b/resource_server_async/schemas/sam3.py
@@ -1,0 +1,10 @@
+from ninja import Schema
+from typing import Literal
+from pathlib import Path
+
+
+class Sam3Request(Schema):
+    inference_type: Literal["single-image", "batch"]
+    data_uri: str
+    single_image_prompt: str | None
+    weights_dir_override: Path | None = None

--- a/resource_server_async/tests/mock_utils.py
+++ b/resource_server_async/tests/mock_utils.py
@@ -180,6 +180,10 @@ class MockGlobusComputeExecutor:
     def submit_to_registered_function(self, function_uuid, args=None):
         return MockFuture()
 
+    @property
+    def client(self):
+        return MockGlobusComputeClient()
+
 
 # Mock get_globus_client function
 def get_globus_client():

--- a/resource_server_async/views.py
+++ b/resource_server_async/views.py
@@ -25,7 +25,9 @@ from utils.pydantic_models.db_models import (
     UserPydantic,
 )
 from utils.pydantic_models.batch import BatchStatusEnum, BatchListFilter
+from utils.globus_utils import get_transfer_client
 from resource_server_async.clusters.cluster import Jobs, JobInfo, BaseCluster
+from resource_server_async.endpoints.globus_compute import GlobusComputeEndpoint
 from resource_server_async.utils import (
     extract_prompt,
     validate_request_body,
@@ -54,6 +56,7 @@ log.info("Utils functions loaded.")
 # Django database
 # from resource_server.models import FederatedEndpoint
 from resource_server_async.models import BatchLog, Cluster, Endpoint
+from resource_server_async.schemas.sam3 import Sam3Request
 
 # Django Ninja API
 from resource_server_async.api import api, router
@@ -111,6 +114,64 @@ async def get_list_endpoints(request):
 
     # Return list of frameworks and models
     return await get_response(json.dumps(all_endpoints), 200, request)
+
+
+@router.put("/data/staging")
+def ensure_staging_area(request):
+    """
+    Idempotent user request to create a staging area for the inference service.
+
+    A temporary directory named with the user's principal ID is created and
+    read/write ACLs are granted to the user to initiate data transfers.
+    """
+    principal_id = request.user.id
+    collection_id = settings.DATA_STAGING_GLOBUS_COLLECTION_ID
+    staging_path = f"/user-staging/{principal_id}/"
+
+    log.info(f"User {principal_id=} requesting staging area in {collection_id=}")
+
+    tc = get_transfer_client()
+
+    try:
+        tc.operation_mkdir(collection_id, staging_path)
+        log.info(f"staging directory {staging_path=} created")
+    except tc.error_class as e:
+        if "exists" not in str(e).lower():
+            raise
+        log.info(f"staging directory {staging_path=} already exists")
+
+    existing_rules = tc.endpoint_acl_list(collection_id)
+    acl_rule_id = next(
+        (
+            r
+            for r in existing_rules
+            if r["principal"] == principal_id and r["path"] == staging_path
+        ),
+        None,
+    )
+
+    if acl_rule_id is None:
+        acl_result = tc.add_endpoint_acl_rule(
+            collection_id,
+            dict(
+                DATA_TYPE="access",
+                principal_type="identity",
+                principal=principal_id,
+                path=staging_path,
+                permissions="rw",
+            ),
+        )
+        acl_rule_id = acl_result["access_id"]
+        log.info(f"Granted rw access via {acl_rule_id=}")
+    else:
+        log.info(f"Staging area {acl_rule_id=} already exists for {principal_id=}")
+
+    return {
+        "collection_id": collection_id,
+        "path": staging_path,
+        "acl_rule_id": acl_rule_id,
+        "principal": principal_id,
+    }
 
 
 # List running and queue models (GET)
@@ -642,6 +703,99 @@ async def post_inference(
     # If not streaming, return the complete response and automate database operations
     else:
         return await get_response(task_response.result, 200, request)
+
+
+# Inference (POST)
+@router.post("/sophia/sam3service/process")
+async def sam3_infer(request, payload: Sam3Request):
+    """
+    Submit single-image inference request to SAM3 Globus Compute endpoint.
+    """
+    # Get cluster wrapper from database
+    response = await get_cluster_wrapper("sophia")
+    if response.error_message:
+        return await get_response(response.error_message, response.error_code, request)
+    cluster: BaseCluster = response.cluster
+
+    # Error if the cluster is under maintenance
+    response = cluster.check_maintenance()
+    if response.error_message:
+        return await get_response(response.error_message, response.error_code, request)
+
+    # Endpoint slug (sophia-sam3service-sam3 hardcoded for now)
+    framework = "sam3service"
+    endpoint_slug = slugify(f"{cluster.cluster_name} {framework} sam3")
+    log.info(f"endpoint_slug: {endpoint_slug} - user: {request.auth.username}")
+
+    # Get endpoint wrapper from database
+    response = await get_endpoint_wrapper(endpoint_slug)
+    if response.error_message:
+        return await get_response(response.error_message, response.error_code, request)
+
+    endpoint: GlobusComputeEndpoint = response.endpoint
+
+    # Block access if the user is not allowed to use the endpoint
+    response = endpoint.check_permission(request.auth, request.user_group_uuids)
+    if (response.is_authorized == False) or response.error_message:
+        return await get_response(response.error_message, response.error_code, request)
+
+    # Submit task
+    data = payload.model_dump(exclude={"weights_dir_override"})
+    config = (
+        {"sam3_weights_dir": str(payload.weights_dir_override)}
+        if payload.weights_dir_override
+        else None
+    )
+
+    task_response = await endpoint.submit_task_async(data, endpoint_config=config)
+
+    # Display error message if any
+    if task_response.error_message:
+        return await get_response(
+            task_response.error_message, task_response.error_code, request
+        )
+
+    return await get_response(task_response.model_dump(), 200, request)
+
+
+@router.get("/sophia/sam3service/tasks/{task_id}")
+async def sam3_get_task_result(request, task_id: str):
+    # Get cluster wrapper from database
+    response = await get_cluster_wrapper("sophia")
+    if response.error_message:
+        return await get_response(response.error_message, response.error_code, request)
+    cluster: BaseCluster = response.cluster
+
+    # Error if the cluster is under maintenance
+    response = cluster.check_maintenance()
+    if response.error_message:
+        return await get_response(response.error_message, response.error_code, request)
+
+    # Endpoint slug (sophia-sam3service-sam3 hardcoded for now)
+    framework = "sam3service"
+    endpoint_slug = slugify(f"{cluster.cluster_name} {framework} sam3")
+    log.info(f"endpoint_slug: {endpoint_slug} - user: {request.auth.username}")
+
+    # Get endpoint wrapper from database
+    response = await get_endpoint_wrapper(endpoint_slug)
+    if response.error_message:
+        return await get_response(response.error_message, response.error_code, request)
+
+    endpoint: GlobusComputeEndpoint = response.endpoint
+
+    # Block access if the user is not allowed to use the endpoint
+    response = endpoint.check_permission(request.auth, request.user_group_uuids)
+    if (response.is_authorized == False) or response.error_message:
+        return await get_response(response.error_message, response.error_code, request)
+
+    task_response = await endpoint.get_task_result(task_id)
+    # Display error message if any
+    if task_response.error_message:
+        return await get_response(
+            task_response.model_dump_json(), task_response.error_code, request
+        )
+
+    return await get_response(task_response.model_dump_json(), 200, request)
 
 
 # Streaming server endpoints (integrated into Django)

--- a/utils/globus_utils.py
+++ b/utils/globus_utils.py
@@ -2,6 +2,7 @@ import asyncio
 import time
 from django.conf import settings
 import globus_sdk
+from globus_sdk import TransferClient
 from globus_compute_sdk import Client, Executor
 from globus_compute_sdk.errors import TaskExecutionFailed
 from globus_compute_sdk.sdk.executor import log as EXECUTOR_LOG
@@ -24,7 +25,7 @@ executor_cache = TTLCache(maxsize=1024, ttl=60 * 10)
 # Get authenticated Compute Client using secret
 # NOTE: Using in-memory TTLCache since Globus Client objects cannot be serialized to Redis
 @cached(cache=TTLCache(maxsize=1024, ttl=60 * 60))
-def get_compute_client_from_globus_app() -> globus_sdk.GlobusHTTPResponse:
+def get_compute_client_from_globus_app() -> Client:
     """
     Create and return an authenticated Compute client using the Globus SDK ClientApp.
 
@@ -46,6 +47,19 @@ def get_compute_client_from_globus_app() -> globus_sdk.GlobusHTTPResponse:
         )
     except Exception as e:
         raise ResourceServerError("Exception in creating client. Error", e)
+
+
+@cached(cache=TTLCache(maxsize=1024, ttl=60 * 60))
+def get_transfer_client() -> TransferClient:
+    confidential_client = globus_sdk.ConfidentialAppAuthClient(
+        client_id=settings.SERVICE_ACCOUNT_ID,
+        client_secret=settings.SERVICE_ACCOUNT_SECRET,
+    )
+    cc_authorizer = globus_sdk.ClientCredentialsAuthorizer(
+        confidential_client, globus_sdk.TransferClient.scopes.all
+    )
+    # create a new client
+    return TransferClient(authorizer=cc_authorizer)
 
 
 # Get authenticated Compute Executor using existing client

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ members = [
 
 [[package]]
 name = "alcf-ai"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "alcf_ai" }
 dependencies = [
     { name = "globus-sdk" },

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,52 @@ version = 1
 revision = 3
 requires-python = "==3.12.6"
 
+[manifest]
+members = [
+    "alcf-ai",
+    "inference-gateway-backend",
+]
+
+[[package]]
+name = "alcf-ai"
+version = "0.2.1"
+source = { editable = "alcf_ai" }
+dependencies = [
+    { name = "globus-sdk" },
+    { name = "httpx" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "openai" },
+    { name = "pillow" },
+    { name = "rich" },
+    { name = "smart-open" },
+    { name = "tifffile" },
+    { name = "typer" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "globus-sdk", specifier = ">=3.65.0,<4" },
+    { name = "httpx" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "openai" },
+    { name = "pillow" },
+    { name = "rich" },
+    { name = "smart-open" },
+    { name = "tifffile" },
+    { name = "typer" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
@@ -143,14 +189,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.0"
+version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943, upload-time = "2025-09-18T17:32:23.696Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc", size = 107295, upload-time = "2025-09-18T17:32:22.42Z" },
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
 ]
 
 [[package]]
@@ -160,6 +206,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "contourpy"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/45/adfee365d9ea3d853550b2e735f9d66366701c65db7855cd07621732ccfc/contourpy-1.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b08a32ea2f8e42cf1d4be3169a98dd4be32bafe4f22b6c4cb4ba810fa9e5d2cb", size = 293419, upload-time = "2025-07-26T12:01:21.16Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3e/405b59cfa13021a56bba395a6b3aca8cec012b45bf177b0eaf7a202cde2c/contourpy-1.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:556dba8fb6f5d8742f2923fe9457dbdd51e1049c4a43fd3986a0b14a1d815fc6", size = 273979, upload-time = "2025-07-26T12:01:22.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/1c/a12359b9b2ca3a845e8f7f9ac08bdf776114eb931392fcad91743e2ea17b/contourpy-1.3.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92d9abc807cf7d0e047b95ca5d957cf4792fcd04e920ca70d48add15c1a90ea7", size = 332653, upload-time = "2025-07-26T12:01:24.155Z" },
+    { url = "https://files.pythonhosted.org/packages/63/12/897aeebfb475b7748ea67b61e045accdfcf0d971f8a588b67108ed7f5512/contourpy-1.3.3-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2e8faa0ed68cb29af51edd8e24798bb661eac3bd9f65420c1887b6ca89987c8", size = 379536, upload-time = "2025-07-26T12:01:25.91Z" },
+    { url = "https://files.pythonhosted.org/packages/43/8a/a8c584b82deb248930ce069e71576fc09bd7174bbd35183b7943fb1064fd/contourpy-1.3.3-cp312-cp312-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:626d60935cf668e70a5ce6ff184fd713e9683fb458898e4249b63be9e28286ea", size = 384397, upload-time = "2025-07-26T12:01:27.152Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d00e655fcef08aba35ec9610536bfe90267d7ab5ba944f7032549c55a146da1", size = 362601, upload-time = "2025-07-26T12:01:28.808Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0a/a3fe3be3ee2dceb3e615ebb4df97ae6f3828aa915d3e10549ce016302bd1/contourpy-1.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:451e71b5a7d597379ef572de31eeb909a87246974d960049a9848c3bc6c41bf7", size = 1331288, upload-time = "2025-07-26T12:01:31.198Z" },
+    { url = "https://files.pythonhosted.org/packages/33/1d/acad9bd4e97f13f3e2b18a3977fe1b4a37ecf3d38d815333980c6c72e963/contourpy-1.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:459c1f020cd59fcfe6650180678a9993932d80d44ccde1fa1868977438f0b411", size = 1403386, upload-time = "2025-07-26T12:01:33.947Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8f/5847f44a7fddf859704217a99a23a4f6417b10e5ab1256a179264561540e/contourpy-1.3.3-cp312-cp312-win32.whl", hash = "sha256:023b44101dfe49d7d53932be418477dba359649246075c996866106da069af69", size = 185018, upload-time = "2025-07-26T12:01:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e8/6026ed58a64563186a9ee3f29f41261fd1828f527dd93d33b60feca63352/contourpy-1.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:8153b8bfc11e1e4d75bcb0bff1db232f9e10b274e0929de9d608027e0d34ff8b", size = 226567, upload-time = "2025-07-26T12:01:36.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/e2/f05240d2c39a1ed228d8328a78b6f44cd695f7ef47beb3e684cf93604f86/contourpy-1.3.3-cp312-cp312-win_arm64.whl", hash = "sha256:07ce5ed73ecdc4a03ffe3e1b3e3c1166db35ae7584be76f65dbbe28a7791b0cc", size = 193655, upload-time = "2025-07-26T12:01:37.999Z" },
 ]
 
 [[package]]
@@ -210,12 +278,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/2a/8c3ac3d8bc94e6de8d7ae270bb5bc437b210bb9d6d9e46630c98f4abd20c/csscompressor-0.9.5.tar.gz", hash = "sha256:afa22badbcf3120a4f392e4d22f9fff485c044a1feda4a950ecc5eba9dd31a05", size = 237808, upload-time = "2017-11-26T21:13:08.238Z" }
 
 [[package]]
+name = "cycler"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
 name = "dill"
 version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/70/43/86fe3f9e130c4137b0f1b50784dd70a5087b911fe07fa81e53e0c4c47fea/dill-0.3.9.tar.gz", hash = "sha256:81aa267dddf68cbfe8029c42ca9ec6a4ab3b22371d1c450abc54422577b4512c", size = 187000, upload-time = "2024-09-29T00:03:20.958Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/d1/e73b6ad76f0b1fb7f23c35c6d95dbc506a9c8804f43dda8cb5b0fa6331fd/dill-0.3.9-py3-none-any.whl", hash = "sha256:468dff3b89520b474c0397703366b7b95eebe6303f108adf9b19da1f702be87a", size = 119418, upload-time = "2024-09-29T00:03:19.344Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
 ]
 
 [[package]]
@@ -322,6 +408,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674, upload-time = "2025-05-10T17:42:49.33Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.62.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/08/7012b00a9a5874311b639c3920270c36ee0c445b69d9989a85e5c92ebcb0/fonttools-4.62.1.tar.gz", hash = "sha256:e54c75fd6041f1122476776880f7c3c3295ffa31962dc6ebe2543c00dca58b5d", size = 3580737, upload-time = "2026-03-13T13:54:25.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/d4/dbacced3953544b9a93088cc10ef2b596d348c983d5c67a404fa41ec51ba/fonttools-4.62.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:90365821debbd7db678809c7491ca4acd1e0779b9624cdc6ddaf1f31992bf974", size = 2870219, upload-time = "2026-03-13T13:52:53.664Z" },
+    { url = "https://files.pythonhosted.org/packages/66/9e/a769c8e99b81e5a87ab7e5e7236684de4e96246aae17274e5347d11ebd78/fonttools-4.62.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:12859ff0b47dd20f110804c3e0d0970f7b832f561630cd879969011541a464a9", size = 2414891, upload-time = "2026-03-13T13:52:56.493Z" },
+    { url = "https://files.pythonhosted.org/packages/69/64/f19a9e3911968c37e1e620e14dfc5778299e1474f72f4e57c5ec771d9489/fonttools-4.62.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c125ffa00c3d9003cdaaf7f2c79e6e535628093e14b5de1dccb08859b680936", size = 5033197, upload-time = "2026-03-13T13:52:59.179Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8a/99c8b3c3888c5c474c08dbfd7c8899786de9604b727fcefb055b42c84bba/fonttools-4.62.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:149f7d84afca659d1a97e39a4778794a2f83bf344c5ee5134e09995086cc2392", size = 4988768, upload-time = "2026-03-13T13:53:02.761Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c6/0f904540d3e6ab463c1243a0d803504826a11604c72dd58c2949796a1762/fonttools-4.62.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0aa72c43a601cfa9273bb1ae0518f1acadc01ee181a6fc60cd758d7fdadffc04", size = 4971512, upload-time = "2026-03-13T13:53:05.678Z" },
+    { url = "https://files.pythonhosted.org/packages/29/0b/5cbef6588dc9bd6b5c9ad6a4d5a8ca384d0cea089da31711bbeb4f9654a6/fonttools-4.62.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:19177c8d96c7c36359266e571c5173bcee9157b59cfc8cb0153c5673dc5a3a7d", size = 5122723, upload-time = "2026-03-13T13:53:08.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/47/b3a5342d381595ef439adec67848bed561ab7fdb1019fa522e82101b7d9c/fonttools-4.62.1-cp312-cp312-win32.whl", hash = "sha256:a24decd24d60744ee8b4679d38e88b8303d86772053afc29b19d23bb8207803c", size = 2281278, upload-time = "2026-03-13T13:53:10.998Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b1/0c2ab56a16f409c6c8a68816e6af707827ad5d629634691ff60a52879792/fonttools-4.62.1-cp312-cp312-win_amd64.whl", hash = "sha256:9e7863e10b3de72376280b515d35b14f5eeed639d1aa7824f4cf06779ec65e42", size = 2331414, upload-time = "2026-03-13T13:53:13.992Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ba/56147c165442cc5ba7e82ecf301c9a68353cede498185869e6e02b4c264f/fonttools-4.62.1-py3-none-any.whl", hash = "sha256:7487782e2113861f4ddcc07c3436450659e3caa5e470b27dc2177cade2d8e7fd", size = 1152647, upload-time = "2026-03-13T13:54:22.735Z" },
 ]
 
 [[package]]
@@ -475,9 +578,10 @@ wheels = [
 
 [[package]]
 name = "inference-gateway-backend"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
+    { name = "alcf-ai" },
     { name = "annotated-types" },
     { name = "asgiref" },
     { name = "asyncache" },
@@ -567,6 +671,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alcf-ai", editable = "alcf_ai" },
     { name = "annotated-types", specifier = "==0.7.0" },
     { name = "asgiref", specifier = "==3.10.0" },
     { name = "asyncache", specifier = ">=0.3.1,<0.4" },
@@ -577,7 +682,7 @@ requires-dist = [
     { name = "certifi", specifier = "==2025.10.5" },
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'", specifier = "==2.0.0" },
     { name = "charset-normalizer", specifier = "==3.4.4" },
-    { name = "click", specifier = "==8.3.0" },
+    { name = "click" },
     { name = "colorama", specifier = "==0.4.6" },
     { name = "cryptography", specifier = "==46.0.3" },
     { name = "csscompressor", specifier = "==0.9.5" },
@@ -643,7 +748,7 @@ requires-dist = [
     { name = "sqlparse", specifier = "==0.5.3" },
     { name = "tblib", specifier = "==1.7.0" },
     { name = "texttable", specifier = "==1.7.0" },
-    { name = "typer", specifier = ">=0.12.5,<0.13" },
+    { name = "typer" },
     { name = "typing-extensions", specifier = "==4.15.0" },
     { name = "typing-inspection", specifier = "==0.4.2" },
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = "==2025.2" },
@@ -673,6 +778,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/5e/4ec91646aee381d01cdb9974e30882c9cd3b8c5d1079d6b5ff4af522439a/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4", size = 164847, upload-time = "2026-02-02T12:37:56.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/30/7687e4f87086829955013ca12a9233523349767f69653ebc27036313def9/jiter-0.13.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0a2bd69fc1d902e89925fc34d1da51b2128019423d7b339a45d9e99c894e0663", size = 307958, upload-time = "2026-02-02T12:35:57.165Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/27/e57f9a783246ed95481e6749cc5002a8a767a73177a83c63ea71f0528b90/jiter-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f917a04240ef31898182f76a332f508f2cc4b57d2b4d7ad2dbfebbfe167eb505", size = 318597, upload-time = "2026-02-02T12:35:58.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/52/e5719a60ac5d4d7c5995461a94ad5ef962a37c8bf5b088390e6fad59b2ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1e2b199f446d3e82246b4fd9236d7cb502dc2222b18698ba0d986d2fecc6152", size = 348821, upload-time = "2026-02-02T12:36:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/61/db/c1efc32b8ba4c740ab3fc2d037d8753f67685f475e26b9d6536a4322bcdd/jiter-0.13.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04670992b576fa65bd056dbac0c39fe8bd67681c380cb2b48efa885711d9d726", size = 364163, upload-time = "2026-02-02T12:36:01.937Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8a/fb75556236047c8806995671a18e4a0ad646ed255276f51a20f32dceaeec/jiter-0.13.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a1aff1fbdb803a376d4d22a8f63f8e7ccbce0b4890c26cc7af9e501ab339ef0", size = 483709, upload-time = "2026-02-02T12:36:03.41Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/16/43512e6ee863875693a8e6f6d532e19d650779d6ba9a81593ae40a9088ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b3fb8c2053acaef8580809ac1d1f7481a0a0bdc012fd7f5d8b18fb696a5a089", size = 370480, upload-time = "2026-02-02T12:36:04.791Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/4c/09b93e30e984a187bc8aaa3510e1ec8dcbdcd71ca05d2f56aac0492453aa/jiter-0.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdaba7d87e66f26a2c45d8cbadcbfc4bf7884182317907baf39cfe9775bb4d93", size = 360735, upload-time = "2026-02-02T12:36:06.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1b/46c5e349019874ec5dfa508c14c37e29864ea108d376ae26d90bee238cd7/jiter-0.13.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7b88d649135aca526da172e48083da915ec086b54e8e73a425ba50999468cc08", size = 391814, upload-time = "2026-02-02T12:36:08.368Z" },
+    { url = "https://files.pythonhosted.org/packages/15/9e/26184760e85baee7162ad37b7912797d2077718476bf91517641c92b3639/jiter-0.13.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e404ea551d35438013c64b4f357b0474c7abf9f781c06d44fcaf7a14c69ff9e2", size = 513990, upload-time = "2026-02-02T12:36:09.993Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/34/2c9355247d6debad57a0a15e76ab1566ab799388042743656e566b3b7de1/jiter-0.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1f4748aad1b4a93c8bdd70f604d0f748cdc0e8744c5547798acfa52f10e79228", size = 548021, upload-time = "2026-02-02T12:36:11.376Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/4a/9f2c23255d04a834398b9c2e0e665382116911dc4d06b795710503cdad25/jiter-0.13.0-cp312-cp312-win32.whl", hash = "sha256:0bf670e3b1445fc4d31612199f1744f67f889ee1bbae703c4b54dc097e5dd394", size = 203024, upload-time = "2026-02-02T12:36:12.682Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ee/f0ae675a957ae5a8f160be3e87acea6b11dc7b89f6b7ab057e77b2d2b13a/jiter-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:15db60e121e11fe186c0b15236bd5d18381b9ddacdcf4e659feb96fc6c969c92", size = 205424, upload-time = "2026-02-02T12:36:13.93Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ae611edf913d3cbf02c97cdb90374af2082c48d7190d74c1111dde08bcdd/jiter-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:41f92313d17989102f3cb5dd533a02787cdb99454d494344b0361355da52fcb9", size = 186818, upload-time = "2026-02-02T12:36:15.308Z" },
+    { url = "https://files.pythonhosted.org/packages/80/60/e50fa45dd7e2eae049f0ce964663849e897300433921198aef94b6ffa23a/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:3d744a6061afba08dd7ae375dcde870cffb14429b7477e10f67e9e6d68772a0a", size = 305169, upload-time = "2026-02-02T12:37:50.376Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
 ]
 
 [[package]]
@@ -706,6 +836,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "kiwisolver"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/67/9c61eccb13f0bdca9307614e782fec49ffdde0f7a2314935d489fa93cd9c/kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a", size = 103482, upload-time = "2026-03-09T13:15:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/b2/818b74ebea34dabe6d0c51cb1c572e046730e64844da6ed646d5298c40ce/kiwisolver-1.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e9750bc21b886308024f8a54ccb9a2cc38ac9fa813bf4348434e3d54f337ff9", size = 123158, upload-time = "2026-03-09T13:13:23.127Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/d9/405320f8077e8e1c5c4bd6adc45e1e6edf6d727b6da7f2e2533cf58bff71/kiwisolver-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:72ec46b7eba5b395e0a7b63025490d3214c11013f4aacb4f5e8d6c3041829588", size = 66388, upload-time = "2026-03-09T13:13:24.765Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9f/795fedf35634f746151ca8839d05681ceb6287fbed6cc1c9bf235f7887c2/kiwisolver-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ed3a984b31da7481b103f68776f7128a89ef26ed40f4dc41a2223cda7fb24819", size = 64068, upload-time = "2026-03-09T13:13:25.878Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/13/680c54afe3e65767bed7ec1a15571e1a2f1257128733851ade24abcefbcc/kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb5136fb5352d3f422df33f0c879a1b0c204004324150cc3b5e3c4f310c9049f", size = 1477934, upload-time = "2026-03-09T13:13:27.166Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2f/cebfcdb60fd6a9b0f6b47a9337198bcbad6fbe15e68189b7011fd914911f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2af221f268f5af85e776a73d62b0845fc8baf8ef0abfae79d29c77d0e776aaf", size = 1278537, upload-time = "2026-03-09T13:13:28.707Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/0d/9b782923aada3fafb1d6b84e13121954515c669b18af0c26e7d21f579855/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b0f172dc8ffaccb8522d7c5d899de00133f2f1ca7b0a49b7da98e901de87bf2d", size = 1296685, upload-time = "2026-03-09T13:13:30.528Z" },
+    { url = "https://files.pythonhosted.org/packages/27/70/83241b6634b04fe44e892688d5208332bde130f38e610c0418f9ede47ded/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ab8ba9152203feec73758dad83af9a0bbe05001eb4639e547207c40cfb52083", size = 1346024, upload-time = "2026-03-09T13:13:32.818Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/db/30ed226fb271ae1a6431fc0fe0edffb2efe23cadb01e798caeb9f2ceae8f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:cdee07c4d7f6d72008d3f73b9bf027f4e11550224c7c50d8df1ae4a37c1402a6", size = 987241, upload-time = "2026-03-09T13:13:34.435Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bd/c314595208e4c9587652d50959ead9e461995389664e490f4dce7ff0f782/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7c60d3c9b06fb23bd9c6139281ccbdc384297579ae037f08ae90c69f6845c0b1", size = 2227742, upload-time = "2026-03-09T13:13:36.4Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/43/0499cec932d935229b5543d073c2b87c9c22846aab48881e9d8d6e742a2d/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e315e5ec90d88e140f57696ff85b484ff68bb311e36f2c414aa4286293e6dee0", size = 2323966, upload-time = "2026-03-09T13:13:38.204Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/79b0d760907965acfd9d61826a3d41f8f093c538f55cd2633d3f0db269f6/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1465387ac63576c3e125e5337a6892b9e99e0627d52317f3ca79e6930d889d15", size = 1977417, upload-time = "2026-03-09T13:13:39.966Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/01d0537c41cb75a551a438c3c7a80d0c60d60b81f694dac83dd436aec0d0/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:530a3fd64c87cffa844d4b6b9768774763d9caa299e9b75d8eca6a4423b31314", size = 2491238, upload-time = "2026-03-09T13:13:41.698Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/34/8aefdd0be9cfd00a44509251ba864f5caf2991e36772e61c408007e7f417/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1d9daea4ea6b9be74fe2f01f7fbade8d6ffab263e781274cffca0dba9be9eec9", size = 2294947, upload-time = "2026-03-09T13:13:43.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cf/0348374369ca588f8fe9c338fae49fa4e16eeb10ffb3d012f23a54578a9e/kiwisolver-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:f18c2d9782259a6dc132fdc7a63c168cbc74b35284b6d75c673958982a378384", size = 73569, upload-time = "2026-03-09T13:13:45.792Z" },
+    { url = "https://files.pythonhosted.org/packages/28/26/192b26196e2316e2bd29deef67e37cdf9870d9af8e085e521afff0fed526/kiwisolver-1.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:f7c7553b13f69c1b29a5bde08ddc6d9d0c8bfb84f9ed01c30db25944aeb852a7", size = 64997, upload-time = "2026-03-09T13:13:46.878Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fa/2910df836372d8761bb6eff7d8bdcb1613b5c2e03f260efe7abe34d388a7/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_10_13_x86_64.whl", hash = "sha256:5ae8e62c147495b01a0f4765c878e9bfdf843412446a247e28df59936e99e797", size = 130262, upload-time = "2026-03-09T13:15:35.629Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/41/c5f71f9f00aabcc71fee8b7475e3f64747282580c2fe748961ba29b18385/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f6764a4ccab3078db14a632420930f6186058750df066b8ea2a7106df91d3203", size = 138036, upload-time = "2026-03-09T13:15:36.894Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/06/7399a607f434119c6e1fdc8ec89a8d51ccccadf3341dee4ead6bd14caaf5/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31c13da98624f957b0fb1b5bae5383b2333c2c3f6793d9825dd5ce79b525cb7", size = 194295, upload-time = "2026-03-09T13:15:38.22Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/91/53255615acd2a1eaca307ede3c90eb550bae9c94581f8c00081b6b1c8f44/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:1f1489f769582498610e015a8ef2d36f28f505ab3096d0e16b4858a9ec214f57", size = 75987, upload-time = "2026-03-09T13:15:39.65Z" },
 ]
 
 [[package]]
@@ -746,6 +903,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
     { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
     { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+]
+
+[[package]]
+name = "matplotlib"
+version = "3.10.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "contourpy" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/76/d3c6e3a13fe484ebe7718d14e269c9569c4eb0020a968a327acb3b9a8fe6/matplotlib-3.10.8.tar.gz", hash = "sha256:2299372c19d56bcd35cf05a2738308758d32b9eaed2371898d8f5bd33f084aa3", size = 34806269, upload-time = "2025-12-10T22:56:51.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/67/f997cdcbb514012eb0d10cd2b4b332667997fb5ebe26b8d41d04962fa0e6/matplotlib-3.10.8-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:64fcc24778ca0404ce0cb7b6b77ae1f4c7231cdd60e6778f999ee05cbd581b9a", size = 8260453, upload-time = "2025-12-10T22:55:30.709Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/07d5f5c7f7c994f12c768708bd2e17a4f01a2b0f44a1c9eccad872433e2e/matplotlib-3.10.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b9a5ca4ac220a0cdd1ba6bcba3608547117d30468fefce49bb26f55c1a3d5c58", size = 8148321, upload-time = "2025-12-10T22:55:33.265Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/f3/c5195b1ae57ef85339fd7285dfb603b22c8b4e79114bae5f4f0fcf688677/matplotlib-3.10.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3ab4aabc72de4ff77b3ec33a6d78a68227bf1123465887f9905ba79184a1cc04", size = 8716944, upload-time = "2025-12-10T22:55:34.922Z" },
+    { url = "https://files.pythonhosted.org/packages/00/f9/7638f5cc82ec8a7aa005de48622eecc3ed7c9854b96ba15bd76b7fd27574/matplotlib-3.10.8-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24d50994d8c5816ddc35411e50a86ab05f575e2530c02752e02538122613371f", size = 9550099, upload-time = "2025-12-10T22:55:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/57/61/78cd5920d35b29fd2a0fe894de8adf672ff52939d2e9b43cb83cd5ce1bc7/matplotlib-3.10.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:99eefd13c0dc3b3c1b4d561c1169e65fe47aab7b8158754d7c084088e2329466", size = 9613040, upload-time = "2025-12-10T22:55:38.715Z" },
+    { url = "https://files.pythonhosted.org/packages/30/4e/c10f171b6e2f44d9e3a2b96efa38b1677439d79c99357600a62cc1e9594e/matplotlib-3.10.8-cp312-cp312-win_amd64.whl", hash = "sha256:dd80ecb295460a5d9d260df63c43f4afbdd832d725a531f008dad1664f458adf", size = 8142717, upload-time = "2025-12-10T22:55:41.103Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/76/934db220026b5fef85f45d51a738b91dea7d70207581063cd9bd8fafcf74/matplotlib-3.10.8-cp312-cp312-win_arm64.whl", hash = "sha256:3c624e43ed56313651bc18a47f838b60d7b8032ed348911c54906b130b20071b", size = 8012751, upload-time = "2025-12-10T22:55:42.684Z" },
 ]
 
 [[package]]
@@ -851,6 +1034,44 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573, upload-time = "2026-03-29T13:18:52.629Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782, upload-time = "2026-03-29T13:18:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038, upload-time = "2026-03-29T13:18:57.769Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666, upload-time = "2026-03-29T13:19:00.341Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480, upload-time = "2026-03-29T13:19:03.63Z" },
+    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036, upload-time = "2026-03-29T13:19:07.428Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643, upload-time = "2026-03-29T13:19:10.775Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117, upload-time = "2026-03-29T13:19:13.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584, upload-time = "2026-03-29T13:19:16.155Z" },
+    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450, upload-time = "2026-03-29T13:19:18.994Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/15/52580c8fbc16d0675d516e8749806eda679b16de1e4434ea06fb6feaa610/openai-2.30.0.tar.gz", hash = "sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885", size = 676084, upload-time = "2026-03-25T22:08:59.96Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/9e/5bfa2270f902d5b92ab7d41ce0475b8630572e71e349b2a4996d14bdda93/openai-2.30.0-py3-none-any.whl", hash = "sha256:9a5ae616888eb2748ec5e0c5b955a51592e0b201a11f4262db920f2a78c5231d", size = 1146656, upload-time = "2026-03-25T22:08:58.2Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -884,6 +1105,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/db/db/d4102f356af18f316c67f2cead8ece307f731dd63140e2c71f170ddacf9b/pika-1.3.2.tar.gz", hash = "sha256:b2a327ddddf8570b4965b3576ac77091b850262d34ce8c1d8cb4e4146aa4145f", size = 145029, upload-time = "2023-05-05T14:25:43.368Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/f3/f412836ec714d36f0f4ab581b84c491e3f42c6b5b97a6c6ed1817f3c16d0/pika-1.3.2-py3-none-any.whl", hash = "sha256:0779a7c1fafd805672796085560d290213a465e4f6f76a6fb19e378d8041a14f", size = 155415, upload-time = "2023-05-05T14:25:41.484Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
 ]
 
 [[package]]
@@ -1021,6 +1261,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1e/6c/9e370934bfa30e889d12e61d0dae009991294f40055c238980066a7fbd83/pymdown_extensions-10.20.1.tar.gz", hash = "sha256:e7e39c865727338d434b55f1dd8da51febcffcaebd6e1a0b9c836243f660740a", size = 852860, upload-time = "2026-01-24T05:56:56.758Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/6d/b6ee155462a0156b94312bdd82d2b92ea56e909740045a87ccb98bf52405/pymdown_extensions-10.20.1-py3-none-any.whl", hash = "sha256:24af7feacbca56504b313b7b418c4f5e1317bb5fea60f03d57be7fcc40912aa0", size = 268768, upload-time = "2026-01-24T05:56:54.537Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
@@ -1167,6 +1416,18 @@ wheels = [
 ]
 
 [[package]]
+name = "smart-open"
+version = "7.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/33/7a00ac9b4a63afb4279b99a766f6cbe56c443526dcbf5db97b219e21fde9/smart_open-7.6.0.tar.gz", hash = "sha256:44717f46b5ff276fac03b88e5d13d1c416f064f3b7b081381b0fa8889004bd7e", size = 54548, upload-time = "2026-04-13T09:48:04.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/bc/2761410d0541e975f384bc89f062d716bf119499dd097eb1af33dcd3b1c0/smart_open-7.6.0-py3-none-any.whl", hash = "sha256:2a78f454610a826aa688065b54b4a0a9b12a5599fa61d5190e9bac2df5e5f53f", size = 64591, upload-time = "2026-04-13T09:48:02.687Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1203,18 +1464,42 @@ wheels = [
 ]
 
 [[package]]
-name = "typer"
-version = "0.12.5"
+name = "tifffile"
+version = "2026.4.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/4a/e687f5957fead200faad58dbf9c9431a2bbb118040e96f5fb8a55f7ebc50/tifffile-2026.4.11.tar.gz", hash = "sha256:17758ff0c0d4db385792a083ad3ca51fcb0f4d942642f4d8f8bc1287fdcf17bc", size = 394956, upload-time = "2026-04-12T01:57:28.793Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/9f/74f110b4271ded519c7add4341cbabc824de26817ff1c345b3109df9e99c/tifffile-2026.4.11-py3-none-any.whl", hash = "sha256:9b94ffeddb39e97601af646345e8808f885773de01b299e480ed6d3a41509ec9", size = 248227, upload-time = "2026-04-12T01:57:26.969Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
     { name = "click" },
     { name = "rich" },
     { name = "shellingham" },
-    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/58/a79003b91ac2c6890fc5d90145c662fd5771c6f11447f116b63300436bc9/typer-0.12.5.tar.gz", hash = "sha256:f592f089bedcc8ec1b974125d64851029c3b1af145f04aca64d69410f0c9b722", size = 98953, upload-time = "2024-08-24T21:17:57.346Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/2b/886d13e742e514f704c33c4caa7df0f3b89e5a25ef8db02aa9ca3d9535d5/typer-0.12.5-py3-none-any.whl", hash = "sha256:62fe4e471711b147e3365034133904df3e235698399bc4de2b36c8579298d52b", size = 47288, upload-time = "2024-08-24T21:17:55.451Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
 ]
 
 [[package]]
@@ -1317,4 +1602,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/99/ab1cdb282f7e595391226f03f9b498f52109d25a2ba03832e21614967dfa/websockets-13.1-cp312-cp312-win32.whl", hash = "sha256:2f85cf4f2a1ba8f602298a853cec8526c2ca42a9a4b947ec236eaedb8f2dc80c", size = 158712, upload-time = "2024-09-21T17:33:07.877Z" },
     { url = "https://files.pythonhosted.org/packages/46/93/e19160db48b5581feac8468330aa11b7292880a94a37d7030478596cc14e/websockets-13.1-cp312-cp312-win_amd64.whl", hash = "sha256:38377f8b0cdeee97c552d20cf1865695fcd56aba155ad1b4ca8779a5b6ef4ac3", size = 159145, upload-time = "2024-09-21T17:33:09.202Z" },
     { url = "https://files.pythonhosted.org/packages/56/27/96a5cd2626d11c8280656c6c71d8ab50fe006490ef9971ccd154e0c42cd2/websockets-13.1-py3-none-any.whl", hash = "sha256:a9a396a6ad26130cdae92ae10c36af09d9bfe6cafe69670fd3b6da9b07b4044f", size = 152134, upload-time = "2024-09-21T17:34:19.904Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255, upload-time = "2026-03-06T02:52:45.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848, upload-time = "2026-03-06T02:53:48.728Z" },
+    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433, upload-time = "2026-03-06T02:54:40.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013, upload-time = "2026-03-06T02:53:26.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326, upload-time = "2026-03-06T02:53:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444, upload-time = "2026-03-06T02:54:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237, upload-time = "2026-03-06T02:54:03.884Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563, upload-time = "2026-03-06T02:53:20.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198, upload-time = "2026-03-06T02:53:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441, upload-time = "2026-03-06T02:52:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836, upload-time = "2026-03-06T02:53:22.053Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]


### PR DESCRIPTION
Hi @bcote-anl , this should be in a decent spot for review.  I think there are some opportunities to refactor going forward, but my goal with this PR is to add a minimum viable SAM3 functionality for demos without perturbing the existing code or architecture too much.  

Then I would like to follow this with some PRs that help organize things better for future iterations of the service.  That being said, let me know if there's anything glaring here that you want to see addressed before it's merged.  

For example, I added methods like `submit_task_async` to the `GlobusComputeExecutor` which are specialized to that subclass.  It doesn't break the `BaseEndpoint` contract and it's only used by SAM3, which is implicitly hardcoded to be backed by a single cluster/endpoint for now.  Still, it is something I believe can be streamlined later on!