### PR TITLE
LCF-63: Automate Format and Lint Checks

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -38,7 +38,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --locked --all-extras --dev
+        run: uv sync --locked --all-extras --all-groups
 
       - name: Build MkDocs site
         run: uv run -- mkdocs build

--- a/.github/workflows/django_tests.yml
+++ b/.github/workflows/django_tests.yml
@@ -73,9 +73,15 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Check Python syntax
-        run: |
-          uvx ruff check --select F821 --ignore F821 --target-version py312 .
+      - name: Lint
+        run: make lint
+
+      # To add in the future:
+      # -  name: Type check
+      #    run: make typecheck
+
+      -  name: Format Check
+         run: make format-check
 
       - name: Setup Django environment
         working-directory: ${{ env.WORKING_DIRECTORY }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: local
+    hooks:
+      - id: ruff-import-sort
+        name: ruff import sort
+        entry: uv run ruff check --select I --fix .
+        language: system
+        types: [python]
+        pass_filenames: false
+
+      - id: ruff-format
+        name: ruff format
+        entry: uv run ruff format .
+        language: system
+        types: [python]
+        pass_filenames: false
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+sync:
+	uv sync --all-groups
+
+typecheck: sync
+	uv run pyright
+
+format: sync
+	uv run ruff check --select I --fix .
+	uv run ruff format .
+
+format-check: sync
+	uv run ruff check --select I .
+	uv run ruff format --check .
+
+lint: sync
+	uv run ruff check .
+
+lint-fix: sync
+	uv run ruff check --fix .

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,6 @@ lint: sync
 
 lint-fix: sync
 	uv run ruff check --fix .
+
+install-dev: sync
+	pre-commit install

--- a/alcf_ai/src/alcf_ai/resources/sam3.py
+++ b/alcf_ai/src/alcf_ai/resources/sam3.py
@@ -1,6 +1,6 @@
 import base64
-import logging
 import gzip
+import logging
 import time
 from io import BytesIO
 from pathlib import Path

--- a/alcf_ai/src/alcf_ai/sam3.py
+++ b/alcf_ai/src/alcf_ai/sam3.py
@@ -13,10 +13,11 @@ import numpy.typing as npt
 import requests
 import smart_open
 import typer
-from PIL.Image import Image, fromarray, open as imopen
+from PIL.Image import Image, fromarray
+from PIL.Image import open as imopen
 
-from .resources.sam3 import Sam3ImageResult
 from .auth import STAGING_COLLECTION_ROOT
+from .resources.sam3 import Sam3ImageResult
 
 NDArray = npt.NDArray[Any]
 
@@ -110,8 +111,8 @@ def plot_bbox(
     text=None,
     ax=None,
 ):
-    import matplotlib.pyplot as plt
     import matplotlib.patches as patches
+    import matplotlib.pyplot as plt
 
     if box_format == "XYXY":
         x, y, x2, y2 = box
@@ -179,8 +180,8 @@ def to_pil(arr: NDArray) -> Image:
 
 
 def preview_sam3_result(arr: NDArray, result: Sam3ImageResult, path: Path):
-    from matplotlib.colors import to_rgb
     import matplotlib.pyplot as plt
+    from matplotlib.colors import to_rgb
 
     plt.figure(figsize=(12, 8))
 

--- a/alcf_ai/src/alcf_ai/sam3.py
+++ b/alcf_ai/src/alcf_ai/sam3.py
@@ -10,7 +10,6 @@ from typing import Any
 
 import numpy as np
 import numpy.typing as npt
-import requests
 import smart_open
 import typer
 from PIL.Image import Image, fromarray

--- a/alcf_ai/src/alcf_ai/transfer.py
+++ b/alcf_ai/src/alcf_ai/transfer.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from datetime import datetime
-from enum import Enum
 
 import globus_sdk
 

--- a/compute-functions/genslm_esm_inference_function.py
+++ b/compute-functions/genslm_esm_inference_function.py
@@ -3,25 +3,18 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import Any
-from typing import cast
+from typing import Any, cast
 
 import numpy as np
 import torch
-from genslm_esm.data import FastaDataset
-from genslm_esm.data import GenslmEsmcDataCollator
-from genslm_esm.modeling import GenslmEsmcModel
-from genslm_esm.modeling import GenslmEsmcModelOutput
-from parsl_object_registry import clear_torch_cuda_memory_callback
-from parsl_object_registry import register
-from pydantic import Field
-from pydantic import SecretStr
-from pydantic_settings import BaseSettings
-from pydantic_settings import SettingsConfigDict
+from genslm_esm.data import FastaDataset, GenslmEsmcDataCollator
+from genslm_esm.modeling import GenslmEsmcModel, GenslmEsmcModelOutput
+from parsl_object_registry import clear_torch_cuda_memory_callback, register
+from pydantic import Field, SecretStr
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from torch.utils.data import DataLoader
 from tqdm import tqdm
-from transformers import AutoModel
-from transformers import AutoTokenizer
+from transformers import AutoModel, AutoTokenizer
 
 
 ########################################################

--- a/compute-functions/genslm_esm_inference_function.py
+++ b/compute-functions/genslm_esm_inference_function.py
@@ -319,7 +319,6 @@ def embeddings_gc_fn(parameters: dict[str, Any]) -> str:
     """
     import json
     import time
-    from typing import Any
 
     # Explicit imports for globus compute
     from genslm_esm_globus_compute.globus_compute_fn import compute_embeddings

--- a/compute-functions/qstat_register_function.py
+++ b/compute-functions/qstat_register_function.py
@@ -2,9 +2,9 @@ import globus_compute_sdk
 
 
 def qstat_inference_function():
+    import json
     import os
     import re
-    import json
     import subprocess
 
     def run_command(cmd):

--- a/compute-functions/vllm_batch_function.py
+++ b/compute-functions/vllm_batch_function.py
@@ -1,16 +1,17 @@
-import globus_compute_sdk
 import json
+
+import globus_compute_sdk
 
 
 def chunked_vllm_inference_function(parameters):
+    import json
     import os
-    import subprocess
-    import uuid
-    import time
     import re
     import signal
+    import subprocess
     import sys
-    import json
+    import time
+    import uuid
     from datetime import datetime
 
     # ---------------------------

--- a/compute-functions/vllm_batch_function.py
+++ b/compute-functions/vllm_batch_function.py
@@ -4,7 +4,6 @@ import globus_compute_sdk
 
 
 def chunked_vllm_inference_function(parameters):
-    import json
     import os
     import re
     import signal
@@ -107,7 +106,6 @@ def chunked_vllm_inference_function(parameters):
         "/lus/eagle/projects/argonne_tpc/inference-service-batch-results/",
     )
     chunk_size = model_params.get("chunk_size", 20000)
-    username = parameters.get("username", "anonymous")
     batch_id = parameters.get("batch_id", f"batch_{uuid.uuid4().hex[:6]}")
 
     if not (model_name and input_file):

--- a/compute-functions/vllm_register_function_with_streaming.py
+++ b/compute-functions/vllm_register_function_with_streaming.py
@@ -8,7 +8,6 @@ def vllm_inference_function(parameters):
     import socket
     import time
 
-    import requests
     from requests.exceptions import RequestException
 
     # Constants
@@ -148,7 +147,7 @@ def vllm_inference_function(parameters):
             use_fresh_session=True,
         )
         if success:
-            print(f"[STREAMING] Done signal sent successfully")
+            print("[STREAMING] Done signal sent successfully")
             return True
         return False
 
@@ -302,7 +301,7 @@ def vllm_inference_function(parameters):
                                 chunks_sent += len(batch_buffer)
                             else:
                                 failed_sends += len(batch_buffer)
-                                print(f"[STREAMING] Failed to send final batch")
+                                print("[STREAMING] Failed to send final batch")
 
                         # Send completion to streaming server
                         done_success = send_done_to_streaming_server(
@@ -315,7 +314,7 @@ def vllm_inference_function(parameters):
 
                         if not done_success:
                             print(
-                                f"[STREAMING] WARNING: Done signal failed, but continuing..."
+                                "[STREAMING] WARNING: Done signal failed, but continuing..."
                             )
 
                         break

--- a/compute-functions/vllm_register_function_with_streaming.py
+++ b/compute-functions/vllm_register_function_with_streaming.py
@@ -3,11 +3,12 @@ import requests
 
 
 def vllm_inference_function(parameters):
-    import socket
-    import os
-    import time
-    import requests
     import json
+    import os
+    import socket
+    import time
+
+    import requests
     from requests.exceptions import RequestException
 
     # Constants

--- a/cron_jobs/check_application_health.py
+++ b/cron_jobs/check_application_health.py
@@ -12,17 +12,18 @@ This script checks the health of the Inference Gateway application by:
 Designed to run as a cron job every 5 minutes.
 """
 
-import os
-import sys
 import json
 import logging
-import subprocess
-import requests
+import os
 import smtplib
-from email.mime.text import MIMEText
-from email.mime.multipart import MIMEMultipart
-from urllib.parse import urljoin
+import subprocess
+import sys
 from datetime import datetime
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from urllib.parse import urljoin
+
+import requests
 
 # Add parent directory to path to import Django modules
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -36,8 +37,9 @@ django.setup()
 from django.conf import settings
 from django.core.cache import cache
 from django.db import connection
-from resource_server.models import Endpoint
+
 import utils.globus_utils as globus_utils
+from resource_server.models import Endpoint
 
 # Setup logging
 logging.basicConfig(

--- a/cron_jobs/check_application_health.py
+++ b/cron_jobs/check_application_health.py
@@ -19,9 +19,7 @@ import smtplib
 import subprocess
 import sys
 from datetime import datetime
-from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from urllib.parse import urljoin
 
 import requests
 
@@ -34,7 +32,6 @@ import django
 
 django.setup()
 
-from django.conf import settings
 from django.core.cache import cache
 from django.db import connection
 
@@ -284,7 +281,7 @@ class ApplicationHealthChecker:
                 log.info(f"Authenticating as {self.smtp_user}...")
                 server.login(self.smtp_user, self.smtp_password)
 
-            log.info(f"Sending email...")
+            log.info("Sending email...")
             server.sendmail(self.alert_email_from, self.alert_email_to, msg.as_string())
             server.quit()
 
@@ -305,7 +302,7 @@ class ApplicationHealthChecker:
             log.info(f"Writing email content to {email_file}")
             with open(email_file, "w") as f:
                 f.write(email_content)
-            log.info(f"✓ Email content written successfully")
+            log.info("✓ Email content written successfully")
 
             # Send email using sendmail
             recipients = " ".join(self.alert_email_to)
@@ -326,7 +323,7 @@ class ApplicationHealthChecker:
                 log.info(
                     f"✓ Alert email queued successfully via sendmail to {recipients}"
                 )
-                log.info(f"⚠️  NOTE: Check mail queue with 'mailq' to verify delivery")
+                log.info("⚠️  NOTE: Check mail queue with 'mailq' to verify delivery")
                 return True
             else:
                 log.error(
@@ -351,7 +348,7 @@ class ApplicationHealthChecker:
             log.info("All application components are healthy. No alert email needed.")
             return
 
-        log.warning(f"⚠️  APPLICATION UNHEALTHY - Attempting to send alert email")
+        log.warning("⚠️  APPLICATION UNHEALTHY - Attempting to send alert email")
 
         if not self.alert_email_to or not any(self.alert_email_to):
             log.error(

--- a/cron_jobs/check_maintenances.py
+++ b/cron_jobs/check_maintenances.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-from enum import Enum
 
 import django
 import requests

--- a/cron_jobs/check_maintenances.py
+++ b/cron_jobs/check_maintenances.py
@@ -2,9 +2,10 @@
 
 import os
 import sys
+from enum import Enum
+
 import django
 import requests
-from enum import Enum
 
 # Setup Django environment to access cache
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -12,7 +13,6 @@ sys.path.insert(0, BASE_DIR)
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "inference_gateway.settings")
 django.setup()
 from django.core.cache import cache
-
 
 # ===================
 # ALCF cluster status

--- a/cron_jobs/direct_health_monitor.py
+++ b/cron_jobs/direct_health_monitor.py
@@ -32,13 +32,12 @@ from argparse import ArgumentParser
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Dict, Iterable, List, Optional, Tuple
-from django.utils.text import slugify
 
 import httpx
 import requests
 from asgiref.sync import sync_to_async
+from django.utils.text import slugify
 from dotenv import load_dotenv
-
 
 # ---------------------------------------------------------------------------
 # Django setup
@@ -61,13 +60,17 @@ django.setup()
 # ---------------------------------------------------------------------------
 from django.conf import settings  # noqa: E402
 
-from resource_server_async.models import Endpoint  # noqa: E402
-from resource_server_async.models import User
-from resource_server_async.utils import get_cluster_wrapper, ClusterWrapperResponse  # noqa: E402
-from resource_server_async.clusters.cluster import GetJobsResponse, Jobs  # noqa: E402
-from utils import globus_utils, metis_utils  # noqa: E402
 from cron_jobs.check_application_health import ApplicationHealthChecker  # noqa: E402
-
+from resource_server_async.clusters.cluster import GetJobsResponse, Jobs  # noqa: E402
+from resource_server_async.models import (
+    Endpoint,  # noqa: E402
+    User,
+)
+from resource_server_async.utils import (  # noqa: E402
+    ClusterWrapperResponse,
+    get_cluster_wrapper,
+)
+from utils import globus_utils, metis_utils  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Logging

--- a/cron_jobs/direct_health_monitor.py
+++ b/cron_jobs/direct_health_monitor.py
@@ -58,10 +58,9 @@ django.setup()
 # ---------------------------------------------------------------------------
 # Imports that require Django to be configured
 # ---------------------------------------------------------------------------
-from django.conf import settings  # noqa: E402
 
 from cron_jobs.check_application_health import ApplicationHealthChecker  # noqa: E402
-from resource_server_async.clusters.cluster import GetJobsResponse, Jobs  # noqa: E402
+from resource_server_async.clusters.cluster import GetJobsResponse  # noqa: E402
 from resource_server_async.models import (
     Endpoint,  # noqa: E402
     User,
@@ -367,13 +366,6 @@ async def check_sophia_models() -> List[HealthRecord]:
             last_result = last_result_raw
 
         last_status = (last_result or {}).get("status")
-        last_health_elapsed = None
-        try:
-            last_health_elapsed = float((last_result or {}).get("elapsed", 0))
-        except (TypeError, ValueError):
-            last_health_elapsed = None
-
-        last_status_time = details.get("timestamp_last_result")
 
         if endpoint_state != "online":
             records.append(
@@ -568,9 +560,7 @@ async def check_metis_models() -> List[HealthRecord]:
 
     for model_entry in models:
         model_name = model_entry["model"]
-        endpoint_id = model_entry["endpoint_id"]
         model_info = model_entry["model_info"]
-        health_path = model_entry["health_path"]
 
         api_url = model_info.get("url")
         if not api_url:

--- a/cron_jobs/get_endpoint_status.py
+++ b/cron_jobs/get_endpoint_status.py
@@ -1,8 +1,9 @@
 import os
 import re
 import time
-import globus_sdk
+
 import globus_compute_sdk
+import globus_sdk
 from dotenv import load_dotenv
 
 load_dotenv(override=True)

--- a/dashboard_async/globus_auth.py
+++ b/dashboard_async/globus_auth.py
@@ -2,12 +2,13 @@
 Globus OAuth2 authentication utilities for dashboard.
 """
 
-import globus_sdk
-from django.conf import settings
-from django.contrib.auth import get_user_model
-from cachetools import TTLCache, cached
 import hashlib
 import logging
+
+import globus_sdk
+from cachetools import TTLCache, cached
+from django.conf import settings
+from django.contrib.auth import get_user_model
 
 log = logging.getLogger(__name__)
 
@@ -278,7 +279,7 @@ def check_group_membership(groups_token, user_id, group_id):
 
     # Cache miss - check with Globus API
     try:
-        from globus_sdk import GroupsClient, AccessTokenAuthorizer
+        from globus_sdk import AccessTokenAuthorizer, GroupsClient
 
         authorizer = AccessTokenAuthorizer(groups_token)
         groups_client = GroupsClient(authorizer=authorizer)

--- a/dashboard_async/globus_auth.py
+++ b/dashboard_async/globus_auth.py
@@ -114,7 +114,7 @@ def validate_dashboard_token(access_token, groups_token=None):
     try:
         cached_result = cache.get(cache_key)
         if cached_result is not None:
-            log.debug(f"Using cached token validation result")
+            log.debug("Using cached token validation result")
             return cached_result
     except Exception as e:
         log.warning(f"Redis cache error for dashboard token validation: {e}")
@@ -328,7 +328,7 @@ def refresh_access_token(refresh_token):
     new_access_token = authorizer.get_authorization_header()
 
     # Get new token info
-    token_response = authorizer.check_expiration_time()
+    authorizer.check_expiration_time()
 
     return {
         "access_token": new_access_token.split(" ")[1],  # Remove 'Bearer ' prefix

--- a/dashboard_async/urls.py
+++ b/dashboard_async/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
+
 from dashboard_async.views import (
-    api,
     analytics_realtime_view,
-    dashboard_login_view,
+    api,
     dashboard_callback_view,
+    dashboard_login_view,
     dashboard_logout_view,
 )
 

--- a/dashboard_async/views.py
+++ b/dashboard_async/views.py
@@ -1,31 +1,41 @@
+import json
+import logging
+import re
 from datetime import timedelta
-from django.db.models import Count, Avg, F, Q, Subquery, OuterRef, Value, CharField
-from django.db.models.functions import TruncWeek, TruncDay
-from django.utils.timezone import now
+
+from django.contrib import messages
+from django.contrib.auth import views as auth_views
+from django.contrib.auth.decorators import login_required
+from django.contrib.auth.forms import AuthenticationForm, PasswordChangeForm
+from django.core.cache import cache
+from django.db.models import Avg, CharField, Count, F, OuterRef, Q, Subquery, Value
+from django.db.models.functions import TruncDay, TruncWeek
+from django.http import HttpRequest, JsonResponse
+from django.shortcuts import redirect, render
+from django.urls import reverse_lazy
 from django.utils import timezone
+from django.utils.timezone import now
 from django.utils.translation.trans_real import accept_language_re
 from ninja import NinjaAPI, Router
 from ninja.security import SessionAuth
-from django.http import JsonResponse, HttpRequest
-from django.core.cache import cache
-from django.contrib.auth.decorators import login_required
-from django.contrib.auth import views as auth_views
-from django.contrib.auth.forms import AuthenticationForm, PasswordChangeForm
-from django.shortcuts import render, redirect
-from django.contrib import messages
-from django.urls import reverse_lazy
-import json
-from resource_server.models import Endpoint, Log, Batch
+
+import utils.metis_utils as metis_utils
+from resource_server.models import Batch, Endpoint, Log
 from resource_server_async.models import (
-    User as AsyncUser,
     AccessLog as AsyncAccessLog,
-    RequestLog as AsyncRequestLog,
+)
+from resource_server_async.models import (
     BatchLog as AsyncBatchLog,
+)
+from resource_server_async.models import (
     Endpoint as AsyncEndpoint,
 )
-import re
-import logging
-import utils.metis_utils as metis_utils
+from resource_server_async.models import (
+    RequestLog as AsyncRequestLog,
+)
+from resource_server_async.models import (
+    User as AsyncUser,
+)
 
 log = logging.getLogger(__name__)
 
@@ -35,8 +45,9 @@ class DjangoSessionAuth(SessionAuth):
     """Use Globus session authentication for API endpoints."""
 
     def authenticate(self, request: HttpRequest, key):
-        from dashboard_async.globus_auth import validate_dashboard_token
         import time
+
+        from dashboard_async.globus_auth import validate_dashboard_token
 
         # Check for Globus tokens in session
         if "globus_tokens" not in request.session:
@@ -217,9 +228,11 @@ def dashboard_callback_view(request):
 
 def dashboard_logout_view(request):
     """Logout and clear both local and Globus sessions."""
-    from dashboard_async.globus_auth import revoke_token
-    from django.conf import settings
     from urllib.parse import urlencode
+
+    from django.conf import settings
+
+    from dashboard_async.globus_auth import revoke_token
 
     # Revoke Globus tokens if present
     if "globus_tokens" in request.session:
@@ -256,12 +269,13 @@ def globus_login_required(view_func):
     Decorator to require Globus authentication for dashboard views.
     Validates Globus token from session and refreshes if needed.
     """
-    from functools import wraps
-    from dashboard_async.globus_auth import (
-        validate_dashboard_token,
-        refresh_access_token,
-    )
     import time
+    from functools import wraps
+
+    from dashboard_async.globus_auth import (
+        refresh_access_token,
+        validate_dashboard_token,
+    )
 
     @wraps(view_func)
     def wrapped_view(request, *args, **kwargs):
@@ -1011,11 +1025,12 @@ def get_health_status(request, cluster: str = "sophia", refresh: int = 0):
     """
     try:
         from asgiref.sync import async_to_sync
-        from resource_server_async.utils import (
-            get_cluster_wrapper,
-            ClusterWrapperResponse,
-        )
+
         from resource_server_async.clusters.cluster import GetJobsResponse, Jobs
+        from resource_server_async.utils import (
+            ClusterWrapperResponse,
+            get_cluster_wrapper,
+        )
 
         # Try cache first unless refresh requested
         cache_key = f"dashboard_health:{cluster}"
@@ -1337,8 +1352,9 @@ def get_batch_logs_rt(request, page: int = 0, per_page: int = 100):
 def query_logs_custom(request):
     """Custom log query builder with flexible filters."""
     try:
-        from django.db import connection
         import re as regex_module
+
+        from django.db import connection
 
         # Parse query parameters
         rows = int(request.GET.get("rows", 10))

--- a/dashboard_async/views.py
+++ b/dashboard_async/views.py
@@ -1,26 +1,14 @@
-import json
 import logging
-import re
 from datetime import timedelta
 
 from django.contrib import messages
-from django.contrib.auth import views as auth_views
-from django.contrib.auth.decorators import login_required
-from django.contrib.auth.forms import AuthenticationForm, PasswordChangeForm
 from django.core.cache import cache
-from django.db.models import Avg, CharField, Count, F, OuterRef, Q, Subquery, Value
-from django.db.models.functions import TruncDay, TruncWeek
 from django.http import HttpRequest, JsonResponse
 from django.shortcuts import redirect, render
-from django.urls import reverse_lazy
 from django.utils import timezone
-from django.utils.timezone import now
-from django.utils.translation.trans_real import accept_language_re
 from ninja import NinjaAPI, Router
 from ninja.security import SessionAuth
 
-import utils.metis_utils as metis_utils
-from resource_server.models import Batch, Endpoint, Log
 from resource_server_async.models import (
     AccessLog as AsyncAccessLog,
 )
@@ -29,9 +17,6 @@ from resource_server_async.models import (
 )
 from resource_server_async.models import (
     Endpoint as AsyncEndpoint,
-)
-from resource_server_async.models import (
-    RequestLog as AsyncRequestLog,
 )
 from resource_server_async.models import (
     User as AsyncUser,
@@ -164,7 +149,7 @@ def dashboard_callback_view(request):
     saved_state = request.session.get("oauth_state")
 
     if not state or state != saved_state:
-        log.warning(f"CSRF state mismatch")
+        log.warning("CSRF state mismatch")
         messages.error(request, "Invalid authentication state. Please try again.")
         request.session.pop("oauth_state", None)
         return render(request, "login.html", {"form": None})
@@ -229,8 +214,6 @@ def dashboard_callback_view(request):
 def dashboard_logout_view(request):
     """Logout and clear both local and Globus sessions."""
     from urllib.parse import urlencode
-
-    from django.conf import settings
 
     from dashboard_async.globus_auth import revoke_token
 
@@ -363,13 +346,6 @@ def get_realtime_metrics(request, cluster: str = "all"):
             return cached
 
         from django.db import connection
-
-        # Build cluster filter condition
-        cluster_filter = ""
-        cluster_params = []
-        if cluster and cluster.lower() != "all":
-            cluster_filter = "AND rl.cluster = %s"
-            cluster_params = [cluster.lower()]
 
         # Refined breakdown of requests using HTTP status codes:
         # - Successful: status_code 200-299 or 0 (all successful requests)
@@ -858,7 +834,7 @@ def get_overall_series(request, window: str = "24h", cluster: str = "all"):
                 )
             else:
                 cursor.execute(
-                    f"""
+                    """
                     WITH series AS (
                       SELECT generate_series(
                         date_trunc(%s, %s::timestamptz),
@@ -921,7 +897,7 @@ def get_model_series(request, model: str, window: str = "24h"):
         )
         with connection.cursor() as cursor:
             cursor.execute(
-                f"""
+                """
                 WITH series AS (
                   SELECT generate_series(
                     date_trunc(%s, %s::timestamptz),
@@ -1352,8 +1328,6 @@ def get_batch_logs_rt(request, page: int = 0, per_page: int = 100):
 def query_logs_custom(request):
     """Custom log query builder with flexible filters."""
     try:
-        import re as regex_module
-
         from django.db import connection
 
         # Parse query parameters

--- a/examples/load-testing/benchmark_analysis.py
+++ b/examples/load-testing/benchmark_analysis.py
@@ -1,15 +1,9 @@
-import json
-import os
-
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
 from matplotlib.ticker import (
-    FuncFormatter,
     LogFormatterMathtext,
-    LogLocator,
-    ScalarFormatter,
 )
 
 # ==============================================================================

--- a/examples/load-testing/benchmark_analysis.py
+++ b/examples/load-testing/benchmark_analysis.py
@@ -1,15 +1,16 @@
 import json
-import pandas as pd
+import os
+
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 import seaborn as sns
 from matplotlib.ticker import (
     FuncFormatter,
+    LogFormatterMathtext,
     LogLocator,
     ScalarFormatter,
-    LogFormatterMathtext,
 )
-import os
 
 # ==============================================================================
 # Configuration Constants

--- a/examples/load-testing/plot_monthly_usage.py
+++ b/examples/load-testing/plot_monthly_usage.py
@@ -1,5 +1,3 @@
-import os
-
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
 import numpy as np

--- a/examples/load-testing/plot_monthly_usage.py
+++ b/examples/load-testing/plot_monthly_usage.py
@@ -1,9 +1,10 @@
-import pandas as pd
+import os
+
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
-import seaborn as sns
 import numpy as np
-import os
+import pandas as pd
+import seaborn as sns
 
 # --- Configuration ---
 INTERACTIVE_CSV = "monthly_requests.csv"

--- a/examples/load-testing/run_rate_comparison.py
+++ b/examples/load-testing/run_rate_comparison.py
@@ -1,21 +1,22 @@
-import asyncio
 import argparse
+import asyncio
 import csv
-import time
-import statistics
-import os
-import numpy as np
-import random
 import json
+import os
+import random
+import statistics
+import time
+
+import numpy as np
 
 # Import necessary functions and classes from benchmark_serving
 # Assuming benchmark_serving.py is in the same directory or accessible in PYTHONPATH
 from benchmark_serving import (
     benchmark,
-    get_tokenizer,
     get_dataset,
-    set_ulimit,
+    get_tokenizer,
     set_global_args,  # Import the function to set global args
+    set_ulimit,
 )
 
 # --- Configuration ---

--- a/gunicorn_asgi.config.py
+++ b/gunicorn_asgi.config.py
@@ -1,4 +1,3 @@
-import multiprocessing
 import os
 
 """gunicorn ASGI server configuration."""

--- a/gunicorn_asgi.config.py
+++ b/gunicorn_asgi.config.py
@@ -1,5 +1,5 @@
-import os
 import multiprocessing
+import os
 
 """gunicorn ASGI server configuration."""
 

--- a/inference_gateway/apps.py
+++ b/inference_gateway/apps.py
@@ -1,8 +1,8 @@
 import globus_sdk
-from ninja.constants import NOT_SET_TYPE
 from django.apps import AppConfig
-from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from ninja.constants import NOT_SET_TYPE
 
 
 class AuthCheckConfig(AppConfig):
@@ -56,7 +56,7 @@ class AuthCheckConfig(AppConfig):
             )
 
         # Make sure the auth check is enforced to all routes within the API
-        from resource_server_async.api import api, GlobalAuth
+        from resource_server_async.api import GlobalAuth, api
 
         if (
             not hasattr(api, "auth")

--- a/inference_gateway/settings.py
+++ b/inference_gateway/settings.py
@@ -10,10 +10,12 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 
-from pathlib import Path
 import json
 import os
+from pathlib import Path
+
 from dotenv import load_dotenv
+
 from inference_gateway.utils import textfield_to_strlist
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.

--- a/inference_gateway/urls.py
+++ b/inference_gateway/urls.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import include, path
 from drf_spectacular.views import (
     SpectacularAPIView,
     SpectacularRedocView,

--- a/inference_gateway/urls.py
+++ b/inference_gateway/urls.py
@@ -1,5 +1,3 @@
-from django.conf import settings
-from django.contrib import admin
 from django.urls import include, path
 from drf_spectacular.views import (
     SpectacularAPIView,

--- a/inference_gateway/utils.py
+++ b/inference_gateway/utils.py
@@ -1,5 +1,5 @@
-from typing import List
 import re
+from typing import List
 
 
 class BackendUtilsError(Exception):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,94 +9,50 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
 ]
+
+# Directly imported dependencies for production:
 dependencies = [
-    "annotated-types==0.7.0",
-    "asgiref==3.10.0",
-    "asyncache>=0.3.1,<0.4",
-    "attrs==25.4.0",
-    "babel==2.17.0",
-    "backrefs==6.0.1",
-    "cachetools>=5.5.2,<6",
-    "certifi==2025.10.5",
-    "cffi==2.0.0 ; platform_python_implementation != 'PyPy'",
-    "charset-normalizer==3.4.4",
-    "click",
-    "colorama==0.4.6",
-    "cryptography==46.0.3",
-    "csscompressor==0.9.5",
-    "dill==0.3.9",
-    "django-cors-headers>=4.9.0,<5",
-    "django-filter>=24.3,<25",
-    "django-ninja>=1.4.5,<2",
-    "django-redis>=6.0.0,<7",
-    "django>=5.2.9,<6",
+    "asgiref>=3.10",
+    "cachetools<6",
+    "django-cors-headers",
+    "django-filter",
+    "django-ninja",
+    "django-redis",
+    "django",
     "djangorestframework>=3.16.1,<4",
-    "drf-spectacular>=0.27.2,<0.28",
-    "exceptiongroup==1.3.0",
-    "ghp-import==2.1.0",
-    "globus-compute-common>=0.7.1,<0.8",
+    "drf-spectacular",
     "globus-compute-sdk>=3.16.1,<4",
     "globus-sdk>=3.65.0,<4",
-    "gunicorn>=23.0.0,<24",
-    "h11>=0.16.0,<0.17",
-    "hiredis>=3.3.0,<4",
-    "htmlmin2==0.1.13",
-    "httpx>=0.27.2,<0.28",
-    "idna==3.11",
-    "inflection==0.5.1",
-    "jinja2==3.1.6",
-    "jsmin==3.0.1",
-    "jsonschema-specifications==2025.9.1",
-    "jsonschema==4.25.1",
-    "markdown-it-py==4.0.0",
-    "markdown==3.10",
-    "markupsafe==3.0.3",
-    "mdurl==0.1.2",
-    "mergedeep==1.3.4",
-    "packaging==25.0",
-    "paginate==0.5.7",
-    "pathspec==0.12.1",
-    "pika==1.3.2",
-    "platformdirs==4.5.0",
-    "psutil==5.9.8",
+    "gunicorn",
+    "h11",
+    "httpx",
     "psycopg-pool>=3.2.7,<4",
     "psycopg>=3.2.12,<4",
-    "pycparser==2.23 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'",
-    "pydantic-core==2.41.5",
-    "pydantic==2.12.4",
-    "pygments==2.19.2",
-    "pyjwt==2.10.1",
-    "python-dateutil==2.9.0.post0",
-    "python-dotenv>=1.2.1,<2",
-    "pyyaml-env-tag==1.1",
-    "pyyaml==6.0.3",
-    "redis>=6.4.0,<7",
-    "referencing==0.37.0",
-    "requests>=2.32.5,<3",
-    "rich==14.2.0",
-    "rpds-py==0.28.0",
-    "shellingham==1.5.4",
-    "six==1.17.0",
-    "sqlparse==0.5.3",
-    "tblib==1.7.0",
-    "texttable==1.7.0",
-    "typer",
-    "typing-extensions==4.15.0",
-    "typing-inspection==0.4.2",
-    "tzdata==2025.2 ; sys_platform == 'win32'",
-    "uritemplate==4.2.0",
-    "urllib3>=2.6.3,<3",
-    "uvicorn>=0.30.6,<0.31",
-    "watchdog==6.0.0",
-    "websockets>=13.1,<14",
-    # Documentation dependencies
-    "mkdocs-get-deps==0.2.0",
-    "mkdocs-material-extensions==1.3.1",
+    "pydantic>=2.12",
+    "pydantic-settings",
+    "python-dotenv<2",
+    "redis<7",
+    "requests<3",
+    "uvicorn[standard]>=0.30.6",
+]
+
+[dependency-groups]
+
+# Dependencies for development/testing:
+dev = [
+    "pyright[nodejs]",
+    "ruff",
+    "alcf-ai",
+]
+
+# Documentation dependencies:
+docs = [
+    "mkdocs-get-deps",
+    "mkdocs-material-extensions",
     "mkdocs-material>=9.7.0,<10",
-    "mkdocs-minify-plugin>=0.8.0,<0.9",
+    "mkdocs-minify-plugin<0.9",
     "mkdocs>=1.5.0",
     "pymdown-extensions>=10.0",
-    "alcf-ai",
 ]
 
 [tool.uv.sources]
@@ -127,3 +83,36 @@ extend-exclude = [
     "resource_server/migrations/*",
     "resource_server_async/migrations/*"
 ]
+
+[tool.ruff.lint]
+select = ["F", "I"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["alcf_ai", "resource_server_async", "dashboard_async", "resource_server", "utils"]
+
+
+
+[tool.pyright]
+# https://microsoft.github.io/pyright/#/configuration
+include = ["alcf_ai", "compute-functions", "cron_jobs", "dashboard_async", "*.py", "inference_gateway", "resource_server", "resource_server_async", "utils"]
+exclude = [
+    "**/.*",
+    "**/__pycache__",
+    "**/.venv",
+    "**/node_modules",
+    "build",
+    "dist",
+    "utils/tests/test*.py"
+]
+
+pythonVersion = "3.12"
+
+typeCheckingMode = "strict"
+
+reportMissingImports = "error"
+reportMissingTypeStubs = "warning"
+
+reportUnusedImport = "error"
+reportUnusedVariable = "error"
+reportPrivateUsage = "warning"
+reportImplicitOverride = "error"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
     "pyright[nodejs]",
     "ruff",
     "alcf-ai",
+    "pre-commit>=4.5.1",
 ]
 
 # Documentation dependencies:

--- a/resource_server/admin.py
+++ b/resource_server/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
-
 # Register your models here.

--- a/resource_server/models.py
+++ b/resource_server/models.py
@@ -1,6 +1,5 @@
 import uuid
 
-from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.text import slugify
 from django.utils.timezone import now

--- a/resource_server/models.py
+++ b/resource_server/models.py
@@ -1,8 +1,9 @@
+import uuid
+
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.text import slugify
-import uuid
 from django.utils.timezone import now
-from django.core.exceptions import ValidationError
 
 
 # Details of a given Globus Compute endpoint

--- a/resource_server_async/admin.py
+++ b/resource_server_async/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
-
 # Register your models here.

--- a/resource_server_async/api.py
+++ b/resource_server_async/api.py
@@ -1,13 +1,15 @@
 import uuid
+
+from asgiref.sync import sync_to_async
 from django.conf import settings
-from django.utils import timezone
-from django.core.cache import cache
 from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.utils import timezone
 from ninja import NinjaAPI, Router
-from ninja.throttling import AnonRateThrottle, AuthRateThrottle
 from ninja.errors import HttpError
 from ninja.security import HttpBearer
-from asgiref.sync import sync_to_async
+from ninja.throttling import AnonRateThrottle, AuthRateThrottle
+
 from resource_server_async.models import User
 from resource_server_async.utils import create_access_log, is_cached
 from utils.auth_utils import validate_access_token

--- a/resource_server_async/api.py
+++ b/resource_server_async/api.py
@@ -3,7 +3,6 @@ import uuid
 from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.cache import cache
 from django.utils import timezone
 from ninja import NinjaAPI, Router
 from ninja.errors import HttpError

--- a/resource_server_async/apps.py
+++ b/resource_server_async/apps.py
@@ -1,7 +1,6 @@
 import logging
 
 from django.apps import AppConfig
-from django.core.cache import cache
 
 log = logging.getLogger(__name__)
 

--- a/resource_server_async/apps.py
+++ b/resource_server_async/apps.py
@@ -1,6 +1,7 @@
+import logging
+
 from django.apps import AppConfig
 from django.core.cache import cache
-import logging
 
 log = logging.getLogger(__name__)
 

--- a/resource_server_async/clusters/cluster.py
+++ b/resource_server_async/clusters/cluster.py
@@ -1,12 +1,14 @@
+import logging
+from abc import ABC, abstractmethod
+from typing import Dict, List, Optional
+
 from django.core.cache import cache
 from pydantic import BaseModel, Field
-from abc import ABC, abstractmethod
-from typing import List, Optional, Dict
-from resource_server_async.models import User
-from utils.auth_utils import check_permission as auth_utils_check_permission
-from utils.auth_utils import CheckPermissionResponse
+
 from inference_gateway.settings import MAINTENANCE_ERROR_NOTICES
-import logging
+from resource_server_async.models import User
+from utils.auth_utils import CheckPermissionResponse
+from utils.auth_utils import check_permission as auth_utils_check_permission
 
 log = logging.getLogger(__name__)
 

--- a/resource_server_async/clusters/globus_compute.py
+++ b/resource_server_async/clusters/globus_compute.py
@@ -1,15 +1,17 @@
-from resource_server_async.clusters.cluster import BaseCluster, GetJobsResponse, Jobs
-from resource_server_async.models import Endpoint, User
-from utils import globus_utils
-from pydantic import BaseModel
-from django.core.cache import cache
-from django.utils.text import slugify
-from asgiref.sync import sync_to_async
-from typing import List
 import json
 
 # Tool to log access requests
 import logging
+from typing import List
+
+from asgiref.sync import sync_to_async
+from django.core.cache import cache
+from django.utils.text import slugify
+from pydantic import BaseModel
+
+from resource_server_async.clusters.cluster import BaseCluster, GetJobsResponse, Jobs
+from resource_server_async.models import Endpoint, User
+from utils import globus_utils
 
 log = logging.getLogger(__name__)
 

--- a/resource_server_async/clusters/metis.py
+++ b/resource_server_async/clusters/metis.py
@@ -1,16 +1,17 @@
+# Tool to log access requests
+import logging
+from typing import Dict, List
+
+from django.core.cache import cache
+
 from resource_server_async.clusters.cluster import (
     BaseCluster,
     GetJobsResponse,
-    Jobs,
     JobInfo,
+    Jobs,
 )
 from resource_server_async.models import User
 from utils import metis_utils
-from typing import Dict, List
-from django.core.cache import cache
-
-# Tool to log access requests
-import logging
 
 log = logging.getLogger(__name__)
 

--- a/resource_server_async/endpoints/direct_api.py
+++ b/resource_server_async/endpoints/direct_api.py
@@ -1,22 +1,24 @@
 import asyncio
 import json
-import time
+import logging
 import os
+import time
+from typing import Any, Dict, List, Optional
+
 import httpx
 from asgiref.sync import sync_to_async
-from django.utils import timezone
 from django.http import StreamingHttpResponse
+from django.utils import timezone
 from pydantic import BaseModel, Field
-from typing import Any, Optional, Dict, List
-from resource_server_async.utils import create_streaming_response_headers
-from resource_server_async.models import RequestLog
+
 from resource_server_async.endpoints.endpoint import (
     BaseEndpoint,
     BaseModelWithError,
-    SubmitTaskResponse,
     SubmitStreamingTaskResponse,
+    SubmitTaskResponse,
 )
-import logging
+from resource_server_async.models import RequestLog
+from resource_server_async.utils import create_streaming_response_headers
 
 log = logging.getLogger(__name__)
 

--- a/resource_server_async/endpoints/direct_api.py
+++ b/resource_server_async/endpoints/direct_api.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 import time
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 import httpx
 from asgiref.sync import sync_to_async
@@ -13,7 +13,6 @@ from pydantic import BaseModel, Field
 
 from resource_server_async.endpoints.endpoint import (
     BaseEndpoint,
-    BaseModelWithError,
     SubmitStreamingTaskResponse,
     SubmitTaskResponse,
 )
@@ -153,7 +152,7 @@ class DirectAPIEndpoint(BaseEndpoint):
                 streaming_state["error"] = error_str
                 streaming_state["completed"] = True
                 error_chunk = {
-                    "id": f"chatcmpl-api-error",
+                    "id": "chatcmpl-api-error",
                     "object": "chat.completion.chunk",
                     "created": int(time.time()),
                     "model": self.model,

--- a/resource_server_async/endpoints/endpoint.py
+++ b/resource_server_async/endpoints/endpoint.py
@@ -1,12 +1,14 @@
 import uuid
-from pydantic import BaseModel, Field, ConfigDict
 from abc import ABC, abstractmethod
+from typing import Any, List, Optional
+
 from django.http import StreamingHttpResponse
-from typing import List, Optional, Any
-from resource_server_async.models import User, BatchLog
-from utils.pydantic_models.batch import BatchStatusEnum
-from utils.auth_utils import check_permission as auth_utils_check_permission
+from pydantic import BaseModel, ConfigDict, Field
+
+from resource_server_async.models import BatchLog, User
 from utils.auth_utils import CheckPermissionResponse
+from utils.auth_utils import check_permission as auth_utils_check_permission
+from utils.pydantic_models.batch import BatchStatusEnum
 
 
 class BaseModelWithError(BaseModel):

--- a/resource_server_async/endpoints/globus_compute.py
+++ b/resource_server_async/endpoints/globus_compute.py
@@ -567,7 +567,7 @@ class GlobusComputeEndpoint(BaseEndpoint):
         # Extract the Globus batch UUID from submission
         # Temporary: globus_batch_uuid not used
         try:
-            globus_batch_uuid = batch_response["request_id"]
+            _ = batch_response["request_id"]
         except Exception as e:
             return SubmitBatchResponse(
                 batch_id=batch_id,

--- a/resource_server_async/endpoints/globus_compute.py
+++ b/resource_server_async/endpoints/globus_compute.py
@@ -1,39 +1,41 @@
-import json
-import uuid
-import time
 import asyncio
-from utils import globus_utils
-from django.http import StreamingHttpResponse
+import json
+import logging
+import time
+import uuid
+from typing import Any, List, Optional
+
 from django.core.cache import cache
+from django.http import StreamingHttpResponse
+from globus_compute_sdk import Executor
+from globus_compute_sdk.errors import TaskPending
 from pydantic import BaseModel, Field
-from typing import Optional, Any, List
-from resource_server_async.utils import (
-    remove_endpoint_from_cache,
-    prepare_streaming_task_data,
-    process_streaming_completion_async,
-    extract_prompt,
-    set_streaming_status,
-    set_streaming_error,
-    get_streaming_metadata,
-    get_streaming_data_and_status_batch,
-    format_streaming_error_for_openai,
-    create_streaming_response_headers,
-    is_cached,
-)
+
 from resource_server_async.endpoints.endpoint import (
     BaseEndpoint,
     BaseModelWithError,
-    SubmitTaskResponse,
-    SubmitTaskAsyncResponse,
-    SubmitStreamingTaskResponse,
-    SubmitBatchResponse,
     GetBatchStatusResponse,
+    SubmitBatchResponse,
+    SubmitStreamingTaskResponse,
+    SubmitTaskAsyncResponse,
+    SubmitTaskResponse,
 )
 from resource_server_async.models import BatchLog
+from resource_server_async.utils import (
+    create_streaming_response_headers,
+    extract_prompt,
+    format_streaming_error_for_openai,
+    get_streaming_data_and_status_batch,
+    get_streaming_metadata,
+    is_cached,
+    prepare_streaming_task_data,
+    process_streaming_completion_async,
+    remove_endpoint_from_cache,
+    set_streaming_error,
+    set_streaming_status,
+)
+from utils import globus_utils
 from utils.pydantic_models.batch import BatchStatusEnum
-from globus_compute_sdk import Executor
-from globus_compute_sdk.errors import TaskPending
-import logging
 
 log = logging.getLogger(__name__)
 

--- a/resource_server_async/endpoints/metis.py
+++ b/resource_server_async/endpoints/metis.py
@@ -1,8 +1,7 @@
-import json
 import logging
 from typing import Any, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from resource_server_async.endpoints.direct_api import DirectAPIEndpoint
 from resource_server_async.endpoints.endpoint import (

--- a/resource_server_async/endpoints/metis.py
+++ b/resource_server_async/endpoints/metis.py
@@ -1,14 +1,16 @@
 import json
+import logging
+from typing import Any, List, Optional
+
 from pydantic import BaseModel, Field
-from typing import Any, Optional, List
+
+from resource_server_async.endpoints.direct_api import DirectAPIEndpoint
 from resource_server_async.endpoints.endpoint import (
     BaseModelWithError,
-    SubmitTaskResponse,
     SubmitStreamingTaskResponse,
+    SubmitTaskResponse,
 )
-from resource_server_async.endpoints.direct_api import DirectAPIEndpoint
 from utils.metis_utils import fetch_metis_status, find_metis_model
-import logging
 
 log = logging.getLogger(__name__)
 

--- a/resource_server_async/management/commands/clear_cache.py
+++ b/resource_server_async/management/commands/clear_cache.py
@@ -7,10 +7,11 @@ Usage:
     python manage.py clear_cache --pattern endpoint:*  # Clear specific pattern
 """
 
-from django.core.management.base import BaseCommand
-from django.core.cache import cache
-from django.conf import settings
 import logging
+
+from django.conf import settings
+from django.core.cache import cache
+from django.core.management.base import BaseCommand
 
 log = logging.getLogger(__name__)
 

--- a/resource_server_async/management/commands/migrate_legacy_logs.py
+++ b/resource_server_async/management/commands/migrate_legacy_logs.py
@@ -1,21 +1,21 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import uuid
 from typing import Iterable, List, Optional, Tuple
-import hashlib
 
 from django.core.management.base import BaseCommand, CommandParser
 from django.db import transaction
 from django.utils.timezone import now
 
-from resource_server.models import Log as LegacyLog
 from resource_server.models import Endpoint as LegacyEndpoint
+from resource_server.models import Log as LegacyLog
 from resource_server_async.models import (
-    User,
     AccessLog,
-    RequestLog,
     AuthService,
+    RequestLog,
+    User,
 )
 
 

--- a/resource_server_async/management/commands/query_model_status.py
+++ b/resource_server_async/management/commands/query_model_status.py
@@ -1,9 +1,10 @@
+from asgiref.sync import async_to_sync
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
+
 from resource_server.models import ModelStatus
 from resource_server_async.utils import get_qstat_details
 from utils.globus_utils import get_compute_client_from_globus_app, get_compute_executor
-from asgiref.sync import async_to_sync
-from django.conf import settings
 
 
 # Django management command

--- a/resource_server_async/management/commands/update_batch_status.py
+++ b/resource_server_async/management/commands/update_batch_status.py
@@ -34,5 +34,5 @@ class Command(BaseCommand):
                 print(
                     f"batch {batch.batch_id} updated from {batch_status_before} to {batch_status}."
                 )
-            except Exception as e:
+            except Exception:
                 pass

--- a/resource_server_async/management/commands/update_batch_status.py
+++ b/resource_server_async/management/commands/update_batch_status.py
@@ -1,7 +1,8 @@
+from asgiref.sync import async_to_sync
 from django.core.management.base import BaseCommand, CommandError
+
 from resource_server.models import Batch
 from resource_server_async.utils import update_batch_status_result
-from asgiref.sync import async_to_sync
 
 
 # Django management command

--- a/resource_server_async/models.py
+++ b/resource_server_async/models.py
@@ -1,8 +1,9 @@
 import uuid
-from django.db import models
-from django.utils.timezone import now
-from django.utils.text import slugify
+
 from django.core.exceptions import ValidationError
+from django.db import models
+from django.utils.text import slugify
+from django.utils.timezone import now
 
 
 # Supported authentication origins

--- a/resource_server_async/schemas/sam3.py
+++ b/resource_server_async/schemas/sam3.py
@@ -1,6 +1,7 @@
-from ninja import Schema
-from typing import Literal
 from pathlib import Path
+from typing import Literal
+
+from ninja import Schema
 
 
 class Sam3Request(Schema):

--- a/resource_server_async/tests/__init__.py
+++ b/resource_server_async/tests/__init__.py
@@ -1,22 +1,24 @@
-from inspect import iscoroutinefunction
+import asyncio
+import copy
+import json
 import re
+from inspect import iscoroutinefunction
 from typing import override
+
+import httpx
 from django.conf import settings
 from django.core.management import call_command
-import asyncio
-import utils.auth_utils as auth_utils
-import utils.globus_utils as globus_utils
-import resource_server_async.tests.mock_utils as mock_utils
-import httpx
-from resource_server_async import api
-from resource_server_async.endpoints import globus_compute, direct_api, metis
-import json
-import copy
 
 # Tools to test with Django Ninja
 from django.test import TestCase
 from ninja.testing import TestAsyncClient
+
+import resource_server_async.tests.mock_utils as mock_utils
+import utils.auth_utils as auth_utils
+import utils.globus_utils as globus_utils
+from resource_server_async import api
 from resource_server_async.api import router
+from resource_server_async.endpoints import direct_api, globus_compute, metis
 
 # Overwrite log data initialization
 api.GlobalAuth._GlobalAuth__initialize_access_log_data = (

--- a/resource_server_async/tests/mixins.py
+++ b/resource_server_async/tests/mixins.py
@@ -1,6 +1,8 @@
 import json
+
 from django.test import TestCase
 
+import resource_server_async.tests.mock_utils as mock_utils
 from resource_server_async.tests import (
     ACTIVE_TOKEN,
     CLIENT,
@@ -9,7 +11,6 @@ from resource_server_async.tests import (
     INVALID_TOKEN,
     KWARGS,
 )
-import resource_server_async.tests.mock_utils as mock_utils
 
 
 class EndpointPostTestsMixin(TestCase):

--- a/resource_server_async/tests/mock_utils.py
+++ b/resource_server_async/tests/mock_utils.py
@@ -2,13 +2,15 @@
 
 import time
 import uuid
-from django.utils import timezone
 from concurrent.futures import Future
-from utils.pydantic_models.db_models import AccessLogPydantic
-from resource_server_async.models import Endpoint
+
+from django.http import StreamingHttpResponse
+from django.utils import timezone
 from httpx import AsyncClient
 from pydantic import BaseModel
-from django.http import StreamingHttpResponse
+
+from resource_server_async.models import Endpoint
+from utils.pydantic_models.db_models import AccessLogPydantic
 
 # =============
 #   Constants

--- a/resource_server_async/tests/test_batch_inference_view.py
+++ b/resource_server_async/tests/test_batch_inference_view.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 
+import resource_server_async.tests.mock_utils as mock_utils
 from resource_server_async.tests import (
     CLIENT,
     DB_ENDPOINTS,
@@ -16,7 +17,6 @@ from resource_server_async.tests.mixins import (
     EndpointPostTestsMixin,
     HeaderFailuresTestMixin,
 )
-import resource_server_async.tests.mock_utils as mock_utils
 
 
 class BatchInferenceViewTestCase(

--- a/resource_server_async/tests/test_endpoint_view.py
+++ b/resource_server_async/tests/test_endpoint_view.py
@@ -1,3 +1,4 @@
+import resource_server_async.tests.mock_utils as mock_utils
 from resource_server_async.tests import (
     CLIENT,
     DB_ENDPOINTS,
@@ -7,7 +8,6 @@ from resource_server_async.tests import (
     get_response_json,
 )
 from resource_server_async.tests.mixins import HeaderFailuresTestMixin
-import resource_server_async.tests.mock_utils as mock_utils
 
 
 class EndpointsViewTestCase(HeaderFailuresTestMixin, ResourceServerTestCase):

--- a/resource_server_async/tests/test_inference_view.py
+++ b/resource_server_async/tests/test_inference_view.py
@@ -1,13 +1,13 @@
 import json
 
 from resource_server_async.tests import (
+    CLIENT,
     DB_ENDPOINTS,
     INVALID_PARAMS,
     KWARGS,
     PREMIUM_HEADERS,
     VALID_PARAMS,
     ResourceServerTestCase,
-    CLIENT,
     get_endpoint_urls,
     get_response_json,
     get_wrong_endpoint_urls,

--- a/resource_server_async/tests/test_stream_inference_view.py
+++ b/resource_server_async/tests/test_stream_inference_view.py
@@ -1,5 +1,6 @@
 import json
 
+import resource_server_async.tests.mock_utils as mock_utils
 from resource_server_async.tests import (
     ALLOWED_OPENAI_ENDPOINTS,
     CLIENT,
@@ -10,7 +11,6 @@ from resource_server_async.tests import (
     ResourceServerTestCase,
     get_response_json,
 )
-import resource_server_async.tests.mock_utils as mock_utils
 
 
 class StreamInferenceViewTestCase(ResourceServerTestCase):

--- a/resource_server_async/urls.py
+++ b/resource_server_async/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+
 from resource_server_async.views import api
 
 # Use the unique namespace or versioned API instance

--- a/resource_server_async/utils.py
+++ b/resource_server_async/utils.py
@@ -1166,7 +1166,7 @@ def format_streaming_error_for_openai(error_message: str):
         }
         return f"data: {json.dumps(fallback_error)}\n\n"
 
-    except Exception as e:
+    except Exception:
         # Ultimate fallback
         fallback_error = {
             "object": "error",

--- a/resource_server_async/utils.py
+++ b/resource_server_async/utils.py
@@ -1,45 +1,47 @@
-import uuid
-import json
-import logging
-import redis
-import time
-import asyncio
-import re
 import ast
-import secrets
+import asyncio
 import hmac
 import importlib
+import json
+import logging
+import re
+import secrets
+import time
+import uuid
 from typing import Optional
-from pydantic import BaseModel, Field, ConfigDict
+
+import redis
+from asgiref.sync import sync_to_async
+from cachetools import TTLCache
+from django.conf import settings
 from django.core.cache import cache
 from django.forms.models import model_to_dict
 from django.http import HttpResponse
 from django.utils import timezone
 from django.utils.text import slugify
-from django.conf import settings
-from utils.pydantic_models.openai_chat_completions import OpenAIChatCompletionsPydantic
-from utils.pydantic_models.openai_completions import OpenAICompletionsPydantic
-from utils.pydantic_models.openai_embeddings import OpenAIEmbeddingsPydantic
+from pydantic import BaseModel, ConfigDict, Field
+from rest_framework.exceptions import ValidationError
+
+from resource_server_async.clusters.cluster import BaseCluster
+from resource_server_async.endpoints.endpoint import BaseEndpoint
+from resource_server_async.models import (
+    AccessLog,
+    BatchLog,
+    BatchMetrics,
+    Cluster,
+    Endpoint,
+    RequestLog,
+    RequestMetrics,
+)
 from utils.pydantic_models.batch import BatchPydantic, BatchStatusEnum
 from utils.pydantic_models.db_models import (
     AccessLogPydantic,
-    RequestLogPydantic,
     BatchLogPydantic,
+    RequestLogPydantic,
 )
-from rest_framework.exceptions import ValidationError
-from asgiref.sync import sync_to_async
-from cachetools import TTLCache
-from resource_server_async.models import (
-    AccessLog,
-    RequestLog,
-    BatchLog,
-    RequestMetrics,
-    BatchMetrics,
-    Endpoint,
-    Cluster,
-)
-from resource_server_async.endpoints.endpoint import BaseEndpoint
-from resource_server_async.clusters.cluster import BaseCluster
+from utils.pydantic_models.openai_chat_completions import OpenAIChatCompletionsPydantic
+from utils.pydantic_models.openai_completions import OpenAICompletionsPydantic
+from utils.pydantic_models.openai_embeddings import OpenAIEmbeddingsPydantic
 
 log = logging.getLogger(__name__)  # Add logger
 

--- a/resource_server_async/views.py
+++ b/resource_server_async/views.py
@@ -1,65 +1,66 @@
-from ninja import Query
-from asgiref.sync import sync_to_async
-from django.conf import settings
-import uuid
 import json
-from django.utils import timezone
-from django.utils.text import slugify
-from django.http import JsonResponse, HttpResponse
 
 # Tool to log access requests
 import logging
+import uuid
+
+from asgiref.sync import sync_to_async
+from django.conf import settings
+from django.http import HttpResponse, JsonResponse
+from django.utils import timezone
+from django.utils.text import slugify
+from ninja import Query
 
 log = logging.getLogger(__name__)
 
 # Force Uvicorn to add timestamps in the Gunicorn access log
 import logging.config
+
 from logging_config import LOGGING_CONFIG
 
 logging.config.dictConfig(LOGGING_CONFIG)
 
 # Local utils
-from utils.pydantic_models.db_models import (
-    RequestLogPydantic,
-    BatchLogPydantic,
-    UserPydantic,
-)
-from utils.pydantic_models.batch import BatchStatusEnum, BatchListFilter
-from utils.globus_utils import get_transfer_client
-from resource_server_async.clusters.cluster import Jobs, JobInfo, BaseCluster
+from resource_server_async.clusters.cluster import BaseCluster, JobInfo, Jobs
 from resource_server_async.endpoints.globus_compute import GlobusComputeEndpoint
 from resource_server_async.utils import (
-    extract_prompt,
-    validate_request_body,
-    validate_batch_body,
-    update_batch,
-    decode_request_body,
-    # Streaming functions
-    store_streaming_data,
-    set_streaming_status,
-    set_streaming_error,
-    set_streaming_metadata,
-    validate_streaming_request_security,
-    # Response functions
-    get_response,
+    GetListEndpointsDataResponse,
     create_access_log,
     create_request_log,
+    decode_request_body,
+    extract_prompt,
+    get_cluster_wrapper,
     # Wrapper function
     get_endpoint_wrapper,
-    get_cluster_wrapper,
     get_list_endpoints_data,
-    GetListEndpointsDataResponse,
+    # Response functions
+    get_response,
+    set_streaming_error,
+    set_streaming_metadata,
+    set_streaming_status,
+    # Streaming functions
+    store_streaming_data,
+    update_batch,
+    validate_batch_body,
+    validate_request_body,
+    validate_streaming_request_security,
+)
+from utils.globus_utils import get_transfer_client
+from utils.pydantic_models.batch import BatchListFilter, BatchStatusEnum
+from utils.pydantic_models.db_models import (
+    BatchLogPydantic,
+    RequestLogPydantic,
+    UserPydantic,
 )
 
 log.info("Utils functions loaded.")
 
 # Django database
 # from resource_server.models import FederatedEndpoint
-from resource_server_async.models import BatchLog, Cluster, Endpoint
-from resource_server_async.schemas.sam3 import Sam3Request
-
 # Django Ninja API
 from resource_server_async.api import api, router
+from resource_server_async.models import BatchLog, Cluster, Endpoint
+from resource_server_async.schemas.sam3 import Sam3Request
 
 # NOTE: All caching is now centralized in resource_server_async.utils
 # Caching uses Django cache (configured for Redis) with automatic fallback to in-memory cache

--- a/resource_server_async/views.py
+++ b/resource_server_async/views.py
@@ -24,7 +24,6 @@ logging.config.dictConfig(LOGGING_CONFIG)
 from resource_server_async.clusters.cluster import BaseCluster, JobInfo, Jobs
 from resource_server_async.endpoints.globus_compute import GlobusComputeEndpoint
 from resource_server_async.utils import (
-    GetListEndpointsDataResponse,
     create_access_log,
     create_request_log,
     decode_request_body,
@@ -59,7 +58,7 @@ log.info("Utils functions loaded.")
 # from resource_server.models import FederatedEndpoint
 # Django Ninja API
 from resource_server_async.api import api, router
-from resource_server_async.models import BatchLog, Cluster, Endpoint
+from resource_server_async.models import BatchLog
 from resource_server_async.schemas.sam3 import Sam3Request
 
 # NOTE: All caching is now centralized in resource_server_async.utils

--- a/utils/auth_utils.py
+++ b/utils/auth_utils.py
@@ -1,17 +1,18 @@
-from pydantic import BaseModel, Field
-from typing import Optional, List
-from dataclasses import dataclass, field
-from resource_server_async.models import AuthService, User
-from utils.pydantic_models.db_models import UserPydantic
-from django.conf import settings
-import globus_sdk
+# Tool to log access requests
+import logging
 import time
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import globus_sdk
 
 # Cache tools to limits how many calls are made to Globus servers
 from cachetools import TTLCache, cached
+from django.conf import settings
+from pydantic import BaseModel, Field
 
-# Tool to log access requests
-import logging
+from resource_server_async.models import AuthService, User
+from utils.pydantic_models.db_models import UserPydantic
 
 log = logging.getLogger(__name__)
 
@@ -46,8 +47,9 @@ def introspect_token(bearer_token: str):
 
     Returns serializable data instead of Globus SDK objects.
     """
-    from django.core.cache import cache
     import hashlib
+
+    from django.core.cache import cache
 
     # Create cache key from token hash (don't store raw tokens in cache keys)
     # Store the entire hash to avoid collisions where different users would have the same last hash digits

--- a/utils/auth_utils.py
+++ b/utils/auth_utils.py
@@ -1,7 +1,7 @@
 # Tool to log access requests
 import logging
 import time
-from dataclasses import dataclass, field
+from dataclasses import field
 from typing import List, Optional
 
 import globus_sdk
@@ -221,7 +221,7 @@ def check_globus_groups(user_groups):
 
     # Deny access if authenticated user is not part of any of the allowed Globus Groups
     else:
-        return False, f"Error: User is not a member of an allowed Globus Group."
+        return False, "Error: User is not a member of an allowed Globus Group."
 
 
 # Check Session Info
@@ -285,7 +285,7 @@ def check_session_info(introspection, user_groups):
         user_str = ", ".join(user_str)
         if len(user_str) == 0:
             user_str = "Unknown (no active session found)"
-    except Exception as e:
+    except Exception:
         user_str = "could not recover user identity"
 
     # Revoke access if authentication did not come from authorized provider
@@ -512,7 +512,7 @@ def check_permission(
         if len(set(user_group_uuids) & set(allowed_globus_groups)) == 0:
             return CheckPermissionResponse(
                 is_authorized=False,
-                error_message=f"Error: Permission denied due to Globus Group restrictions.",
+                error_message="Error: Permission denied due to Globus Group restrictions.",
                 error_code=401,
             )
 
@@ -531,7 +531,7 @@ def check_permission(
         if user_domain not in allowed_domains:
             return CheckPermissionResponse(
                 is_authorized=False,
-                error_message=f"Error: Permission denied due to IdP domain restrictions.",
+                error_message="Error: Permission denied due to IdP domain restrictions.",
                 error_code=401,
             )
 

--- a/utils/globus_utils.py
+++ b/utils/globus_utils.py
@@ -200,7 +200,7 @@ async def submit_and_get_result(
     try:
         asyncio_future = asyncio.wrap_future(future)
         result = await asyncio.wait_for(asyncio_future, timeout=timeout)
-    except TimeoutError as e:
+    except TimeoutError:
         error_message = "Error: TimeoutError while attempting to access compute resources. Please try again later."
         return None, get_task_uuid(future), error_message, 408
     except Exception as e:

--- a/utils/globus_utils.py
+++ b/utils/globus_utils.py
@@ -1,14 +1,14 @@
 import asyncio
+import logging
 import time
-from django.conf import settings
+
 import globus_sdk
-from globus_sdk import TransferClient
+from cachetools import TTLCache, cached
+from django.conf import settings
 from globus_compute_sdk import Client, Executor
 from globus_compute_sdk.errors import TaskExecutionFailed
 from globus_compute_sdk.sdk.executor import log as EXECUTOR_LOG
-from cachetools import TTLCache, cached
-
-import logging
+from globus_sdk import TransferClient
 
 log = logging.getLogger(__name__)
 

--- a/utils/metis_utils.py
+++ b/utils/metis_utils.py
@@ -8,16 +8,18 @@ an API. This module provides utilities to:
 - Make direct API calls to Metis endpoints
 """
 
+import asyncio
 import json
 import logging
 import time
+from typing import Dict, List, Optional, Tuple
+
 import httpx
-import asyncio
-from django.utils import timezone
 from asgiref.sync import sync_to_async
 from django.conf import settings
-from typing import Dict, Tuple, Optional, List
 from django.core.cache import cache
+from django.utils import timezone
+
 from resource_server_async.models import RequestLog
 
 log = logging.getLogger(__name__)

--- a/utils/metis_utils.py
+++ b/utils/metis_utils.py
@@ -8,19 +8,13 @@ an API. This module provides utilities to:
 - Make direct API calls to Metis endpoints
 """
 
-import asyncio
 import json
 import logging
-import time
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import httpx
-from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.core.cache import cache
-from django.utils import timezone
-
-from resource_server_async.models import RequestLog
 
 log = logging.getLogger(__name__)
 

--- a/utils/openai_models.py
+++ b/utils/openai_models.py
@@ -15,13 +15,13 @@ from typing import Dict, List, Optional, Union
 from pydantic import (
     AnyUrl,
     BaseModel,
+    ConfigDict,
     Extra,
     Field,
+    RootModel,
     confloat,
     conint,
-    RootModel,
     field_validator,
-    ConfigDict,
 )
 
 

--- a/utils/pydantic_models/batch.py
+++ b/utils/pydantic_models/batch.py
@@ -1,7 +1,8 @@
-from pydantic import BaseModel, Field
-from ninja import FilterSchema
 from enum import Enum
 from typing import Optional
+
+from ninja import FilterSchema
+from pydantic import BaseModel, Field
 
 
 # Batch status

--- a/utils/pydantic_models/db_models.py
+++ b/utils/pydantic_models/db_models.py
@@ -1,6 +1,7 @@
 from datetime import datetime
+from typing import Any, List, Optional
+
 from pydantic import BaseModel, Field
-from typing import Any, Optional, List
 
 
 class UserPydantic(BaseModel):

--- a/utils/pydantic_models/openai_chat_completions.py
+++ b/utils/pydantic_models/openai_chat_completions.py
@@ -1,6 +1,7 @@
-from pydantic import BaseModel, Field, AfterValidator, model_validator
-from typing import List, Optional, Union, Dict, Annotated, Any
 from enum import Enum
+from typing import Annotated, Any, Dict, List, Optional, Union
+
+from pydantic import AfterValidator, BaseModel, Field, model_validator
 
 
 # Extra validation for the metadata field

--- a/utils/pydantic_models/openai_chat_completions.py
+++ b/utils/pydantic_models/openai_chat_completions.py
@@ -254,7 +254,7 @@ class ResponseFormat(BaseModelExtraForbid):
     def set_dynamic_content_type(cls, values):
         # Check if type was provided
         if "type" not in values:
-            raise ValueError(f"'type' must be provided.")
+            raise ValueError("'type' must be provided.")
 
         # Validate the input type
         response_type = values.get("type")
@@ -436,7 +436,7 @@ class UserMessageContent(BaseModelExtraForbid):
         # Check if type was provided
         if "type" not in values:
             raise ValueError(
-                f"'type' must be provided in each user message content item."
+                "'type' must be provided in each user message content item."
             )
 
         # Validate the input type
@@ -482,7 +482,7 @@ class AssistantMessageContent(BaseModelExtraForbid):
         # Check if type was provided
         if "type" not in values:
             raise ValueError(
-                f"'type' must be provided in each assistant message content item."
+                "'type' must be provided in each assistant message content item."
             )
 
         # Validate the input type
@@ -543,7 +543,7 @@ class Message(BaseModelExtraForbid):
     def set_dynamic_message_role(cls, values):
         # Check if role was provided
         if "role" not in values:
-            raise ValueError(f"'role' must be provided in each message object.")
+            raise ValueError("'role' must be provided in each message object.")
 
         # Validate the input role
         input_role = values.get("role")

--- a/utils/pydantic_models/openai_completions.py
+++ b/utils/pydantic_models/openai_completions.py
@@ -1,5 +1,6 @@
+from typing import Dict, List, Optional, Union
+
 from pydantic import BaseModel, Field, model_validator
-from typing import List, Optional, Union, Dict
 
 
 # Extention of the Pydantic BaseModel that prevent extra attributes

--- a/utils/pydantic_models/openai_embeddings.py
+++ b/utils/pydantic_models/openai_embeddings.py
@@ -1,6 +1,7 @@
-from pydantic import BaseModel, Field, model_validator
-from typing import List, Optional, Union
 from enum import Enum
+from typing import List, Optional, Union
+
+from pydantic import BaseModel, Field, model_validator
 
 
 # Extention of the Pydantic BaseModel that prevent extra attributes

--- a/utils/serializers.py
+++ b/utils/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+
 from utils import serializer_utils
 
 # TODO: overwrite is_valid or validate function to raise errors when passing extra parameters

--- a/utils/tests/test_pydantic_models.py
+++ b/utils/tests/test_pydantic_models.py
@@ -1,10 +1,12 @@
+import json
+
+from pydantic import ValidationError
+from rest_framework.test import APITestCase
+
+from utils.pydantic_models.batch import BatchPydantic
 from utils.pydantic_models.openai_chat_completions import OpenAIChatCompletionsPydantic
 from utils.pydantic_models.openai_completions import OpenAICompletionsPydantic
 from utils.pydantic_models.openai_embeddings import OpenAIEmbeddingsPydantic
-from utils.pydantic_models.batch import BatchPydantic
-from pydantic import ValidationError
-from rest_framework.test import APITestCase
-import json
 
 # Constants
 COMPLETIONS = "completions"

--- a/uv.lock
+++ b/uv.lock
@@ -80,18 +80,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asyncache"
-version = "0.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cachetools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/49/cf/17f8a6b6b97f77b5981fbce1266913e718daaa3467b46f60a785cbaadc29/asyncache-0.3.1.tar.gz", hash = "sha256:9a1e60a75668e794657489bdea6540ee7e3259c483517b934670db7600bf5035", size = 3797, upload-time = "2022-11-15T10:06:47.476Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/94/51927deb4f40872361ec4f5534f68f7a9ce81c4ef20bf5cd765307f4c15d/asyncache-0.3.1-py3-none-any.whl", hash = "sha256:ef20a1024d265090dd1e0785c961cf98b9c32cc7d9478973dcf25ac1b80011f5", size = 3722, upload-time = "2022-11-15T10:06:45.546Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -510,27 +498,6 @@ wheels = [
 ]
 
 [[package]]
-name = "hiredis"
-version = "3.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/82/d2817ce0653628e0a0cb128533f6af0dd6318a49f3f3a6a7bd1f2f2154af/hiredis-3.3.0.tar.gz", hash = "sha256:105596aad9249634361815c574351f1bd50455dc23b537c2940066c4a9dea685", size = 89048, upload-time = "2025-10-14T16:33:34.263Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/1c/ed28ae5d704f5c7e85b946fa327f30d269e6272c847fef7e91ba5fc86193/hiredis-3.3.0-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:5b8e1d6a2277ec5b82af5dce11534d3ed5dffeb131fd9b210bc1940643b39b5f", size = 82026, upload-time = "2025-10-14T16:32:12.004Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/9b/79f30c5c40e248291023b7412bfdef4ad9a8a92d9e9285d65d600817dac7/hiredis-3.3.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c4981de4d335f996822419e8a8b3b87367fcef67dc5fb74d3bff4df9f6f17783", size = 46217, upload-time = "2025-10-14T16:32:13.133Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/c3/02b9ed430ad9087aadd8afcdf616717452d16271b701fa47edfe257b681e/hiredis-3.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1706480a683e328ae9ba5d704629dee2298e75016aa0207e7067b9c40cecc271", size = 41858, upload-time = "2025-10-14T16:32:13.98Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/98/b2a42878b82130a535c7aa20bc937ba2d07d72e9af3ad1ad93e837c419b5/hiredis-3.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a95cef9989736ac313639f8f545b76b60b797e44e65834aabbb54e4fad8d6c8", size = 170195, upload-time = "2025-10-14T16:32:14.728Z" },
-    { url = "https://files.pythonhosted.org/packages/66/1d/9dcde7a75115d3601b016113d9b90300726fa8e48aacdd11bf01a453c145/hiredis-3.3.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ca2802934557ccc28a954414c245ba7ad904718e9712cb67c05152cf6b9dd0a3", size = 181808, upload-time = "2025-10-14T16:32:15.622Z" },
-    { url = "https://files.pythonhosted.org/packages/56/a1/60f6bda9b20b4e73c85f7f5f046bc2c154a5194fc94eb6861e1fd97ced52/hiredis-3.3.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fe730716775f61e76d75810a38ee4c349d3af3896450f1525f5a4034cf8f2ed7", size = 180578, upload-time = "2025-10-14T16:32:16.514Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/01/859d21de65085f323a701824e23ea3330a0ac05f8e184544d7aa5c26128d/hiredis-3.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:749faa69b1ce1f741f5eaf743435ac261a9262e2d2d66089192477e7708a9abc", size = 172508, upload-time = "2025-10-14T16:32:17.411Z" },
-    { url = "https://files.pythonhosted.org/packages/99/a8/28fd526e554c80853d0fbf57ef2a3235f00e4ed34ce0e622e05d27d0f788/hiredis-3.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:95c9427f2ac3f1dd016a3da4e1161fa9d82f221346c8f3fdd6f3f77d4e28946c", size = 166341, upload-time = "2025-10-14T16:32:18.561Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/91/ded746b7d2914f557fbbf77be55e90d21f34ba758ae10db6591927c642c8/hiredis-3.3.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c863ee44fe7bff25e41f3a5105c936a63938b76299b802d758f40994ab340071", size = 176765, upload-time = "2025-10-14T16:32:19.491Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/4c/04aa46ff386532cb5f08ee495c2bf07303e93c0acf2fa13850e031347372/hiredis-3.3.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:2213c7eb8ad5267434891f3241c7776e3bafd92b5933fc57d53d4456247dc542", size = 170312, upload-time = "2025-10-14T16:32:20.404Z" },
-    { url = "https://files.pythonhosted.org/packages/90/6e/67f9d481c63f542a9cf4c9f0ea4e5717db0312fb6f37fb1f78f3a66de93c/hiredis-3.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a172bae3e2837d74530cd60b06b141005075db1b814d966755977c69bd882ce8", size = 167965, upload-time = "2025-10-14T16:32:21.259Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/df/dde65144d59c3c0d85e43255798f1fa0c48d413e668cfd92b3d9f87924ef/hiredis-3.3.0-cp312-cp312-win32.whl", hash = "sha256:cb91363b9fd6d41c80df9795e12fffbaf5c399819e6ae8120f414dedce6de068", size = 20533, upload-time = "2025-10-14T16:32:22.192Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/a9/55a4ac9c16fdf32e92e9e22c49f61affe5135e177ca19b014484e28950f7/hiredis-3.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:04ec150e95eea3de9ff8bac754978aa17b8bf30a86d4ab2689862020945396b0", size = 22379, upload-time = "2025-10-14T16:32:22.916Z" },
-]
-
-[[package]]
 name = "htmlmin2"
 version = "0.1.13"
 source = { registry = "https://pypi.org/simple" }
@@ -549,6 +516,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/7f/403e5d787dc4942316e515e949b0c8a013d84078a915910e9f391ba9b3ed/httptools-0.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:38e0c83a2ea9746ebbd643bdfb521b9aa4a91703e2cd705c20443405d2fd16a5", size = 206280, upload-time = "2025-10-10T03:54:39.274Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0d/7f3fd28e2ce311ccc998c388dd1c53b18120fda3b70ebb022b135dc9839b/httptools-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f25bbaf1235e27704f1a7b86cd3304eabc04f569c828101d94a0e605ef7205a5", size = 110004, upload-time = "2025-10-10T03:54:40.403Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c15f37ef679ab9ecc06bfc4e6e8628c32a8e4b305459de7cf6785acd57e4d03", size = 517655, upload-time = "2025-10-10T03:54:41.347Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7d/71fee6f1844e6fa378f2eddde6c3e41ce3a1fb4b2d81118dd544e3441ec0/httptools-0.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fe6e96090df46b36ccfaf746f03034e5ab723162bc51b0a4cf58305324036f2", size = 511440, upload-time = "2025-10-10T03:54:42.452Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a5/079d216712a4f3ffa24af4a0381b108aa9c45b7a5cc6eb141f81726b1823/httptools-0.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f72fdbae2dbc6e68b8239defb48e6a5937b12218e6ffc2c7846cc37befa84362", size = 495186, upload-time = "2025-10-10T03:54:43.937Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/025ad7b65278745dee3bd0ebf9314934c4592560878308a6121f7f812084/httptools-0.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e99c7b90a29fd82fea9ef57943d501a16f3404d7b9ee81799d41639bdaae412c", size = 499192, upload-time = "2025-10-10T03:54:45.003Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/de/40a8f202b987d43afc4d54689600ff03ce65680ede2f31df348d7f368b8f/httptools-0.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:3e14f530fefa7499334a79b0cf7e7cd2992870eb893526fb097d51b4f2d0f321", size = 86694, upload-time = "2025-10-10T03:54:45.923Z" },
 ]
 
 [[package]]
@@ -581,22 +563,8 @@ name = "inference-gateway-backend"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [
-    { name = "alcf-ai" },
-    { name = "annotated-types" },
     { name = "asgiref" },
-    { name = "asyncache" },
-    { name = "attrs" },
-    { name = "babel" },
-    { name = "backrefs" },
     { name = "cachetools" },
-    { name = "certifi" },
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "charset-normalizer" },
-    { name = "click" },
-    { name = "colorama" },
-    { name = "cryptography" },
-    { name = "csscompressor" },
-    { name = "dill" },
     { name = "django" },
     { name = "django-cors-headers" },
     { name = "django-filter" },
@@ -604,159 +572,75 @@ dependencies = [
     { name = "django-redis" },
     { name = "djangorestframework" },
     { name = "drf-spectacular" },
-    { name = "exceptiongroup" },
-    { name = "ghp-import" },
-    { name = "globus-compute-common" },
     { name = "globus-compute-sdk" },
     { name = "globus-sdk" },
     { name = "gunicorn" },
     { name = "h11" },
-    { name = "hiredis" },
-    { name = "htmlmin2" },
     { name = "httpx" },
-    { name = "idna" },
-    { name = "inflection" },
-    { name = "jinja2" },
-    { name = "jsmin" },
-    { name = "jsonschema" },
-    { name = "jsonschema-specifications" },
-    { name = "markdown" },
-    { name = "markdown-it-py" },
-    { name = "markupsafe" },
-    { name = "mdurl" },
-    { name = "mergedeep" },
+    { name = "psycopg" },
+    { name = "psycopg-pool" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "redis" },
+    { name = "requests" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "alcf-ai" },
+    { name = "pyright", extra = ["nodejs"] },
+    { name = "ruff" },
+]
+docs = [
     { name = "mkdocs" },
     { name = "mkdocs-get-deps" },
     { name = "mkdocs-material" },
     { name = "mkdocs-material-extensions" },
     { name = "mkdocs-minify-plugin" },
-    { name = "packaging" },
-    { name = "paginate" },
-    { name = "pathspec" },
-    { name = "pika" },
-    { name = "platformdirs" },
-    { name = "psutil" },
-    { name = "psycopg" },
-    { name = "psycopg-pool" },
-    { name = "pycparser", marker = "implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'" },
-    { name = "pydantic" },
-    { name = "pydantic-core" },
-    { name = "pygments" },
-    { name = "pyjwt" },
     { name = "pymdown-extensions" },
-    { name = "python-dateutil" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "pyyaml-env-tag" },
-    { name = "redis" },
-    { name = "referencing" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "rpds-py" },
-    { name = "shellingham" },
-    { name = "six" },
-    { name = "sqlparse" },
-    { name = "tblib" },
-    { name = "texttable" },
-    { name = "typer" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-    { name = "uritemplate" },
-    { name = "urllib3" },
-    { name = "uvicorn" },
-    { name = "watchdog" },
-    { name = "websockets" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "alcf-ai", editable = "alcf_ai" },
-    { name = "annotated-types", specifier = "==0.7.0" },
-    { name = "asgiref", specifier = "==3.10.0" },
-    { name = "asyncache", specifier = ">=0.3.1,<0.4" },
-    { name = "attrs", specifier = "==25.4.0" },
-    { name = "babel", specifier = "==2.17.0" },
-    { name = "backrefs", specifier = "==6.0.1" },
-    { name = "cachetools", specifier = ">=5.5.2,<6" },
-    { name = "certifi", specifier = "==2025.10.5" },
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'", specifier = "==2.0.0" },
-    { name = "charset-normalizer", specifier = "==3.4.4" },
-    { name = "click" },
-    { name = "colorama", specifier = "==0.4.6" },
-    { name = "cryptography", specifier = "==46.0.3" },
-    { name = "csscompressor", specifier = "==0.9.5" },
-    { name = "dill", specifier = "==0.3.9" },
-    { name = "django", specifier = ">=5.2.9,<6" },
-    { name = "django-cors-headers", specifier = ">=4.9.0,<5" },
-    { name = "django-filter", specifier = ">=24.3,<25" },
-    { name = "django-ninja", specifier = ">=1.4.5,<2" },
-    { name = "django-redis", specifier = ">=6.0.0,<7" },
+    { name = "asgiref", specifier = ">=3.10" },
+    { name = "cachetools", specifier = "<6" },
+    { name = "django" },
+    { name = "django-cors-headers" },
+    { name = "django-filter" },
+    { name = "django-ninja" },
+    { name = "django-redis" },
     { name = "djangorestframework", specifier = ">=3.16.1,<4" },
-    { name = "drf-spectacular", specifier = ">=0.27.2,<0.28" },
-    { name = "exceptiongroup", specifier = "==1.3.0" },
-    { name = "ghp-import", specifier = "==2.1.0" },
-    { name = "globus-compute-common", specifier = ">=0.7.1,<0.8" },
+    { name = "drf-spectacular" },
     { name = "globus-compute-sdk", specifier = ">=3.16.1,<4" },
     { name = "globus-sdk", specifier = ">=3.65.0,<4" },
-    { name = "gunicorn", specifier = ">=23.0.0,<24" },
-    { name = "h11", specifier = ">=0.16.0,<0.17" },
-    { name = "hiredis", specifier = ">=3.3.0,<4" },
-    { name = "htmlmin2", specifier = "==0.1.13" },
-    { name = "httpx", specifier = ">=0.27.2,<0.28" },
-    { name = "idna", specifier = "==3.11" },
-    { name = "inflection", specifier = "==0.5.1" },
-    { name = "jinja2", specifier = "==3.1.6" },
-    { name = "jsmin", specifier = "==3.0.1" },
-    { name = "jsonschema", specifier = "==4.25.1" },
-    { name = "jsonschema-specifications", specifier = "==2025.9.1" },
-    { name = "markdown", specifier = "==3.10" },
-    { name = "markdown-it-py", specifier = "==4.0.0" },
-    { name = "markupsafe", specifier = "==3.0.3" },
-    { name = "mdurl", specifier = "==0.1.2" },
-    { name = "mergedeep", specifier = "==1.3.4" },
-    { name = "mkdocs", specifier = ">=1.5.0" },
-    { name = "mkdocs-get-deps", specifier = "==0.2.0" },
-    { name = "mkdocs-material", specifier = ">=9.7.0,<10" },
-    { name = "mkdocs-material-extensions", specifier = "==1.3.1" },
-    { name = "mkdocs-minify-plugin", specifier = ">=0.8.0,<0.9" },
-    { name = "packaging", specifier = "==25.0" },
-    { name = "paginate", specifier = "==0.5.7" },
-    { name = "pathspec", specifier = "==0.12.1" },
-    { name = "pika", specifier = "==1.3.2" },
-    { name = "platformdirs", specifier = "==4.5.0" },
-    { name = "psutil", specifier = "==5.9.8" },
+    { name = "gunicorn" },
+    { name = "h11" },
+    { name = "httpx" },
     { name = "psycopg", specifier = ">=3.2.12,<4" },
     { name = "psycopg-pool", specifier = ">=3.2.7,<4" },
-    { name = "pycparser", marker = "implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'", specifier = "==2.23" },
-    { name = "pydantic", specifier = "==2.12.4" },
-    { name = "pydantic-core", specifier = "==2.41.5" },
-    { name = "pygments", specifier = "==2.19.2" },
-    { name = "pyjwt", specifier = "==2.10.1" },
+    { name = "pydantic", specifier = ">=2.12" },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv", specifier = "<2" },
+    { name = "redis", specifier = "<7" },
+    { name = "requests", specifier = "<3" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "alcf-ai", editable = "alcf_ai" },
+    { name = "pyright", extras = ["nodejs"] },
+    { name = "ruff" },
+]
+docs = [
+    { name = "mkdocs", specifier = ">=1.5.0" },
+    { name = "mkdocs-get-deps" },
+    { name = "mkdocs-material", specifier = ">=9.7.0,<10" },
+    { name = "mkdocs-material-extensions" },
+    { name = "mkdocs-minify-plugin", specifier = "<0.9" },
     { name = "pymdown-extensions", specifier = ">=10.0" },
-    { name = "python-dateutil", specifier = "==2.9.0.post0" },
-    { name = "python-dotenv", specifier = ">=1.2.1,<2" },
-    { name = "pyyaml", specifier = "==6.0.3" },
-    { name = "pyyaml-env-tag", specifier = "==1.1" },
-    { name = "redis", specifier = ">=6.4.0,<7" },
-    { name = "referencing", specifier = "==0.37.0" },
-    { name = "requests", specifier = ">=2.32.5,<3" },
-    { name = "rich", specifier = "==14.2.0" },
-    { name = "rpds-py", specifier = "==0.28.0" },
-    { name = "shellingham", specifier = "==1.5.4" },
-    { name = "six", specifier = "==1.17.0" },
-    { name = "sqlparse", specifier = "==0.5.3" },
-    { name = "tblib", specifier = "==1.7.0" },
-    { name = "texttable", specifier = "==1.7.0" },
-    { name = "typer" },
-    { name = "typing-extensions", specifier = "==4.15.0" },
-    { name = "typing-inspection", specifier = "==0.4.2" },
-    { name = "tzdata", marker = "sys_platform == 'win32'", specifier = "==2025.2" },
-    { name = "uritemplate", specifier = "==4.2.0" },
-    { name = "urllib3", specifier = ">=2.6.3,<3" },
-    { name = "uvicorn", specifier = ">=0.30.6,<0.31" },
-    { name = "watchdog", specifier = "==6.0.0" },
-    { name = "websockets", specifier = ">=13.1,<14" },
 ]
 
 [[package]]
@@ -1034,6 +918,31 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "nodejs-wheel-binaries"
+version = "24.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/87/e5755ad739daafce2e152ab609293d65e6c663b399e28a4bbcd0f4af1f45/nodejs_wheel_binaries-24.14.1.tar.gz", hash = "sha256:d00ae0c86d7e1bfa798e8f8ad282db751af157cdcaa1208a1b9a2cf2a85ac821", size = 8056, upload-time = "2026-03-31T14:07:27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/b7/9765d9a5d3b95475829ef5965d4a4f6f4badb034ee4e18c2d5f8b9b65d6f/nodejs_wheel_binaries-24.14.1-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:d9e856ba0f2d3d2659869e6e0f4cae6874faeeeca7f879131a88451356373ac4", size = 54945603, upload-time = "2026-03-31T14:06:58.526Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/15/bc2fa51ee31ce597b2af1905081e5a5add07fe0cf619bfa531d7df2f1f1b/nodejs_wheel_binaries-24.14.1-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:634f57829ebfdfe95d096f32a50c5cdd3a6c72a94dcf2b92a8bef9868cccb13e", size = 55119951, upload-time = "2026-03-31T14:07:02.597Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/dd/92ff0831262af4bbb5473d4e7964fd27afb0901a2690a6ff7bc3d220d97f/nodejs_wheel_binaries-24.14.1-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:404b563467129e6a0ea7006a38b3d8af0ebfbc340b31a6a0af2c59ea3af90b7c", size = 59487620, upload-time = "2026-03-31T14:07:06.198Z" },
+    { url = "https://files.pythonhosted.org/packages/45/36/bbbee3adf6afd00944e5a86ebd64987dea90bd347090155a4989dc3e8594/nodejs_wheel_binaries-24.14.1-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:7863c62f8a3946b727831f71375a9ae00205b3258478476034b49c3a1d57ac12", size = 59986044, upload-time = "2026-03-31T14:07:09.846Z" },
+    { url = "https://files.pythonhosted.org/packages/05/16/119e4168bf7ed17ad7961d122701c75ac86135fa243a958b960a3f1b7055/nodejs_wheel_binaries-24.14.1-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a3f64daa1235fa6a83c778ded98d5fe4e74979ca54aa2ffb807f0805c57c3abe", size = 61489823, upload-time = "2026-03-31T14:07:13.378Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a6/d581996827b9d1133094dc347f1c4e3d2a70557973ce7a427a03337b1427/nodejs_wheel_binaries-24.14.1-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:810a48ce096925ead0690f7d143e48fb902ebfc9212097e8f6cb3ac6cbe8f314", size = 62069740, upload-time = "2026-03-31T14:07:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/27/da/396d1a48cbf3d5899461bda12fa97ae4010d7e4013e7f28230cb04af5818/nodejs_wheel_binaries-24.14.1-py2.py3-none-win_amd64.whl", hash = "sha256:7a087b6a727fb9242d1cc83c8b121711bd0e9686408d27de48b34b23dfb26ac5", size = 41400067, upload-time = "2026-03-31T14:07:20.513Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b7/adb21cf549934579e98934531e7f9b038d583fc9c2dd4b82ea01cc31bdd2/nodejs_wheel_binaries-24.14.1-py2.py3-none-win_arm64.whl", hash = "sha256:978fdfe76624c48111ab99ed0f99f9d4c1c682e420b0212ac9e1daee52f20283", size = 39096873, upload-time = "2026-03-31T14:07:23.977Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1228,6 +1137,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1270,6 +1193,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+]
+
+[package.optional-dependencies]
+nodejs = [
+    { name = "nodejs-wheel-binaries" },
 ]
 
 [[package]]
@@ -1395,6 +1336,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/89/33e675dccff11a06d4d85dbb4d1865f878d5020cbb69b2c1e7b2d3f82562/rpds_py-0.28.0-cp312-cp312-win32.whl", hash = "sha256:d15431e334fba488b081d47f30f091e5d03c18527c325386091f31718952fe08", size = 216954, upload-time = "2025-10-22T22:22:24.105Z" },
     { url = "https://files.pythonhosted.org/packages/af/36/45f6ebb3210887e8ee6dbf1bc710ae8400bb417ce165aaf3024b8360d999/rpds_py-0.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:a410542d61fc54710f750d3764380b53bf09e8c4edbf2f9141a82aa774a04f7c", size = 227844, upload-time = "2025-10-22T22:22:25.551Z" },
     { url = "https://files.pythonhosted.org/packages/57/91/f3fb250d7e73de71080f9a221d19bd6a1c1eb0d12a1ea26513f6c1052ad6/rpds_py-0.28.0-cp312-cp312-win_arm64.whl", hash = "sha256:1f0cfd1c69e2d14f8c892b893997fa9a60d890a0c8a603e88dca4955f26d1edd", size = 217624, upload-time = "2025-10-22T22:22:26.914Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
+    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
+    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
 ]
 
 [[package]]
@@ -1563,6 +1529,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f5/8e/cdc7d6263db313030e4c257dd5ba3909ebc4e4fb53ad62d5f09b1a2f5458/uvicorn-0.30.6-py3-none-any.whl", hash = "sha256:65fd46fe3fda5bdc1b03b94eb634923ff18cd35b2f084813ea79d1f103f711b5", size = 62835, upload-time = "2024-08-13T09:27:33.536Z" },
 ]
 
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+]
+
 [[package]]
 name = "watchdog"
 version = "6.0.0"
@@ -1582,6 +1573,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -151,6 +151,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -284,6 +293,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -396,6 +414,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674, upload-time = "2025-05-10T17:42:49.33Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
 ]
 
 [[package]]
@@ -550,6 +577,15 @@ wheels = [
 ]
 
 [[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -590,6 +626,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "alcf-ai" },
+    { name = "pre-commit" },
     { name = "pyright", extra = ["nodejs"] },
     { name = "ruff" },
 ]
@@ -631,6 +668,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "alcf-ai", editable = "alcf_ai" },
+    { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pyright", extras = ["nodejs"] },
     { name = "ruff" },
 ]
@@ -1045,6 +1083,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pre-commit"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
 name = "psutil"
 version = "5.9.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1223,6 +1277,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a", size = 31894, upload-time = "2026-04-07T17:28:48.09Z" },
 ]
 
 [[package]]
@@ -1552,6 +1619,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
     { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
     { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR:

- Adds ruff configuration and standardized `Makefile` for linting and formatting:

```
# Set up environment and install pre-commit hooks:
make install-dev

# Format code:
make format

# Lint code:
make lint

# Autofix lint errors:
make lint-fix
```

- Adds `pre-commit` hooks to automatically format on commit.  This is useful to minimize the size of diffs and eliminate any code churn related to format issues.
- Adds GitHub CI actions to verify formatting and lint checks pass.  This is a better substitute for the syntax-only check that was previously in place.
- Applies the format and lint fixes.  The diff is large, but this is a one-time step that can be verified by running the formatter on the content of commit `fc97b812e8` and comparing to the resulting commit `9f28cf8`.
- Removes transitive dependencies and pinned dependencies from `pyproject.toml`.  Over-constraining the dependencies in pyproject.toml is not a good practice; rather, we allow `uv.lock` to be the locked source of truth.  Lifting restrictions to only the essential constraints will facilitate vulnerability patching going forward.