### PR TITLE
Slight log enhancements

### DIFF
--- a/alcf_ai/src/alcf_ai/cli.py
+++ b/alcf_ai/src/alcf_ai/cli.py
@@ -81,6 +81,7 @@ def chat(
     oai = client.clusters(cluster).openai
 
     response: Any
+    all_chunks = []
     if stream:
         collected = []
         with console.status("[dim]Thinking…[/dim]", spinner="dots"):
@@ -93,13 +94,14 @@ def chat(
             )
 
         for chunk in response:
+            all_chunks.append(chunk)
             if chunk.choices and chunk.choices[0].delta.content:
                 token = chunk.choices[0].delta.content
                 print(token, end="")
                 collected.append(token)
 
         if not collected:
-            print(str(response))
+            print(all_chunks)
 
         print("")
 

--- a/deploy/gateway_async.service
+++ b/deploy/gateway_async.service
@@ -10,7 +10,7 @@ Environment=PATH=/home/webportal/inference-gateway/.venv/bin/
 Environment="PYTHONUNBUFFERED=1"
 ExecStartPre=+/bin/mkdir -p /var/log/inference-service
 ExecStartPre=+/bin/chown webportal:webportal /var/log/inference-service
-ExecStart=/bin/sh -c '/home/webportal/inference-gateway/.venv/bin/gunicorn -c deploy/gateway_asgi.config.py inference_gateway.asgi:application 2>>/var/log/inference-service/error.log | /usr/bin/rotatelogs -l -f -L /var/log/inference-service/out.log /var/log/inference-service/out.log.%%Y-%%m-%%d 86400'
+ExecStart=/bin/sh -c '/home/webportal/inference-gateway/.venv/bin/gunicorn -c deploy/gateway_asgi.config.py inference_gateway.asgi:application 2>>/var/log/inference-service/error.log | /usr/bin/rotatelogs -c -f -L /var/log/inference-service/out.log /var/log/inference-service/out.log.%%Y-%%m-%%d 86400'
 ExecReload=/bin/kill -s HUP $MAINPID
 KillMode=mixed
 TimeoutStopSec=5


### PR DESCRIPTION
- alcf-ai client: print chat streaming errors more clearly to user
- Drop `-l` (local) flag from rotatelogs, so that rotation happens at midnight UTC instead of midnight Chicago time.  This will keep the timestamps in the log lines aligned with the file names.
- Add `-c` (create) flag to rotatelogs, so that a new empty file is always created at midnight instead of waiting for the first log line to arrive.