### PR TITLE
resource_server: centralize caching usage to `cache.py` interface

### DIFF
--- a/resource_server_async/api.py
+++ b/resource_server_async/api.py
@@ -73,7 +73,7 @@ class GlobalAuth(HttpBearer):
     ) -> UserPydantic:
         # Introspect and validate the access token
         # Raises Unauthorized (HTTP 401) if authentication fails:
-        atv_response = validate_access_token(request)
+        atv_response = await validate_access_token(request)
 
         ctx = get_request_context()
 

--- a/resource_server_async/api.py
+++ b/resource_server_async/api.py
@@ -3,7 +3,6 @@ import uuid
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.cache import cache
 from django.http import HttpRequest, HttpResponse
 from ninja import NinjaAPI
 from ninja.errors import HttpError
@@ -11,6 +10,7 @@ from ninja.security import HttpBearer
 from ninja.throttling import AnonRateThrottle, AuthRateThrottle, BaseThrottle
 
 from resource_server_async.auth import validate_access_token
+from resource_server_async.cache import should_throttle
 from resource_server_async.schemas.structured_logs import UserPydantic
 
 from .errors import BaseError, TaskPending
@@ -90,7 +90,7 @@ class GlobalAuth(HttpBearer):
             is_superuser=False,
         )
 
-        if cache.add(f"authed_user:{ctx.user.id}", "", timeout=120):
+        if not await should_throttle(f"authed_user:{ctx.user.id}", ttl=120):
             ctx.user.emit()
 
         # Makes the user accessible through the request.auth attribute:

--- a/resource_server_async/auth.py
+++ b/resource_server_async/auth.py
@@ -9,9 +9,12 @@ import globus_sdk
 
 # Cache tools to limits how many calls are made to Globus servers
 from django.conf import settings
-from django.core.cache import cache
 from django.http import HttpRequest
 
+from resource_server_async.cache import (
+    cache_item_async,
+    get_item_from_cache_async,
+)
 from resource_server_async.errors import Unauthorized
 from resource_server_async.models import AuthService
 from resource_server_async.schemas.auth import (
@@ -49,7 +52,7 @@ def get_globus_client() -> globus_sdk.ConfidentialAppAuthClient:
     )
 
 
-def introspect_token(bearer_token: str) -> TokenIntrospectionResult:
+async def introspect_token(bearer_token: str) -> TokenIntrospectionResult:
     """
     Introspect a token with policies, collect group memberships, and return the response.
     Uses Redis cache for multi-worker support with fallback to in-memory cache.
@@ -61,7 +64,9 @@ def introspect_token(bearer_token: str) -> TokenIntrospectionResult:
     token_hash = hashlib.sha256(bearer_token.encode()).hexdigest()
     cache_key = f"token_introspect:{token_hash}"
 
-    cached_result: TokenIntrospectionResult | None = cache.get(cache_key)
+    cached_result: TokenIntrospectionResult | None = await get_item_from_cache_async(
+        cache_key
+    )
     if cached_result is not None:
         return cached_result
 
@@ -71,7 +76,9 @@ def introspect_token(bearer_token: str) -> TokenIntrospectionResult:
     except Unauthorized as e:
         # Introspection error!  60 seconds cooldown period before retrying
         # introspection
-        cache.set(cache_key, TokenIntrospectionResult(None, [], error=str(e)), 60)
+        await cache_item_async(
+            cache_key, TokenIntrospectionResult(None, [], error=str(e)), ttl=60
+        )
         raise
 
     # If the introspection was successful ...
@@ -87,7 +94,7 @@ def introspect_token(bearer_token: str) -> TokenIntrospectionResult:
     ttl = min(600, seconds_until_expiration)
 
     # Cache the result (successful or error)
-    cache.set(cache_key, result, ttl)
+    await cache_item_async(cache_key, result, ttl=ttl)
     return result
 
 
@@ -375,7 +382,7 @@ def extract_service_account_client(
 
 
 # Validate access token sent by user
-def validate_access_token(request: HttpRequest) -> ATVResponse:
+async def validate_access_token(request: HttpRequest) -> ATVResponse:
     """
     Returns ATVResponse if and only if the user is authenticated.  Raises
     Unauthorized otherwise.
