### PR TITLE
co: oci builds

### DIFF
--- a/.github/workflows/oci-builds.yml
+++ b/.github/workflows/oci-builds.yml
@@ -1,0 +1,39 @@
+name: OCI Builds
+
+on: [push]
+
+jobs:
+  oci-builds:
+    name: OCI Builds
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "pyproject.toml"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - name: Sync environment
+        run: uv sync --locked --all-extras --dev
+      - name: Build inference-gateway
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: inference-api
+          tags: ${{ github.sha }}
+          containerfiles: |
+            ./deploy/docker/Dockerfile
+          oci: true
+      - name: Publish to GoHarbor
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: ghcr.io/${{ github.repository_owner }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}

--- a/.github/workflows/oci-builds.yml
+++ b/.github/workflows/oci-builds.yml
@@ -1,6 +1,9 @@
 name: OCI Builds
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   oci-builds:

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -10,6 +10,9 @@ ENV DJANGO_SETTINGS_MODULE=inference_gateway.settings
 # Set work directory
 WORKDIR /app
 
+# Copy project files
+COPY . .
+
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -21,9 +24,6 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --locked --all-extras --dev --no-install-project
-
-# Copy project files
-COPY . .
 
 # Sync project
 RUN --mount=type=cache,target=/root/.cache/uv \


### PR DESCRIPTION
Adds a CI workflow to build `inference-api` images with the resource server using `buildah`.

Fixes LCF-40.