### PR TITLE
LCF-11: Add Anthropic Messages and OpenAI Responses support

### DIFF
--- a/resource_server_async/endpoints/direct_api.py
+++ b/resource_server_async/endpoints/direct_api.py
@@ -87,10 +87,12 @@ class DirectAPIEndpoint(BaseEndpoint):
     # Submit task
     async def submit_task(self, data: dict[str, Any]) -> SubmitTaskResult:
         """Submits a single interactive task to the compute resource."""
+        endpoint = data.pop("openai_endpoint", "chat/completions").strip("/")
+        url = f"{self.config.api_url.rstrip('/')}/{endpoint}"
 
         # Submit POST call and wait for the response
         try:
-            response = await self.httpx_client.post(self.config.api_url, data=data)
+            response = await self.httpx_client.post(url, data=data)
         except httpx.HTTPStatusError as e:
             raise EndpointError(
                 f"Upstream endpoint returned {e.response.status_code}: {e.response.content[:256]!r}.",
@@ -98,13 +100,13 @@ class DirectAPIEndpoint(BaseEndpoint):
             )
         except httpx.TimeoutException:
             raise EndpointError(
-                f"Timeout calling {self.config.api_url}.",
+                f"Timeout calling {url}.",
                 status_code=504,
                 info={"timeout": self.config.api_request_timeout},
             )
         except httpx.HTTPError as e:
             raise EndpointError(
-                f"HTTP error calling API at {self.config.api_url}: {e}", status_code=500
+                f"HTTP error calling API at {url}: {e}", status_code=500
             )
 
         return SubmitTaskResult(result=response, task_id=None)
@@ -195,6 +197,8 @@ class DirectAPIEndpoint(BaseEndpoint):
         self, data: dict[str, Any]
     ) -> AsyncGenerator[str, None]:
         """Make a direct API streaming call to the endpoint."""
+        endpoint = data.pop("openai_endpoint", "chat/completions").strip("/")
+        url = f"{self.config.api_url.rstrip('/')}/{endpoint}"
 
         # Create an async HTTPx client
         try:
@@ -204,7 +208,7 @@ class DirectAPIEndpoint(BaseEndpoint):
                 # Create a streaming client
                 async with client.stream(
                     "POST",
-                    self.config.api_url,
+                    url,
                     json=data,
                     headers=self.httpx_client.headers,
                 ) as response:
@@ -212,7 +216,7 @@ class DirectAPIEndpoint(BaseEndpoint):
                     if response.status_code != 200:
                         error_text = await response.aread()
                         raise ValueError(
-                            f"Error: Could not send stream API call to {self.config.api_url}: {error_text.decode().strip()}"
+                            f"Error: Could not send stream API call to {url}: {error_text.decode().strip()}"
                         )
 
                     # Stream the response
@@ -223,12 +227,10 @@ class DirectAPIEndpoint(BaseEndpoint):
         # Errors
         except httpx.TimeoutException:
             raise ValueError(
-                f"Error: Timeout calling stream API at {self.config.api_url} (timeout: {self.config.api_request_timeout})"
+                f"Error: Timeout calling stream API at {url} (timeout: {self.config.api_request_timeout})"
             )
         except httpx.HTTPError as e:
-            raise ValueError(
-                f"Error: HTTP error calling stream API at {self.config.api_url}: {e}"
-            )
+            raise ValueError(f"Error: HTTP error calling stream API at {url}: {e}")
         except Exception as e:
             raise ValueError(f"Error: Unexpected error calling stream API: {e}")
 

--- a/resource_server_async/endpoints/metis.py
+++ b/resource_server_async/endpoints/metis.py
@@ -88,7 +88,6 @@ class MetisEndpoint(DirectAPIEndpoint):
         api_request_data["stream"] = False
 
         # Remove internal field that shouldn't be sent to Metis
-        api_request_data.pop("openai_endpoint", None)
         api_request_data.pop("api_port", None)
 
         # Log model and Metis endpoint ID
@@ -112,7 +111,6 @@ class MetisEndpoint(DirectAPIEndpoint):
         api_request_data["stream"] = True
 
         # Remove internal field that shouldn't be sent to Metis
-        api_request_data.pop("openai_endpoint", None)
         api_request_data.pop("api_port", None)
 
         # Log model and Metis endpoint ID

--- a/resource_server_async/globus_utils.py
+++ b/resource_server_async/globus_utils.py
@@ -15,7 +15,7 @@ from globus_compute_sdk.sdk.executor import log as EXECUTOR_LOG
 from globus_sdk import TransferClient
 
 from resource_server_async.cache import cache_item, get_item_from_cache