@@ -401,7 +408,7 @@ def validate_access_token(request: HttpRequest) -> ATVResponse:
         raise Unauthorized(f"Something went wrong while reading headers. {e}")
 
     # Introspect the access token
-    introspection = introspect_token(bearer_token)
+    introspection = await introspect_token(bearer_token)
 
     if introspection.token_data is None:
         raise Unauthorized(f"Token introspection: {introspection.error}")

--- a/resource_server_async/cache.py
+++ b/resource_server_async/cache.py
@@ -86,10 +86,16 @@ def get_item_from_cache(cache_key: str) -> Any:
     return None
 
 
+get_item_from_cache_async = sync_to_async(get_item_from_cache)
+
+
 def cache_item(cache_key: str, data: Any, ttl: int = 3600) -> None:
     """Cache item data (60 minutes TTL by default)."""
     cache.set(cache_key, data, ttl)
     logger.debug(f"Cached {cache_key}.")
+
+
+cache_item_async = sync_to_async(cache_item)
 
 
 def remove_item_from_cache(cache_key: str) -> None:

--- a/resource_server_async/cache.py
+++ b/resource_server_async/cache.py
@@ -10,6 +10,7 @@ from logging import getLogger
 from typing import TYPE_CHECKING, Any
 
 import redis
+from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.core.cache import cache
 
@@ -58,6 +59,7 @@ def get_redis_client() -> redis.Redis | None:
     return None
 
 
