### PR TITLE
LCF-125 Batch timeout

### DIFF
--- a/inference_gateway/settings.py
+++ b/inference_gateway/settings.py
@@ -64,6 +64,7 @@ GLOBUS_COMPUTE_EXECUTOR_DEBUG = os.getenv(
 # Batch processing feature flag
 ENABLE_BATCHES = os.getenv("ENABLE_BATCHES", False) == "True"
 MAX_BATCHES_PER_USER = int(os.getenv("MAX_BATCHES_PER_USER", 1))
+GLOBUS_BATCH_TIMEOUT_IN_DAYS = int(os.getenv("GLOBUS_BATCH_TIMEOUT_IN_DAYS", 7))
 
 # Rate limit (req/s) per user accross the board
 RATE_LIMIT_PER_SEC_PER_USER = int(os.getenv("RATE_LIMIT_PER_SEC_PER_USER", 10))

--- a/resource_server_async/endpoints/globus_compute.py
+++ b/resource_server_async/endpoints/globus_compute.py
@@ -558,12 +558,13 @@ class GlobusComputeEndpoint(BaseEndpoint):
         if not batch.task_ids:
             raise BatchNotFound("Cannot get batch status with missing task_ids")
 
-        days_passed = (timezone.now() - batch.in_progress_at).days
-        if days_passed >= GLOBUS_BATCH_TIMEOUT_IN_DAYS:
-            return BatchStatusResult(
-                status=BatchStatus.failed,
-                result=f"Timeout after {GLOBUS_BATCH_TIMEOUT_IN_DAYS} days.",
-            )
+        if batch.in_progress_at:
+            days_passed = (timezone.now() - batch.in_progress_at).days
+            if days_passed >= GLOBUS_BATCH_TIMEOUT_IN_DAYS:
+                return BatchStatusResult(
+                    status=BatchStatus.failed,
+                    result=f"Timeout after {GLOBUS_BATCH_TIMEOUT_IN_DAYS} days.",
+                )
 
         task_statuses = globus_utils.get_batch_status(batch.task_ids)
 

--- a/resource_server_async/endpoints/globus_compute.py
+++ b/resource_server_async/endpoints/globus_compute.py
@@ -557,13 +557,13 @@ class GlobusComputeEndpoint(BaseEndpoint):
 
         if not batch.task_ids:
             raise BatchNotFound("Cannot get batch status with missing task_ids")
-        
+
         days_passed = (timezone.now() - batch.in_progress_at).days
         if days_passed >= GLOBUS_BATCH_TIMEOUT_IN_DAYS:
             return BatchStatusResult(
-                    status=BatchStatus.failed,
-                    result=f"Timeout after {GLOBUS_BATCH_TIMEOUT_IN_DAYS} days."
-                )
+                status=BatchStatus.failed,
+                result=f"Timeout after {GLOBUS_BATCH_TIMEOUT_IN_DAYS} days.",
+            )
 
         task_statuses = globus_utils.get_batch_status(batch.task_ids)
 

--- a/resource_server_async/endpoints/globus_compute.py
+++ b/resource_server_async/endpoints/globus_compute.py
@@ -6,10 +6,12 @@ import uuid
 from typing import Any, AsyncGenerator, Optional, cast, override
 
 from django.http import StreamingHttpResponse
+from django.utils import timezone
 from globus_compute_sdk import Client, Executor
 from globus_compute_sdk.errors import TaskPending as GlobusTaskPending
 from pydantic import BaseModel
 
+from inference_gateway.settings import GLOBUS_BATCH_TIMEOUT_IN_DAYS
 from resource_server_async import globus_utils
 from resource_server_async.cache import (
     cache_item,
@@ -555,6 +557,13 @@ class GlobusComputeEndpoint(BaseEndpoint):
 
         if not batch.task_ids:
             raise BatchNotFound("Cannot get batch status with missing task_ids")
+        
+        days_passed = (timezone.now() - batch.in_progress_at).days
+        if days_passed >= GLOBUS_BATCH_TIMEOUT_IN_DAYS:
+            return BatchStatusResult(
+                    status=BatchStatus.failed,
+                    result=f"Timeout after {GLOBUS_BATCH_TIMEOUT_IN_DAYS} days."
+                )
 
         task_statuses = globus_utils.get_batch_status(batch.task_ids)
 


### PR DESCRIPTION
A user had an issue with a batch stuck in "pending" for weeks. This is a task that is either lost in the Globus land, or lost due to a node failure on our cluster. This prevented the user from submitting a new batch because of the imposed quota of 2 active/pending batch per user. This PR adds an adjustable timeout to batches to fail them if it takes too long. It won't solve the whole problem, but at least it will bring some protection.