### PR TITLE
LCF 50: Dynamic globus credentials

### DIFF
--- a/inference_gateway/settings.py
+++ b/inference_gateway/settings.py
@@ -15,9 +15,9 @@ import os
 from pathlib import Path
 
 from dotenv import load_dotenv
+from pydantic import TypeAdapter
 
 from inference_gateway.utils import (
-    BackendUtilsError,
     GlobusCredentials,
     textfield_to_strlist,
 )
@@ -48,17 +48,10 @@ GLOBUS_GROUP_MANAGER_ID = os.getenv("GLOBUS_GROUP_MANAGER_ID", "")
 GLOBUS_GROUP_MANAGER_SECRET = os.getenv("GLOBUS_GROUP_MANAGER_SECRET", "")
 
 # Overwrite Globus Compute credentials (ID/secret) for specific endpoint UUIDs
-credentials_overwrite = json.loads(
-    os.getenv("GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES", "{}")
+ta = TypeAdapter(dict[str, GlobusCredentials])
+GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES = ta.validate_json(
+    os.environ.get("GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES", "{}")
 )
-try:
-    GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES = {
-        key: GlobusCredentials(**value) for key, value in credentials_overwrite.items()
-    }
-except Exception as e:
-    raise BackendUtilsError(
-        f"Could not load GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES into a dictionary. {e}"
-    )
 
 # Globus Dashboard Application Credentials
 GLOBUS_DASHBOARD_APPLICATION_ID = os.getenv("GLOBUS_DASHBOARD_APPLICATION_ID")

--- a/inference_gateway/settings.py
+++ b/inference_gateway/settings.py
@@ -16,7 +16,11 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-from inference_gateway.utils import textfield_to_strlist, BackendUtilsError, GlobusCredentials
+from inference_gateway.utils import (
+    BackendUtilsError,
+    GlobusCredentials,
+    textfield_to_strlist,
+)
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -44,11 +48,12 @@ GLOBUS_GROUP_MANAGER_ID = os.getenv("GLOBUS_GROUP_MANAGER_ID", "")
 GLOBUS_GROUP_MANAGER_SECRET = os.getenv("GLOBUS_GROUP_MANAGER_SECRET", "")
 
 # Overwrite Globus Compute credentials (ID/secret) for specific endpoint UUIDs
-credentials_overwrite = json.loads(os.getenv("GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES", "{}"))
+credentials_overwrite = json.loads(
+    os.getenv("GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES", "{}")
+)
 try:
     GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES = {
-        key: GlobusCredentials(**value)
-        for key, value in credentials_overwrite.items()
+        key: GlobusCredentials(**value) for key, value in credentials_overwrite.items()
     }
 except Exception as e:
     raise BackendUtilsError(

--- a/inference_gateway/settings.py
+++ b/inference_gateway/settings.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-from inference_gateway.utils import textfield_to_strlist
+from inference_gateway.utils import textfield_to_strlist, BackendUtilsError, GlobusCredentials
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -43,6 +43,17 @@ SERVICE_ACCOUNT_SECRET = os.getenv("SERVICE_ACCOUNT_SECRET")
 GLOBUS_GROUP_MANAGER_ID = os.getenv("GLOBUS_GROUP_MANAGER_ID", "")
 GLOBUS_GROUP_MANAGER_SECRET = os.getenv("GLOBUS_GROUP_MANAGER_SECRET", "")
 
+# Overwrite Globus Compute credentials (ID/secret) for specific endpoint UUIDs
+credentials_overwrite = json.loads(os.getenv("GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES", "{}"))
+try:
+    GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES = {
+        key: GlobusCredentials(**value)
+        for key, value in credentials_overwrite.items()
+    }
+except Exception as e:
+    raise BackendUtilsError(
+        f"Could not load GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES into a dictionary. {e}"
+    )
 
 # Globus Dashboard Application Credentials
 GLOBUS_DASHBOARD_APPLICATION_ID = os.getenv("GLOBUS_DASHBOARD_APPLICATION_ID")

--- a/inference_gateway/utils.py
+++ b/inference_gateway/utils.py
@@ -1,9 +1,15 @@
 import re
 from typing import List
+from pydantic import BaseModel
 
 
 class BackendUtilsError(Exception):
     pass
+
+
+class GlobusCredentials(BaseModel):
+    client_id: str
+    client_secret: str
 
 
 # Convert a text field into a list of strings

--- a/inference_gateway/utils.py
+++ b/inference_gateway/utils.py
@@ -1,5 +1,6 @@
 import re
 from typing import List
+
 from pydantic import BaseModel
 
 

--- a/resource_server_async/endpoints/globus_compute.py
+++ b/resource_server_async/endpoints/globus_compute.py
@@ -107,7 +107,7 @@ class GlobusComputeEndpoint(BaseEndpoint):
             try:
                 gcc = globus_utils.get_compute_client_from_globus_app(
                     client_id_env_name=self.__config.client_id_env_name,
-                    client_secret_env_name=self.__config.client_secret_env_name
+                    client_secret_env_name=self.__config.client_secret_env_name,
                 )
             except Exception as e:
                 return GetEndpointStatusResponse(error_message=str(e), error_code=500)
@@ -173,7 +173,7 @@ class GlobusComputeEndpoint(BaseEndpoint):
         try:
             gcc = globus_utils.get_compute_client_from_globus_app(
                 client_id_env_name=self.__config.client_id_env_name,
-                client_secret_env_name=self.__config.client_secret_env_name
+                client_secret_env_name=self.__config.client_secret_env_name,
             )
             gce = globus_utils.get_compute_executor(client=gcc)
         except Exception as e:

--- a/resource_server_async/endpoints/globus_compute.py
+++ b/resource_server_async/endpoints/globus_compute.py
@@ -103,7 +103,9 @@ class GlobusComputeEndpoint(BaseEndpoint):
         # Get Globus Compute client
         if gcc is None:
             try:
-                gcc = globus_utils.get_compute_client_from_endpoint_id(self.config.endpoint_uuid)
+                gcc = globus_utils.get_compute_client_from_endpoint_id(
+                    self.config.endpoint_uuid
+                )
             except Exception as e:
                 return GetEndpointStatusResponse(error_message=str(e), error_code=500)
 
@@ -166,7 +168,9 @@ class GlobusComputeEndpoint(BaseEndpoint):
     async def prepare_executor(self, for_batch: bool = False) -> Executor:
         # Get Globus Compute client and executor
         try:
-            gcc = globus_utils.get_compute_client_from_endpoint_id(self.config.endpoint_uuid)
+            gcc = globus_utils.get_compute_client_from_endpoint_id(
+                self.config.endpoint_uuid
+            )
             gce = globus_utils.get_compute_executor(client=gcc)
         except Exception as e:
             raise EndpointError(error_code=500, error_message=str(e)) from e

--- a/resource_server_async/endpoints/globus_compute.py
+++ b/resource_server_async/endpoints/globus_compute.py
@@ -50,6 +50,8 @@ class GlobusComputeEndpointConfig(BaseModel):
     function_uuid: str
     batch_endpoint_uuid: Optional[str] = Field(default=None)
     batch_function_uuid: Optional[str] = Field(default=None)
+    client_id_env_name: Optional[str] = Field(default=None)
+    client_secret_env_name: Optional[str] = Field(default=None)
 
 
 class EndpointError(Exception):
@@ -103,7 +105,10 @@ class GlobusComputeEndpoint(BaseEndpoint):
         # Get Globus Compute client
         if gcc is None:
             try:
-                gcc = globus_utils.get_compute_client_from_globus_app()
+                gcc = globus_utils.get_compute_client_from_globus_app(
+                    client_id_env_name=self.__config.client_id_env_name,
+                    client_secret_env_name=self.__config.client_secret_env_name
+                )
             except Exception as e:
                 return GetEndpointStatusResponse(error_message=str(e), error_code=500)
 
@@ -166,7 +171,10 @@ class GlobusComputeEndpoint(BaseEndpoint):
     async def prepare_executor(self, for_batch: bool = False) -> Executor:
         # Get Globus Compute client and executor
         try:
-            gcc = globus_utils.get_compute_client_from_globus_app()
+            gcc = globus_utils.get_compute_client_from_globus_app(
+                client_id_env_name=self.__config.client_id_env_name,
+                client_secret_env_name=self.__config.client_secret_env_name
+            )
             gce = globus_utils.get_compute_executor(client=gcc)
         except Exception as e:
             raise EndpointError(error_code=500, error_message=str(e)) from e

--- a/resource_server_async/endpoints/globus_compute.py
+++ b/resource_server_async/endpoints/globus_compute.py
@@ -50,8 +50,6 @@ class GlobusComputeEndpointConfig(BaseModel):
     function_uuid: str
     batch_endpoint_uuid: Optional[str] = Field(default=None)
     batch_function_uuid: Optional[str] = Field(default=None)
-    client_id_env_name: Optional[str] = Field(default=None)
-    client_secret_env_name: Optional[str] = Field(default=None)
 
 
 class EndpointError(Exception):
@@ -105,10 +103,7 @@ class GlobusComputeEndpoint(BaseEndpoint):
         # Get Globus Compute client
         if gcc is None:
             try:
-                gcc = globus_utils.get_compute_client_from_globus_app(
-                    client_id_env_name=self.config.client_id_env_name,
-                    client_secret_env_name=self.config.client_secret_env_name,
-                )
+                gcc = globus_utils.get_compute_client_from_endpoint_id(self.config.endpoint_uuid)
             except Exception as e:
                 return GetEndpointStatusResponse(error_message=str(e), error_code=500)
 
@@ -171,10 +166,7 @@ class GlobusComputeEndpoint(BaseEndpoint):
     async def prepare_executor(self, for_batch: bool = False) -> Executor:
         # Get Globus Compute client and executor
         try:
-            gcc = globus_utils.get_compute_client_from_globus_app(
-                client_id_env_name=self.config.client_id_env_name,
-                client_secret_env_name=self.config.client_secret_env_name,
-            )
+            gcc = globus_utils.get_compute_client_from_endpoint_id(self.config.endpoint_uuid)
             gce = globus_utils.get_compute_executor(client=gcc)
         except Exception as e:
             raise EndpointError(error_code=500, error_message=str(e)) from e

--- a/resource_server_async/endpoints/globus_compute.py
+++ b/resource_server_async/endpoints/globus_compute.py
@@ -106,8 +106,8 @@ class GlobusComputeEndpoint(BaseEndpoint):
         if gcc is None:
             try:
                 gcc = globus_utils.get_compute_client_from_globus_app(
-                    client_id_env_name=self.__config.client_id_env_name,
-                    client_secret_env_name=self.__config.client_secret_env_name,
+                    client_id_env_name=self.config.client_id_env_name,
+                    client_secret_env_name=self.config.client_secret_env_name,
                 )
             except Exception as e:
                 return GetEndpointStatusResponse(error_message=str(e), error_code=500)
@@ -172,8 +172,8 @@ class GlobusComputeEndpoint(BaseEndpoint):
         # Get Globus Compute client and executor
         try:
             gcc = globus_utils.get_compute_client_from_globus_app(
-                client_id_env_name=self.__config.client_id_env_name,
-                client_secret_env_name=self.__config.client_secret_env_name,
+                client_id_env_name=self.config.client_id_env_name,
+                client_secret_env_name=self.config.client_secret_env_name,
             )
             gce = globus_utils.get_compute_executor(client=gcc)
         except Exception as e:

--- a/utils/globus_utils.py
+++ b/utils/globus_utils.py
@@ -34,7 +34,7 @@ def get_compute_client_from_endpoint_id(endpoint_id: str) -> Client:
     """
 
     # Overwrite Globus credentials if needed, or use default credentials otherwise
-    if (credentials := settings.GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES.get(endpoint_id)):
+    if credentials := settings.GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES.get(endpoint_id):
         client_id = credentials.client_id
         client_secret = credentials.client_secret
     else:

--- a/utils/globus_utils.py
+++ b/utils/globus_utils.py
@@ -33,23 +33,13 @@ def get_compute_client_from_endpoint_id(endpoint_id: str) -> Client:
     have degraded the performance in the past.
     """
 
-    # Assign default Globus credentials
-    client_id = settings.SERVICE_ACCOUNT_ID
-    client_secret = settings.SERVICE_ACCOUNT_SECRET
-
-    # Overwrite Globus credentials if needed
-    if endpoint_id in settings.GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES:
-        try:
-            client_id = settings.GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES[
-                endpoint_id
-            ].client_id
-            client_secret = settings.GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES[
-                endpoint_id
-            ].client_secret
-        except Exception:
-            raise ResourceServerError(
-                f"Could not retrieve Globus credentials from environment for endpoint {endpoint_id}."
-            )
+    # Overwrite Globus credentials if needed, or use default credentials otherwise
+    if (credentials := settings.GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES.get(endpoint_id)):
+        client_id = credentials.client_id
+        client_secret = credentials.client_secret
+    else:
+        client_id = settings.SERVICE_ACCOUNT_ID
+        client_secret = settings.SERVICE_ACCOUNT_SECRET
 
     # Create and return the Globus Compute client
     return get_compute_client_from_globus_app(

--- a/utils/globus_utils.py
+++ b/utils/globus_utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import time
+import os
 
 import globus_sdk
 from cachetools import TTLCache, cached
@@ -9,6 +10,7 @@ from globus_compute_sdk import Client, Executor
 from globus_compute_sdk.errors import TaskExecutionFailed
 from globus_compute_sdk.sdk.executor import log as EXECUTOR_LOG
 from globus_sdk import TransferClient
+
 
 log = logging.getLogger(__name__)
 
@@ -25,7 +27,7 @@ executor_cache = TTLCache(maxsize=1024, ttl=60 * 10)
 # Get authenticated Compute Client using secret
 # NOTE: Using in-memory TTLCache since Globus Client objects cannot be serialized to Redis
 @cached(cache=TTLCache(maxsize=1024, ttl=60 * 60))
-def get_compute_client_from_globus_app() -> Client:
+def get_compute_client_from_globus_app(client_id_env_name: str = None, client_secret_env_name: str = None) -> Client:
     """
     Create and return an authenticated Compute client using the Globus SDK ClientApp.
 
@@ -37,12 +39,19 @@ def get_compute_client_from_globus_app() -> Client:
         globus_compute_sdk.Client: Compute client to operate Globus Compute
     """
 
+    # Extract alternative Globus credentials
+    try:
+        client_id = os.environ.get(client_id_env_name, None) if client_id_env_name else settings.SERVICE_ACCOUNT_ID
+        client_secret = os.environ.get(client_secret_env_name, None) if client_secret else settings.SERVICE_ACCOUNT_SECRET
+    except Exception as e:
+        raise ResourceServerError("Could not retrieve Globus credentials from environment.")
+
     # Try to create and return the Compute client
     try:
         return Client(
             app=globus_sdk.ClientApp(
-                client_id=settings.SERVICE_ACCOUNT_ID,
-                client_secret=settings.SERVICE_ACCOUNT_SECRET,
+                client_id=client_id,
+                client_secret=client_secret,
             )
         )
     except Exception as e:

--- a/utils/globus_utils.py
+++ b/utils/globus_utils.py
@@ -3,7 +3,6 @@ import logging
 import time
 import os
 
-from django.conf import settings
 import globus_sdk
 from cachetools import TTLCache, cached
 from django.conf import settings

--- a/utils/globus_utils.py
+++ b/utils/globus_utils.py
@@ -11,7 +11,6 @@ from globus_compute_sdk.errors import TaskExecutionFailed
 from globus_compute_sdk.sdk.executor import log as EXECUTOR_LOG
 from globus_sdk import TransferClient
 
-
 log = logging.getLogger(__name__)
 
 

--- a/utils/globus_utils.py
+++ b/utils/globus_utils.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
-import time
 import os
+import time
 
 import globus_sdk
 from cachetools import TTLCache, cached
@@ -26,7 +26,9 @@ executor_cache = TTLCache(maxsize=1024, ttl=60 * 10)
 # Get authenticated Compute Client using secret
 # NOTE: Using in-memory TTLCache since Globus Client objects cannot be serialized to Redis
 @cached(cache=TTLCache(maxsize=1024, ttl=60 * 60))
-def get_compute_client_from_globus_app(client_id_env_name: str = None, client_secret_env_name: str = None) -> Client:
+def get_compute_client_from_globus_app(
+    client_id_env_name: str = None, client_secret_env_name: str = None
+) -> Client:
     """
     Create and return an authenticated Compute client using the Globus SDK ClientApp.
 
@@ -40,10 +42,20 @@ def get_compute_client_from_globus_app(client_id_env_name: str = None, client_se
 
     # Extract alternative Globus credentials
     try:
-        client_id = os.environ.get(client_id_env_name, None) if client_id_env_name else settings.SERVICE_ACCOUNT_ID
-        client_secret = os.environ.get(client_secret_env_name, None) if client_secret_env_name else settings.SERVICE_ACCOUNT_SECRET
-    except Exception as e:
-        raise ResourceServerError("Could not retrieve Globus credentials from environment.")
+        client_id = (
+            os.environ.get(client_id_env_name, None)
+            if client_id_env_name
+            else settings.SERVICE_ACCOUNT_ID
+        )
+        client_secret = (
+            os.environ.get(client_secret_env_name, None)
+            if client_secret_env_name
+            else settings.SERVICE_ACCOUNT_SECRET
+        )
+    except Exception:
+        raise ResourceServerError(
+            "Could not retrieve Globus credentials from environment."
+        )
 
     # Try to create and return the Compute client
     try:

--- a/utils/globus_utils.py
+++ b/utils/globus_utils.py
@@ -24,7 +24,7 @@ executor_cache = TTLCache(maxsize=1024, ttl=60 * 10)
 
 
 # Get authenticated Compute Client from endpoint ID
-def get_compute_client_from_endpoint_id(endpoint_id: str = None) -> Client:
+def get_compute_client_from_endpoint_id(endpoint_id: str) -> Client:
     """
     Extract credentials for target endpoint and submit to
     get_compute_client_from_globus_app with the credentials
@@ -38,7 +38,7 @@ def get_compute_client_from_endpoint_id(endpoint_id: str = None) -> Client:
     client_secret = settings.SERVICE_ACCOUNT_SECRET
 
     # Overwrite Globus credentials if needed
-    if endpoint_id and endpoint_id in settings.GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES:
+    if endpoint_id in settings.GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES:
         try:
             client_id = settings.GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES[
                 endpoint_id

--- a/utils/globus_utils.py
+++ b/utils/globus_utils.py
@@ -77,7 +77,7 @@ def get_compute_client_from_globus_app(
     """
 
     # Use default credentials if not provided
-    # This is in case the function is call outside of get_compute_client_from_endpoint_id
+    # This is in case the function is called outside of get_compute_client_from_endpoint_id
     if client_id is None or client_secret is None:
         client_id = settings.SERVICE_ACCOUNT_ID
         client_secret = settings.SERVICE_ACCOUNT_SECRET

--- a/utils/globus_utils.py
+++ b/utils/globus_utils.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import os
 import time
 
 import globus_sdk
@@ -10,6 +9,7 @@ from globus_compute_sdk import Client, Executor
 from globus_compute_sdk.errors import TaskExecutionFailed
 from globus_compute_sdk.sdk.executor import log as EXECUTOR_LOG
 from globus_sdk import TransferClient
+from typing import Optional
 
 log = logging.getLogger(__name__)
 
@@ -23,11 +23,45 @@ class ResourceServerError(Exception):
 executor_cache = TTLCache(maxsize=1024, ttl=60 * 10)
 
 
+# Get authenticated Compute Client from endpoint ID
+def get_compute_client_from_endpoint_id(
+    endpoint_id: str = None
+) -> Client:
+    """
+    Extract credentials for target endpoint and submit to 
+    get_compute_client_from_globus_app with the credentials
+    to limit the number of cached Globus Clients and Executors.
+    Having too many instances of Executors with the same credentials
+    have degraded the performance in the past.
+    """
+
+    # Assign default Globus credentials
+    client_id = settings.SERVICE_ACCOUNT_ID
+    client_secret = settings.SERVICE_ACCOUNT_SECRET
+
+    # Overwrite Globus credentials if needed
+    if endpoint_id and endpoint_id in settings.GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES:
+        try:
+            client_id = settings.GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES[endpoint_id].client_id
+            client_secret = settings.GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES[endpoint_id].client_secret
+        except Exception:
+            raise ResourceServerError(
+                f"Could not retrieve Globus credentials from environment for endpoint {endpoint_id}."
+            )
+        
+    # Create and return the Globus Compute client
+    return get_compute_client_from_globus_app(
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+
+
 # Get authenticated Compute Client using secret
 # NOTE: Using in-memory TTLCache since Globus Client objects cannot be serialized to Redis
 @cached(cache=TTLCache(maxsize=1024, ttl=60 * 60))
 def get_compute_client_from_globus_app(
-    client_id_env_name: str = None, client_secret_env_name: str = None
+    client_id: Optional[str] = None,
+    client_secret: Optional[str] = None,
 ) -> Client:
     """
     Create and return an authenticated Compute client using the Globus SDK ClientApp.
@@ -40,22 +74,11 @@ def get_compute_client_from_globus_app(
         globus_compute_sdk.Client: Compute client to operate Globus Compute
     """
 
-    # Extract alternative Globus credentials
-    try:
-        client_id = (
-            os.environ.get(client_id_env_name, None)
-            if client_id_env_name
-            else settings.SERVICE_ACCOUNT_ID
-        )
-        client_secret = (
-            os.environ.get(client_secret_env_name, None)
-            if client_secret_env_name
-            else settings.SERVICE_ACCOUNT_SECRET
-        )
-    except Exception:
-        raise ResourceServerError(
-            "Could not retrieve Globus credentials from environment."
-        )
+    # Use default credentials if not provided
+    # This is in case the function is call outside of get_compute_client_from_endpoint_id
+    if client_id is None or client_secret is None:
+        client_id = settings.SERVICE_ACCOUNT_ID
+        client_secret = settings.SERVICE_ACCOUNT_SECRET
 
     # Try to create and return the Compute client
     try:

--- a/utils/globus_utils.py
+++ b/utils/globus_utils.py
@@ -3,6 +3,7 @@ import logging
 import time
 import os
 
+from django.conf import settings
 import globus_sdk
 from cachetools import TTLCache, cached
 from django.conf import settings

--- a/utils/globus_utils.py
+++ b/utils/globus_utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import time
+from typing import Optional
 
 import globus_sdk
 from cachetools import TTLCache, cached
@@ -9,7 +10,6 @@ from globus_compute_sdk import Client, Executor
 from globus_compute_sdk.errors import TaskExecutionFailed
 from globus_compute_sdk.sdk.executor import log as EXECUTOR_LOG
 from globus_sdk import TransferClient
-from typing import Optional
 
 log = logging.getLogger(__name__)
 
@@ -24,11 +24,9 @@ executor_cache = TTLCache(maxsize=1024, ttl=60 * 10)
 
 
 # Get authenticated Compute Client from endpoint ID
-def get_compute_client_from_endpoint_id(
-    endpoint_id: str = None
-) -> Client:
+def get_compute_client_from_endpoint_id(endpoint_id: str = None) -> Client:
     """
-    Extract credentials for target endpoint and submit to 
+    Extract credentials for target endpoint and submit to
     get_compute_client_from_globus_app with the credentials
     to limit the number of cached Globus Clients and Executors.
     Having too many instances of Executors with the same credentials
@@ -42,13 +40,17 @@ def get_compute_client_from_endpoint_id(
     # Overwrite Globus credentials if needed
     if endpoint_id and endpoint_id in settings.GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES:
         try:
-            client_id = settings.GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES[endpoint_id].client_id
-            client_secret = settings.GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES[endpoint_id].client_secret
+            client_id = settings.GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES[
+                endpoint_id
+            ].client_id
+            client_secret = settings.GLOBUS_ENDPOINT_CREDENTIALS_OVERRIDES[
+                endpoint_id
+            ].client_secret
         except Exception:
             raise ResourceServerError(
                 f"Could not retrieve Globus credentials from environment for endpoint {endpoint_id}."
             )
-        
+
     # Create and return the Globus Compute client
     return get_compute_client_from_globus_app(
         client_id=client_id,

--- a/utils/globus_utils.py
+++ b/utils/globus_utils.py
@@ -42,7 +42,7 @@ def get_compute_client_from_globus_app(client_id_env_name: str = None, client_se
     # Extract alternative Globus credentials
     try:
         client_id = os.environ.get(client_id_env_name, None) if client_id_env_name else settings.SERVICE_ACCOUNT_ID
-        client_secret = os.environ.get(client_secret_env_name, None) if client_secret else settings.SERVICE_ACCOUNT_SECRET
+        client_secret = os.environ.get(client_secret_env_name, None) if client_secret_env_name else settings.SERVICE_ACCOUNT_SECRET
     except Exception as e:
         raise ResourceServerError("Could not retrieve Globus credentials from environment.")
 


### PR DESCRIPTION
Adding optional configuration fields in the Globus Compute endpoint adaptor:
- client_id_env_name (None by default)
- client_secret_env_name (None by default)

Those are environment variables that we can add to the `.env` file to overwrite the Globus Compute endpoint credentials used for a given endpoint/model. This will be particularly useful for load testing when we do not want to interfere with the production Globus client running the endpoint. It could also be useful if we end up having multiple clusters with Globus Compute endpoints. It might be more elegant to have separate Globus credentials for different clusters.