### PR TITLE
Fix torn writes when logging large prompts/results.

### DIFF
--- a/deploy/gateway_async.service
+++ b/deploy/gateway_async.service
@@ -10,7 +10,7 @@ Environment=PATH=/home/webportal/inference-gateway/.venv/bin/
 Environment="PYTHONUNBUFFERED=1"
 ExecStartPre=+/bin/mkdir -p /var/log/inference-service
 ExecStartPre=+/bin/chown webportal:webportal /var/log/inference-service
-ExecStart=/bin/sh -c '/home/webportal/inference-gateway/.venv/bin/gunicorn -c deploy/gateway_asgi.config.py inference_gateway.asgi:application 2>>/var/log/inference-service/error.log | /usr/bin/rotatelogs -n 99999 /var/log/inference-service/out.log 200M 1440'
+ExecStart=/bin/sh -c '/home/webportal/inference-gateway/.venv/bin/gunicorn -c deploy/gateway_asgi.config.py inference_gateway.asgi:application 2>>/var/log/inference-service/error.log | /usr/bin/rotatelogs -l -f -L /var/log/inference-service/out.log /var/log/inference-service/out.log.%%Y-%%m-%%d 86400'
 ExecReload=/bin/kill -s HUP $MAINPID
 KillMode=mixed
 TimeoutStopSec=5

--- a/inference_gateway/settings.py
+++ b/inference_gateway/settings.py
@@ -322,6 +322,9 @@ METIS_API_TOKENS = os.environ.get("METIS_API_TOKENS", "{}")
 # inference_data_staging Globus Guest Collection:
 DATA_STAGING_GLOBUS_COLLECTION_ID = "96c7390b-a3e8-4dd4-a327-1af7d143283e"
 
+PROMPT_STORAGE_DIR = Path(os.environ.get("PROMPT_STORAGE_DIR", "prompt-records"))
+PROMPT_STORAGE_DIR.mkdir(exist_ok=True, parents=True)
+
 
 # --- Optional: Grafana Admin Credentials (for Docker setup) ---
 # GF_SECURITY_ADMIN_USER=admin

--- a/resource_server_async/globus_utils.py
+++ b/resource_server_async/globus_utils.py
@@ -15,7 +15,7 @@ from globus_compute_sdk.sdk.executor import log as EXECUTOR_LOG
 from globus_sdk import TransferClient
 
 from resource_server_async.cache import cache_item, get_item_from_cache
-from resource_server_async.errors import EndpointError, EndpointNotFound, RequestTimeout
+from resource_server_async.errors import EndpointError, RequestTimeout
 from resource_server_async.schemas.endpoints import SubmitTaskResult
 
 log = logging.getLogger(__name__)
@@ -240,8 +240,8 @@ async def submit_and_get_result(
         )
     except Exception as exc:
         error_msg = str(exc)
-        if "API request" in error_msg and "Not Found" in error_msg:
-            raise EndpointNotFound("The upstream API returned a 'Not Found' response.")
+        if "API request" in error_msg:
+            raise EndpointError(error_msg)
         raise
 
     result = unwrap_json(result)

--- a/resource_server_async/logging.py
+++ b/resource_server_async/logging.py
@@ -62,7 +62,8 @@ def initialize_access_log(request: HttpRequest) -> AccessLogPydantic:
     )
 
 