+@sync_to_async
 def should_throttle(*args: Any, ttl: int = 30) -> bool:
     """
     Returns True if called with the same *args less than `ttl` seconds ago.

--- a/resource_server_async/clusters/cluster.py
+++ b/resource_server_async/clusters/cluster.py
@@ -8,7 +8,7 @@ from cachetools import TTLCache
 from django.forms.models import model_to_dict
 
 from inference_gateway.settings import MAINTENANCE_ERROR_NOTICES
-from resource_server_async.cache import get_item_from_cache
+from resource_server_async.cache import get_item_from_cache_async
 
 from ..auth import check_permission as auth_utils_check_permission
 from ..errors import ClusterNotFound, Unauthorized
@@ -49,12 +49,14 @@ class BaseCluster(ABC):
         self.__allowed_domains = allowed_domains
 
     # Check maintenance
-    def check_maintenance(self) -> CheckMaintenanceResult:
+    async def check_maintenance(self) -> CheckMaintenanceResult:
         """Verify is the cluster is currently under maintenance."""
 
         # Check Redis cache for cluster status from ALCF facility API
         cache_key = f"cluster_status:{self.cluster_name}"
-        cluster_status: ClusterStatus | None = get_item_from_cache(cache_key)
+        cluster_status: ClusterStatus | None = await get_item_from_cache_async(
+            cache_key
+        )
 
         if not isinstance(cluster_status, dict):
             cluster_status = {"status": "unknown", "message": ""}

--- a/resource_server_async/clusters/cluster.py
+++ b/resource_server_async/clusters/cluster.py
@@ -5,10 +5,10 @@ from abc import ABC, abstractmethod
 from typing import List, Self, Type
 
 from cachetools import TTLCache
-from django.core.cache import cache
 from django.forms.models import model_to_dict
 
 from inference_gateway.settings import MAINTENANCE_ERROR_NOTICES
+from resource_server_async.cache import get_item_from_cache
 
 from ..auth import check_permission as auth_utils_check_permission
 from ..errors import ClusterNotFound, Unauthorized
@@ -54,7 +54,7 @@ class BaseCluster(ABC):
 
         # Check Redis cache for cluster status from ALCF facility API
         cache_key = f"cluster_status:{self.cluster_name}"
-        cluster_status: ClusterStatus | None = cache.get(cache_key)
+        cluster_status: ClusterStatus | None = get_item_from_cache(cache_key)
 
         if not isinstance(cluster_status, dict):
             cluster_status = {"status": "unknown", "message": ""}

--- a/resource_server_async/clusters/globus_compute.py
+++ b/resource_server_async/clusters/globus_compute.py
@@ -2,11 +2,11 @@ import logging
 from typing import Any
 
 from asgiref.sync import sync_to_async
-from django.core.cache import cache
 from django.utils.text import slugify
 from pydantic import BaseModel
 
 from resource_server_async import globus_utils
+from resource_server_async.cache import cache_item_async, get_item_from_cache_async
 from resource_server_async.clusters.cluster import BaseCluster
 
 from ..errors import EndpointError, GetJobsError
@@ -61,7 +61,7 @@ class GlobusComputeCluster(BaseCluster):
         cache_key = f"qstat_details:{auth.username}:{auth.id}:{self.cluster_name}"
 
         # Try to get qstat details from Redis
-        cached_result: JobsByStatus | None = cache.get(cache_key)
+        cached_result: JobsByStatus | None = await get_item_from_cache_async(cache_key)
         if cached_result is not None:
             return cached_result
 
@@ -140,7 +140,7 @@ class GlobusComputeCluster(BaseCluster):
         response = JobsByStatus(**result)
 
         # Cache the result for 60 seconds
-        cache.set(cache_key, response, 60)
+        await cache_item_async(cache_key, response, ttl=60)
 
         # Return qstat result
         return response

--- a/resource_server_async/clusters/globus_compute.py
+++ b/resource_server_async/clusters/globus_compute.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Any
 
-from asgiref.sync import sync_to_async
 from django.utils.text import slugify
 from pydantic import BaseModel
 
@@ -111,9 +110,7 @@ class GlobusComputeCluster(BaseCluster):
                     endpoint_slug = slugify(
                         " ".join([running_cluster, running_framework, running_model])
                     )
-                    endpoint = await sync_to_async(Endpoint.objects.get)(
-                        endpoint_slug=endpoint_slug
-                    )
+                    endpoint = await Endpoint.objects.aget(endpoint_slug=endpoint_slug)
                     endpoint_config = globus_utils.unwrap_json(endpoint.config)
                     endpoint_uuid = endpoint_config["endpoint_uuid"]
 

--- a/resource_server_async/clusters/metis.py
+++ b/resource_server_async/clusters/metis.py
@@ -2,9 +2,9 @@
 import logging
 from typing import Any, List, override
 
-from django.core.cache import cache
 from httpx import HTTPError, TimeoutException
 
+from resource_server_async.cache import cache_item_async, get_item_from_cache_async
 from resource_server_async.clusters.direct_api import DirectAPICluster
 
 from ..errors import GetJobsError
@@ -50,7 +50,7 @@ class MetisCluster(DirectAPICluster):
         # Redis cache key
         cache_key = "metis_status_response"
 
-        cached_result: JobsByStatus | None = cache.get(cache_key)
+        cached_result: JobsByStatus | None = await get_item_from_cache_async(cache_key)
         if cached_result is not None:
             return cached_result
 
@@ -104,7 +104,7 @@ class MetisCluster(DirectAPICluster):
 
         # Cache the result for 60 seconds
         try:
-            cache.set(cache_key, formatted, 60)
+            await cache_item_async(cache_key, formatted, ttl=60)
         except Exception as e:
             log.warning(f"Failed to cache metis_status_response: {e}")
 

--- a/resource_server_async/endpoints/globus_compute.py
+++ b/resource_server_async/endpoints/globus_compute.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 from inference_gateway.settings import GLOBUS_BATCH_TIMEOUT_IN_DAYS
 from resource_server_async import globus_utils
 from resource_server_async.cache import (
-    cache_item,
+    cache_item_async,
     is_cached,
     remove_endpoint_from_cache,
 )
@@ -305,7 +305,7 @@ class GlobusComputeEndpoint(BaseEndpoint):
 
         # Cache the endpoint slug to tell the application that a user already submitted a request to this endpoint
         cache_key = f"endpoint_triggered:{self.endpoint_slug}"
-        cache_item(cache_key, True, ttl=600)
+        await cache_item_async(cache_key, True, ttl=600)
 
         try:
             context = get_request_context()

--- a/resource_server_async/globus_utils.py
+++ b/resource_server_async/globus_utils.py
@@ -13,7 +13,11 @@ from globus_compute_sdk.sdk.asynchronous.compute_future import ComputeFuture
 from globus_compute_sdk.sdk.executor import log as EXECUTOR_LOG
 from globus_sdk import TransferClient
 
-from resource_server_async.cache import cache_item, get_item_from_cache
+from resource_server_async.cache import (
+    cache_item,
+    cache_item_async,
+    get_item_from_cache,
+)
 from resource_server_async.errors import EndpointError, RequestTimeout
 from resource_server_async.schemas.endpoints import SubmitTaskResult
 
@@ -224,7 +228,7 @@ async def submit_and_get_result(
     if endpoint_slug:
         cache_key = f"endpoint_triggered:{endpoint_slug}"
         ttl = 600  # 10 minutes
-        cache_item(cache_key, True, ttl)
+        await cache_item_async(cache_key, True, ttl=ttl)
 
     # Wait for the Globus Compute result using asyncio and coroutine
     try:

--- a/resource_server_async/logging.py
+++ b/resource_server_async/logging.py
@@ -115,7 +115,7 @@ class AccessLogMiddleware:
         finally:
             _request_context.reset(token)
 
-        if should_skip_logging(ctx_data, request, response):
+        if await should_skip_logging(ctx_data, request, response):
             return response
 
         # Fire-and-forget logging pattern:
@@ -125,7 +125,7 @@ class AccessLogMiddleware:
         return response
 
 
-def should_skip_logging(
+async def should_skip_logging(
     ctx: RequestContext,
     request: HttpRequest,
     response: HttpResponse | StreamingHttpResponse,
@@ -144,11 +144,11 @@ def should_skip_logging(
     user = ctx.user.username if ctx.user else ctx.access_log.origin_ip
 
     # Debounce if it's the same user/error repeatedly:
-    if status_code >= 400 and should_throttle(user, fingerprint, status_code):
+    if status_code >= 400 and await should_throttle(user, fingerprint, status_code):
         return True
 
     # Internal errors de-dup'd at user/status level:
-    if status_code >= 500 and should_throttle(user, status_code):
+    if status_code >= 500 and await should_throttle(user, status_code):
         return True
 
     return False

--- a/resource_server_async/services.py
+++ b/resource_server_async/services.py
@@ -267,7 +267,7 @@ async def submit_openai_inference_request(
     cluster = await BaseCluster.load_adapter(cluster_name)
 
     # Error if the cluster is under maintenance
-    cluster.check_maintenance().raise_if_down()
+    (await cluster.check_maintenance()).raise_if_down()
 
     # Verify that the framework is available by the cluster
     if framework not in cluster.frameworks:
@@ -353,7 +353,7 @@ async def submit_batch(
     cluster = await BaseCluster.load_adapter(cluster_name)
 
     # Error if the cluster is under maintenance
-    cluster.check_maintenance().raise_if_down()
+    (await cluster.check_maintenance()).raise_if_down()
 
     # Verify that the framework is enabled by the cluster
     if framework not in cluster.frameworks:

--- a/resource_server_async/streaming.py
+++ b/resource_server_async/streaming.py
@@ -10,10 +10,14 @@ from typing import Any
 
 from cachetools import TTLCache
 from django.conf import settings
-from django.core.cache import cache
 from django.http import HttpRequest
 
-from .cache import get_redis_client
+from .cache import (
+    cache_item,
+    get_item_from_cache,
+    get_redis_client,
+    remove_item_from_cache,
+)
 from .logging import RequestContext
 from .schemas.structured_logs import UsageTokens
 
@@ -78,7 +82,7 @@ def _cache_set(task_id: str, key_type: str, value: str, ttl: int = 3600) -> None
     """Generic cache set - uses Django cache (which is Redis in production)"""
     try:
         key = _get_cache_key(key_type, task_id)
-        cache.set(key, value, ttl)
+        cache_item(key, value, ttl=ttl)
     except Exception as e:
         logger.error(f"Error setting streaming {key_type} for task {task_id}: {e}")
 
@@ -87,7 +91,7 @@ def _cache_get(task_id: str, key_type: str) -> Any:
     """Generic cache get - uses Django cache (which is Redis in production)"""
     try:
         key = _get_cache_key(key_type, task_id)
-        return cache.get(key)
+        return get_item_from_cache(key)
     except Exception as e:
         logger.error(f"Error getting streaming {key_type} for task {task_id}: {e}")
         return None
@@ -104,9 +108,9 @@ def store_streaming_data(task_id: str, chunk_data: str, ttl: int = 600) -> None:
         else:
             # Fallback: store as regular list in cache (less efficient)
             key = _get_cache_key("data", task_id)
-            existing = cache.get(key, [])
+            existing = get_item_from_cache(key) or []
             existing.append(chunk_data)
-            cache.set(key, existing, ttl)
+            cache_item(key, existing, ttl=ttl)
     except Exception as e:
         logger.error(f"Error storing streaming data for task {task_id}: {e}")
 
@@ -125,7 +129,7 @@ def get_streaming_data(task_id: str) -> list[str]:
         else:
             # Fallback: retrieve from cache as regular list
             key = _get_cache_key("data", task_id)
-            return cache.get(key, [])  # type: ignore[no-any-return]
+            return get_item_from_cache(key) or []
     except Exception as e:
         logger.error(f"Error getting streaming data for task {task_id}: {e}")
         return []
@@ -727,7 +731,7 @@ def cleanup_streaming_data(task_id: str) -> None:
         else:
             # Fallback to Django cache delete
             for key_type in key_types:
-                cache.delete(_get_cache_key(key_type, task_id))
+                remove_item_from_cache(_get_cache_key(key_type, task_id))
 
         logger.debug(f"Cleaned up streaming data for task {task_id}")
     except Exception as e:

--- a/resource_server_async/tests/mock_utils.py
+++ b/resource_server_async/tests/mock_utils.py
@@ -94,7 +94,7 @@ def get_mock_headers(access_token="", bearer=True):
 
 
 # Get mock token introspection
-def introspect_token(access_token):
+async def introspect_token(access_token):
     # Emulate an error in the introspection call
     if (ACTIVE not in access_token) or (EXPIRED in access_token):
         return TokenIntrospectionResult(None, [], error="mock error message")

--- a/resource_server_async/views/core.py
+++ b/resource_server_async/views/core.py
@@ -55,7 +55,9 @@ async def status_check(request: HttpRequest) -> dict[str, bool]:
 
     # Build status
     return {
-        cluster.cluster_name: not cluster.check_maintenance().is_under_maintenance
+        cluster.cluster_name: not (
+            await cluster.check_maintenance()
+        ).is_under_maintenance
         for cluster in authorized_clusters
     }
 
@@ -87,7 +89,7 @@ async def get_jobs(request: AuthedRequest, cluster_name: str) -> JobsByStatus:
     cluster.check_permission(request.auth)
 
     # If the cluster is under maintenance, report all jobs stopped:
-    if cluster.check_maintenance().is_under_maintenance:
+    if (await cluster.check_maintenance()).is_under_maintenance:
         all_endpoints = await get_list_endpoints_data(request.auth)
         cluster_info = all_endpoints.clusters.get(cluster.cluster_name)
         frameworks = cluster_info.frameworks if cluster_info else {}

--- a/resource_server_async/views/sam3.py
+++ b/resource_server_async/views/sam3.py
@@ -29,7 +29,7 @@ async def sam3_infer(
     cluster = await BaseCluster.load_adapter("sophia")
 
     # Error if the cluster is under maintenance
-    cluster.check_maintenance().raise_if_down()
+    (await cluster.check_maintenance()).raise_if_down()
 
     # Endpoint slug (sophia-sam3service-sam3 hardcoded for now)
     endpoint = await BaseEndpoint.load_adapter(
@@ -61,7 +61,7 @@ async def sam3_get_task_result(
     cluster = await BaseCluster.load_adapter("sophia")
 
     # Error if the cluster is under maintenance
-    cluster.check_maintenance().raise_if_down()
+    (await cluster.check_maintenance()).raise_if_down()
 
     endpoint = await BaseEndpoint.load_adapter(
         cluster.cluster_name, "sam3service", "sam3"


### PR DESCRIPTION
This PR refactors the majority of caching calls to rely on the `async` executor to drive progress. There are notable exceptions which require some more work to resolve.

- Globus routines which rely on the cache are blocking in nature, therefore we utilize the blocking routines. We would need to refactor the usage of the SDK to be non-blocking for this to be truly fixed.
- Streaming routines are in a similar situation; we need to refactor the streaming routines to be non-blocking to resolve this.
- There may be database accesses within `async` routines which initiate a blocking transaction. We need to investigate if there are any remaining within the codebase.

Fixes LCF-77.