-from resource_server_async.errors import EndpointError, RequestTimeout
+from resource_server_async.errors import EndpointError, EndpointNotFound, RequestTimeout
 from resource_server_async.schemas.endpoints import SubmitTaskResult
 
 log = logging.getLogger(__name__)
@@ -238,6 +238,11 @@ async def submit_and_get_result(
             "TimeoutError while attempting to access compute resources. Please try again later.",
             info={"task_id": task_id},
         )
+    except Exception as exc:
+        error_msg = str(exc)
+        if "API request" in error_msg and "Not Found" in error_msg:
+            raise EndpointNotFound("The upstream API returned a 'Not Found' response.")
+        raise
 
     result = unwrap_json(result)
 

--- a/resource_server_async/schemas/anthropic_messages.py
+++ b/resource_server_async/schemas/anthropic_messages.py
@@ -1,0 +1,37 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class BaseModelExtraAllow(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+class AnthropicMessage(BaseModelExtraAllow):
+    role: Literal["user", "assistant"]
+    content: str | list[dict[str, Any]]
+
+
+class AnthropicSystemBlock(BaseModelExtraAllow):
+    type: str | None = None
+    text: str | None = None
+
+
+class AnthropicMessagesPydantic(BaseModelExtraAllow):
+    openai_endpoint: Literal["messages"] = "messages"
+
+    model: str = Field(..., min_length=1)
+    messages: list[AnthropicMessage]
+    max_tokens: int = Field(..., ge=1)
+    system: str | list[AnthropicSystemBlock] | None = None
+    metadata: dict[str, Any] | None = None
+    stop_sequences: list[str] | None = None
+    stream: bool | None = Field(default=False)
+    temperature: float | None = Field(default=None, ge=0, le=1)
+    top_k: int | None = Field(default=None, ge=0)
+    top_p: float | None = Field(default=None, ge=0, le=1)
+    tool_choice: dict[str, Any] | None = None
+    tools: list[dict[str, Any]] | None = None
+    thinking: dict[str, Any] | None = None
+    service_tier: str | None = None
+    user: str | None = None

--- a/resource_server_async/schemas/openai_responses.py
+++ b/resource_server_async/schemas/openai_responses.py
@@ -1,0 +1,45 @@
+from typing import Any, List, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class BaseModelExtraAllow(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+class ResponsesInputItem(BaseModelExtraAllow):
+    type: str | None = None
+    role: str | None = None
+    content: Any | None = None
+
+
+class ResponsesReasoning(BaseModelExtraAllow):
+    effort: str | None = None
+    summary: str | None = None
+
+
+class ResponsesTextFormat(BaseModelExtraAllow):
+    format: dict[str, Any] | None = None
+
+
+# https://platform.openai.com/docs/api-reference/responses/create
+class OpenAIResponsesPydantic(BaseModelExtraAllow):
+    openai_endpoint: Literal["responses"] = "responses"
+    model: str = Field(..., min_length=1)
+    input: str | List[ResponsesInputItem] | List[dict[str, Any]]
+    instructions: str | None = None
+    max_output_tokens: int | None = Field(default=None, ge=0)
+    metadata: dict[str, Any] | None = None
+    parallel_tool_calls: bool | None = None
+    previous_response_id: str | None = None
+    reasoning: ResponsesReasoning | None = None
+    store: bool | None = None
+    stream: bool | None = Field(default=False)
+    temperature: float | None = Field(default=None, ge=0, le=2)
+    text: ResponsesTextFormat | None = None
+    tool_choice: str | dict[str, Any] | None = None
+    tools: List[dict[str, Any]] | None = None
+    top_p: float | None = Field(default=None, ge=0, le=1)
+    truncation: str | None = None
+    include: List[str] | None = None
+    user: str | None = None

--- a/resource_server_async/schemas/structured_logs.py
+++ b/resource_server_async/schemas/structured_logs.py
@@ -249,9 +249,26 @@ def _get_int(data: dict[str, Any], key: str) -> int | None:
 
 def extract_usage(result: str) -> UsageTokens:
     """
-    Attempt to parse token usage counts from a JSON response body containing
-    'usage' or 'metrics' keys with 'prompt_tokens', 'completion_tokens',
-    'total_tokens'.
+    Attempt to parse token usage counts from a JSON response body.
+
+    Handles three shapes:
+
+    - OpenAI chat/completions, completions, embeddings::
+        {"usage": {"prompt_tokens": int,
+                   "completion_tokens": int,
+                   "total_tokens": int}}
+    - OpenAI Responses API::
+        {"usage": {"input_tokens": int,
+                   "output_tokens": int,
+                   "total_tokens": int}}
+    - Anthropic Messages API::
+        {"usage": {"input_tokens": int,
+                   "output_tokens": int}}  # no total_tokens
+
+    Also honours a top-level ``metrics.total_tokens`` if present (the compute
+    function attaches that to non-streaming responses).  When the upstream
+    only reports input/output tokens, total_tokens is computed as their sum
+    so token-rate-limit accounting still works.
     """
     try:
         data = json.loads(result)
@@ -264,9 +281,21 @@ def extract_usage(result: str) -> UsageTokens:
     usage = _get_dict(data, "usage")
     metrics = _get_dict(data, "metrics")
 
+    prompt_tokens = _get_int(usage, "prompt_tokens") or _get_int(usage, "input_tokens")
+    completion_tokens = _get_int(usage, "completion_tokens") or _get_int(
+        usage, "output_tokens"
+    )
+    total_tokens = _get_int(usage, "total_tokens") or _get_int(metrics, "total_tokens")
+
+    # Anthropic does not report total_tokens; derive it from input/output so
+    # TPM accounting still charges the right amount.
+    if total_tokens is None and (
+        prompt_tokens is not None or completion_tokens is not None
+    ):
+        total_tokens = (prompt_tokens or 0) + (completion_tokens or 0)
+
     return UsageTokens(
-        prompt_tokens=_get_int(usage, "prompt_tokens"),
-        completion_tokens=_get_int(usage, "completion_tokens"),
-        total_tokens=_get_int(usage, "total_tokens")
-        or _get_int(metrics, "total_tokens"),
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
     )

--- a/resource_server_async/services.py
+++ b/resource_server_async/services.py
@@ -8,11 +8,15 @@ from django.http import StreamingHttpResponse
 from django.utils import timezone
 
 from resource_server_async.globus_utils import get_transfer_client
+from resource_server_async.schemas.anthropic_messages import AnthropicMessagesPydantic
 from resource_server_async.schemas.openai_chat_completions import (
     OpenAIChatCompletionsPydantic,
 )
 from resource_server_async.schemas.openai_completions import OpenAICompletionsPydantic
 from resource_server_async.schemas.openai_embeddings import OpenAIEmbeddingsPydantic
+from resource_server_async.schemas.openai_responses import (
+    OpenAIResponsesPydantic,
+)
 from resource_server_async.schemas.structured_logs import (
     RequestLogPydantic,
 )
@@ -47,7 +51,11 @@ from .schemas.endpoints import (
 from .schemas.structured_logs import UserPydantic
 
 OpenAIRequestPayload = (
-    OpenAIChatCompletionsPydantic | OpenAICompletionsPydantic | OpenAIEmbeddingsPydantic
+    OpenAIChatCompletionsPydantic
+    | OpenAICompletionsPydantic
+    | OpenAIEmbeddingsPydantic
+    | OpenAIResponsesPydantic
+    | AnthropicMessagesPydantic
 )
 
 logger = logging.getLogger(__name__)
@@ -229,6 +237,12 @@ async def submit_openai_inference_request(
     elif isinstance(payload, OpenAIEmbeddingsPydantic):
         stream = False
         prompt = payload.input
+    elif isinstance(payload, OpenAIResponsesPydantic):
+        stream = payload.stream or False
+        prompt = payload.model_dump(include={"input"}, mode="json")["input"]
+    elif isinstance(payload, AnthropicMessagesPydantic):
+        stream = payload.stream or False
+        prompt = payload.model_dump(include={"messages"}, mode="json")["messages"]
     else:
         raise ValueError(f"Invalid {payload=}")
 

--- a/resource_server_async/views/__init__.py
+++ b/resource_server_async/views/__init__.py
@@ -1,5 +1,6 @@
 from ninja import Router
 
+from .anthropic import router as anthropic_router
 from .batch import router as batch_router
 from .core import router as core_router
 from .data import router as data_router
@@ -8,6 +9,7 @@ from .sam3 import router as sam3_router
 from .streaming import router as streaming_router
 
 router = Router()
+router.add_router("/", anthropic_router, tags=["anthropic"])
 router.add_router("/", batch_router, tags=["batch"])
 router.add_router("/", core_router, tags=["core"])
 router.add_router("/data", data_router, tags=["data"])

--- a/resource_server_async/views/anthropic.py
+++ b/resource_server_async/views/anthropic.py
@@ -1,0 +1,34 @@
+import logging
+from typing import Any
+
+from ninja import Router
+
+from ..errors import UnsupportedEndpoint
+from ..logging import get_request_context
+from ..schemas.anthropic_messages import AnthropicMessagesPydantic
+from ..schemas.auth import AuthedRequest
+from ..services import (
+    submit_openai_inference_request,
+)
+
+router = Router()
+log = logging.getLogger(__name__)
+
+
+@router.post("/{cluster_name}/{framework}/v1/messages")
+async def create_message(
+    request: AuthedRequest,
+    cluster_name: str,
+    framework: str,
+    payload: AnthropicMessagesPydantic,
+) -> Any:
+
+    if payload.stream:
+        raise UnsupportedEndpoint(
+            "Streaming is not supported for the Anthropic Messages API on "
+            "this gateway. Re-issue the request with 'stream': false."
+        )
+
+    return await submit_openai_inference_request(
+        get_request_context(), cluster_name, framework, payload
+    )

--- a/resource_server_async/views/openai.py
+++ b/resource_server_async/views/openai.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from ninja import Router
 
+from ..errors import UnsupportedEndpoint
 from ..logging import get_request_context
 from ..schemas.auth import AuthedRequest
 from ..schemas.openai_chat_completions import (
@@ -10,6 +11,9 @@ from ..schemas.openai_chat_completions import (
 )
 from ..schemas.openai_completions import OpenAICompletionsPydantic
 from ..schemas.openai_embeddings import OpenAIEmbeddingsPydantic
+from ..schemas.openai_responses import (
+    OpenAIResponsesPydantic,
+)
 from ..services import (
     submit_openai_inference_request,
 )
@@ -49,6 +53,23 @@ async def create_embedding(
     framework: str,
     payload: OpenAIEmbeddingsPydantic,
 ) -> Any:
+    return await submit_openai_inference_request(
+        get_request_context(), cluster_name, framework, payload
+    )
+
+
+@router.post("/{cluster_name}/{framework}/v1/responses")
+async def create_response(
+    request: AuthedRequest,
+    cluster_name: str,
+    framework: str,
+    payload: OpenAIResponsesPydantic,
+) -> Any:
+    if payload.stream:
+        raise UnsupportedEndpoint(
+            "Streaming is not supported for the OpenAI Responses API on this "
+            "gateway. Re-issue the request with 'stream': false."
+        )
     return await submit_openai_inference_request(
         get_request_context(), cluster_name, framework, payload
     )


### PR DESCRIPTION
This PR adds support for OpenAI Responses and Anthropic Messages APIs by a straightforward extension of the views and schemas.

Notably, `"stream": true` is **rejected** by the gateway for Responses and Messages, because the gateway streaming chunk aggregator is designed to work with Chat Completions specifically.  This restriction can be lifted after we migrate away from the Globus Compute + Streaming callback architecture for inference.

The TPM accounting logic was updated to work with all 3 styles of LLM inference.  I manually verified that `total_tokens` is populated (and therefore charged to the user's rate limit) for all endpoints:

- Metis Responses
- Metis Chat Completions
- Sophia Responses
- Sophia Messages
- Sophia Chat Completions

Our Metis endpoint configurations up to date have hard-coded the `chat/completions` path in the config API URL.  To handle this, I have updated the logic in `endpoints/direct_api.py` to deal with the OpenAI endpoint and pass it through the request URL. 

🚨 **This change requires the endpoint fixtures for Metis to be updated as follows:**

```
"api_url": "https://metis.alcf.anl.gov/v1"
```

Test `curl` commands:


```bash
# Test Anthropic Messages API:
curl https://dev-inference-api.cels.anl.gov/resource_server/sophia/vllm/v1/messages -XPOST -H "Authorization: Bearer $token" -d '{"messages": [{"role": "user", "content": "Hello!"}], "model": "openai/gpt-oss-120b", "max_tokens": 1024}' | jq


# Test OpenAI Responses API:
curl https://dev-inference-api.cels.anl.gov/resource_server/sophia/vllm/v1/responses -XPOST -H "Authorization: Bearer $token" -d '{"input": [{"role": "user", "content": "Hello!"}], "model": "openai/gpt-oss-120b" }' | jq


# On Metis:
curl https://dev-inference-api.cels.anl.gov/resource_server/metis/api/v1/responses -XPOST -H "Authorization: Bearer $token" -d '{"input": [{"role": "user", "content": "Hello! What are you?"}], "messages": [], "model": "gpt-oss-120b"}' | jq
```