-def _write_logs_sync(
+@sync_to_async(thread_sensitive=False)
+def write_logs(
     context: RequestContext, response: HttpResponse | StreamingHttpResponse
 ) -> None:
     context.access_log.emit(context.user, response)
@@ -77,9 +78,6 @@ def _write_logs_sync(
 
         if not isinstance(response, StreamingHttpResponse):
             async_to_sync(context.request_log.emit_metrics)()
-
-
-write_logs = sync_to_async(_write_logs_sync, thread_sensitive=False)
 
 
 class AccessLogMiddleware:

--- a/resource_server_async/logging.py
+++ b/resource_server_async/logging.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from inspect import iscoroutinefunction
 from logging import getLogger
 
-from asgiref.sync import markcoroutinefunction
+from asgiref.sync import async_to_sync, markcoroutinefunction, sync_to_async
 from django.http import HttpRequest, HttpResponse, StreamingHttpResponse
 
 from resource_server_async.schemas.structured_logs import (
@@ -62,7 +62,7 @@ def initialize_access_log(request: HttpRequest) -> AccessLogPydantic:
     )
 
 
-async def write_logs(
+def _write_logs_sync(
     context: RequestContext, response: HttpResponse | StreamingHttpResponse
 ) -> None:
     context.access_log.emit(context.user, response)
@@ -76,7 +76,10 @@ async def write_logs(
         context.request_log.emit(body, response.status_code)
 
         if not isinstance(response, StreamingHttpResponse):
-            await context.request_log.emit_metrics()
+            async_to_sync(context.request_log.emit_metrics)()
+
+
+write_logs = sync_to_async(_write_logs_sync, thread_sensitive=False)
 
 
 class AccessLogMiddleware:

--- a/resource_server_async/schemas/structured_logs.py
+++ b/resource_server_async/schemas/structured_logs.py
@@ -3,11 +3,20 @@ import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from logging import getLogger
-from typing import Any
+from pathlib import Path
+from typing import Annotated, Any
 from uuid import UUID
 
+from django.conf import settings
 from django.http import HttpResponse, StreamingHttpResponse
-from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PlainSerializer,
+    computed_field,
+    field_validator,
+)
 
 _user_slog = getLogger("resource_server_async.structured.user")
 _access_slog = getLogger("resource_server_async.structured.access_log")
@@ -15,6 +24,17 @@ _request_slog = getLogger("resource_server_async.structured.request_log")
 _request_metrics_slog = getLogger("resource_server_async.structured.request_metrics")
 _batch_slog = getLogger("resource_server_async.structured.batch_log")
 _batch_metrics_slog = getLogger("resource_server_async.structured.batch_metrics")
+
+MAX_LEN = 1800
+
+
+def _truncate_str(value: str) -> str:
+    if len(value) <= MAX_LEN:
+        return value
+    return value[:MAX_LEN] + f"...<truncated {len(value) - MAX_LEN} chars>"
+
+
+TruncatedStr = Annotated[str, PlainSerializer(_truncate_str)]
 
 
 @dataclass(slots=True)
@@ -53,7 +73,7 @@ class AccessLogPydantic(BaseModel):
     origin_ip: str | None
     timestamp_response: datetime | None = None
     status_code: int | None = None
-    error: str | None = None
+    error: TruncatedStr | None = None
     authorized_groups: str | None = None
 
     def emit(
@@ -88,16 +108,19 @@ class RequestLogPydantic(BaseModel):
     framework: str
     model: str
     openai_endpoint: str
-    prompt: str
+    prompt: TruncatedStr
     timestamp_compute_request: datetime
     status_code: int | None = None
     timestamp_compute_response: datetime | None = None
-    result: str | None = None
+    result: TruncatedStr | None = None
     task_uuid: str | None = None
 
     def emit(self, response_body: str, status_code: int | None) -> None:
         """
         Log an LLM prompt request and results.
+
+        Large prompt/result payloads exceeding MAX_LEN will be written to the
+        filesystem.
         """
         self.status_code = status_code
         self.result = response_body
@@ -109,6 +132,16 @@ class RequestLogPydantic(BaseModel):
             "created",
             extra=self.model_dump(mode="json"),
         )
+
+        if len(self.prompt) > MAX_LEN or len(self.result) > MAX_LEN:
+            full = {"prompt": self.prompt, "result": self.result}
+            prompt_dir = Path(settings.PROMPT_STORAGE_DIR)
+            prompt_file = Path(prompt_dir) / f"{self.id}.json"
+            try:
+                prompt_file.write_text(json.dumps(full, indent=2))
+            except FileNotFoundError:
+                prompt_file.parent.mkdir(parents=True, exist_ok=True)
+                prompt_file.write_text(json.dumps(full, indent=2))
 
     async def emit_metrics(self, usage: UsageTokens | None = None) -> None:
         """
@@ -192,7 +225,7 @@ class BatchLogPydantic(BaseModel):
 
     globus_batch_uuid: str | None = None
     task_ids: str | None = None
-    result: str | None = Field(default="")
+    result: TruncatedStr | None = Field(default="")
 
     status: str | None = None
     in_progress_at: datetime | None = None


### PR DESCRIPTION
- Update rotation logic to daily with `out.log` symlink and timestamped file suffixes. Files will only rotate once at midnight, regardless of size.  This alone greatly reduces the probability that a very large logging event will get torn between two files on rotation.  And `tail -f out.log` will now always correctly follow the latest log file, even after a rotation at midnight.
- Truncate long prompts/results before serialization. Set ~1800 per field limit.  Logic is that 2 large fields (prompt+result) on RequestLog will still fit within the 4k PIPE_BUF size limit on linux where atomic writes are guaranteed.
- Save large prompt/result pairs to {PROMPT_STORAGE_DIR}/{request_id}.json
- Change write_logs() logic to run under sync_to_async() threadpool to reduce impact of slow logging/prompt dumping on the event loop.