### PR TITLE
docs: update repo url for hrefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-![Build](https://github.com/auroraGPT-ANL/inference-gateway/workflows/Django/badge.svg)
+![Build](https://github.com/argonne-lcf/FIRST/workflows/Django/badge.svg)
 
 # FIRST
 
@@ -17,16 +17,16 @@ The Inference Gateway consists of several components:
 
 ## Documentation
 
-📚 **Complete documentation is available at: [https://auroragpt-anl.github.io/inference-gateway/](https://auroragpt-anl.github.io/inference-gateway/)**
+📚 **Complete documentation is available at: [https://argonne-lcf.github.io/FIRST/](https://argonne-lcf.github.io/FIRST/)**
 
 ### Quick Links
 
-- **[Administrator Guide](https://auroragpt-anl.github.io/inference-gateway/admin-guide/)** - Setup and deployment instructions
-  - [Docker Deployment](https://auroragpt-anl.github.io/inference-gateway/admin-guide/gateway-setup/docker/)
-  - [Bare Metal Setup](https://auroragpt-anl.github.io/inference-gateway/admin-guide/gateway-setup/bare-metal/)
-  - [Inference Backend Setup](https://auroragpt-anl.github.io/inference-gateway/admin-guide/inference-setup/)
+- **[Administrator Guide](https://argonne-lcf.github.io/FIRST/admin-guide/)** - Setup and deployment instructions
+  - [Docker Deployment](https://argonne-lcf.github.io/FIRST/admin-guide/gateway-setup/docker/)
+  - [Bare Metal Setup](https://argonne-lcf.github.io/FIRST/admin-guide/gateway-setup/bare-metal/)
+  - [Inference Backend Setup](https://argonne-lcf.github.io/FIRST/admin-guide/inference-setup/)
   
-- **[User Guide](https://auroragpt-anl.github.io/inference-gateway/user-guide/)** - How to use the inference API
+- **[User Guide](https://argonne-lcf.github.io/FIRST/user-guide/)** - How to use the inference API
 
 - **[Example Deployment](https://github.com/argonne-lcf/inference-endpoints)** - ALCF production deployment
 

--- a/compute-endpoints/README.md
+++ b/compute-endpoints/README.md
@@ -324,7 +324,7 @@ squeue -j <job-id>  # Slurm
 
 For ALCF-specific issues, contact ALCF Support.
 
-For FIRST Gateway issues, open an issue on [GitHub](https://github.com/auroraGPT-ANL/inference-gateway/issues).
+For FIRST Gateway issues, open an issue on [GitHub](https://github.com/argonne-lcf/FIRST/issues).
 
 For Globus Compute issues, see [Globus Compute Documentation](https://globus-compute.readthedocs.io/).
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -148,7 +148,7 @@ Documentation automatically deploys to GitHub Pages when you push to `main`:
    git push origin main
    ```
 3. GitHub Actions builds and deploys automatically
-4. View at: https://auroragpt-anl.github.io/inference-gateway/
+4. View at: https://argonne-lcf.github.io/FIRST/
 
 ### Manual Deployment
 

--- a/docs/admin-guide/deployment/kubernetes.md
+++ b/docs/admin-guide/deployment/kubernetes.md
@@ -38,9 +38,9 @@ For now, please use one of these deployment methods:
 
 To be notified when Kubernetes support is available:
 
-- :star: Star the [GitHub repository](https://github.com/auroraGPT-ANL/inference-gateway)
+- :star: Star the [GitHub repository](https://github.com/argonne-lcf/FIRST)
 - Watch the repository for releases
-- Check the [releases page](https://github.com/auroraGPT-ANL/inference-gateway/releases)
+- Check the [releases page](https://github.com/argonne-lcf/FIRST/releases)
 
 ## Contribute
 

--- a/docs/admin-guide/deployment/production.md
+++ b/docs/admin-guide/deployment/production.md
@@ -10,7 +10,7 @@ Restrict access to:
  - specific identity providers (`AUTHORIZED_IDP_DOMAINS` and Globus High-Assurance policy)
  - specific groups (`GLOBUS_GROUPS` and `AUTHORIZED_GROUPS_PER_IDP`)
 
-See [example environment file](https://github.com/auroraGPT-ANL/inference-gateway/blob/main/env.example) and [Globus Setup](../gateway-setup/globus-setup.md) for more details.
+See [example environment file](https://github.com/argonne-lcf/FIRST/blob/main/env.example) and [Globus Setup](../gateway-setup/globus-setup.md) for more details.
 
 ### Secrets Management
 

--- a/docs/admin-guide/gateway-setup/bare-metal.md
+++ b/docs/admin-guide/gateway-setup/bare-metal.md
@@ -43,7 +43,7 @@ uv --version
 ## Step 3: Clone and Setup Project
 
 ```bash
-git clone https://github.com/auroraGPT-ANL/inference-gateway.git
+git clone https://github.com/argonne-lcf/FIRST.git
 cd inference-gateway
 
 # Install dependencies
@@ -122,7 +122,7 @@ redis-cli ping
 
 ## Step 6: Configure Environment
 
-Create a `.env` file from the [example environment file](https://github.com/auroraGPT-ANL/inference-gateway/blob/main/env.example) and customize the `.env` file following the instructions found in the example file:
+Create a `.env` file from the [example environment file](https://github.com/argonne-lcf/FIRST/blob/main/env.example) and customize the `.env` file following the instructions found in the example file:
 ```bash
 cp env.example .env
 ```

--- a/docs/admin-guide/gateway-setup/configuration.md
+++ b/docs/admin-guide/gateway-setup/configuration.md
@@ -4,7 +4,7 @@ This page documents all environment variables and configuration options for the 
 
 ## Environment Variables
 
-All configuration is done through environment variables, typically stored in a `.env` file. See [example environment file](https://github.com/auroraGPT-ANL/inference-gateway/blob/main/env.example) to get started and see definition examples of all variables.
+All configuration is done through environment variables, typically stored in a `.env` file. See [example environment file](https://github.com/argonne-lcf/FIRST/blob/main/env.example) to get started and see definition examples of all variables.
 
 ### Core Django Settings
 

--- a/docs/admin-guide/gateway-setup/docker.md
+++ b/docs/admin-guide/gateway-setup/docker.md
@@ -12,13 +12,13 @@ This guide shows you how to deploy the FIRST Inference Gateway using Docker and 
 ## Step 1: Clone the Repository
 
 ```bash
-git clone https://github.com/auroraGPT-ANL/inference-gateway.git
+git clone https://github.com/argonne-lcf/FIRST.git
 cd inference-gateway
 ```
 
 ## Step 2: Configure Environment
 
-Create a `.env` file from the [example environment file](https://github.com/auroraGPT-ANL/inference-gateway/blob/main/env.example) and customize the `.env` file following the instructions found in the example file:
+Create a `.env` file from the [example environment file](https://github.com/argonne-lcf/FIRST/blob/main/env.example) and customize the `.env` file following the instructions found in the example file:
 ```bash
 cp env.example .env
 ```

--- a/docs/admin-guide/monitoring.md
+++ b/docs/admin-guide/monitoring.md
@@ -313,7 +313,7 @@ When issues occur, work through this checklist:
 If you're still stuck:
 
 1. **Check documentation**: Review the relevant setup guides
-2. **Search issues**: Look for similar issues on [GitHub](https://github.com/auroraGPT-ANL/inference-gateway/issues)
+2. **Search issues**: Look for similar issues on [GitHub](https://github.com/argonne-lcf/FIRST/issues)
 3. **Enable debug logging**: Set `DEBUG=True` temporarily
 4. **Collect information**:
    - Version information

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,13 +48,13 @@ For a production example, see the [ALCF Inference Endpoints](https://github.com/
 
 ## Getting Help
 
-- **GitHub**: [Report issues or contribute](https://github.com/auroraGPT-ANL/inference-gateway)
+- **GitHub**: [Report issues or contribute](https://github.com/argonne-lcf/FIRST)
 - **Citation**: [Research Paper](reference/citation.md)
 - **API Reference**: [Complete API documentation](reference/api.md)
 
 ## License
 
-This project is licensed under the Apache License 2.0. See the [LICENSE](https://github.com/auroraGPT-ANL/inference-gateway/blob/main/LICENSE) file for details.
+This project is licensed under the Apache License 2.0. See the [LICENSE](https://github.com/argonne-lcf/FIRST/blob/main/LICENSE) file for details.
 
 ---
 

--- a/docs/reference/citation.md
+++ b/docs/reference/citation.md
@@ -35,5 +35,5 @@ For more information about FIRST and related work:
 
 - [Research Paper](https://doi.org/10.1145/3731599.3767346)
 - [ALCF Inference Endpoints](https://github.com/argonne-lcf/inference-endpoints)
-- [GitHub Repository](https://github.com/auroraGPT-ANL/inference-gateway)
+- [GitHub Repository](https://github.com/argonne-lcf/FIRST)
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -341,7 +341,7 @@ The Gateway returns standard HTTP status codes:
 ## Support
 
 For issues, questions, or feature requests:
-- Check the [GitHub repository](https://github.com/auroraGPT-ANL/inference-gateway)
+- Check the [GitHub repository](https://github.com/argonne-lcf/FIRST)
 - Contact your Gateway administrator
 - Review the [Administrator Setup Guide](../admin-guide/index.md) for deployment issues
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,10 @@
 site_name: FIRST Documentation
 site_description: Federated Inference Resource Scheduling Toolkit - Documentation for deploying and using LLM inference as a service
 site_author: Argonne National Laboratory
-site_url: https://auroragpt-anl.github.io/inference-gateway/
+site_url: https://argonne-lcf.github.io/FIRST/
 
-repo_name: auroraGPT-ANL/inference-gateway
-repo_url: https://github.com/auroraGPT-ANL/inference-gateway
+repo_name: argonne-lcf/FIRST
+repo_url: https://github.com/argonne-lcf/FIRST
 edit_uri: edit/main/docs/
 
 theme:
@@ -99,7 +99,7 @@ nav:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/auroraGPT-ANL/inference-gateway
+      link: https://github.com/argonne-lcf/FIRST
     - icon: fontawesome/solid/book
       link: https://doi.org/10.1145/3731599.3767346
 


### PR DESCRIPTION
Fixes broken hyperlinks after the repository ownership migration.