### PR TITLE
schemas: allow extra fields in `extra_body` and `tools`

### DIFF
--- a/resource_server_async/schemas/openai_chat_completions.py
+++ b/resource_server_async/schemas/openai_chat_completions.py
@@ -198,12 +198,16 @@ class ToolChoice(str, Enum):
 
 # Extention of the Pydantic BaseModel that prevent extra attributes
 class BaseModelExtraForbid(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
+
+
+# Antonym of `BaseModelExtraForbid`
+class BaseModelExtraAllow(BaseModel):
+    model_config = ConfigDict(extra="allow")
 
 
 # vLLM extra_body field
-class ExtraBody(BaseModelExtraForbid):
+class ExtraBody(BaseModelExtraAllow):
     use_beam_search: bool
 
 

--- a/resource_server_async/schemas/openai_chat_completions.py
+++ b/resource_server_async/schemas/openai_chat_completions.py
@@ -314,7 +314,7 @@ class ToolFunction(BaseModelExtraForbid):
 
 
 # Tool
-class Tool(BaseModelExtraForbid):
+class Tool(BaseModelExtraAllow):
     function: ToolFunction
     type: ToolType
 

--- a/resource_server_async/schemas/openai_completions.py
+++ b/resource_server_async/schemas/openai_completions.py
@@ -1,12 +1,11 @@
 from typing import Dict, List, Literal, Optional, Self, Union
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 # Extention of the Pydantic BaseModel that prevent extra attributes
 class BaseModelExtraForbid(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 # OpenAI stream_options

--- a/resource_server_async/schemas/openai_embeddings.py
+++ b/resource_server_async/schemas/openai_embeddings.py
@@ -1,13 +1,12 @@
 from enum import Enum
 from typing import List, Literal, Optional, Self, Union
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 # Extention of the Pydantic BaseModel that prevent extra attributes
 class BaseModelExtraForbid(BaseModel):
-    class Config:
-        extra = "forbid"
+    model_config = ConfigDict(extra="forbid")
 
 
 # Encoding format

--- a/resource_server_async/tests/json/invalid_chat_completions.json
+++ b/resource_server_async/tests/json/invalid_chat_completions.json
@@ -1042,13 +1042,6 @@
     {
         "model": "meta-llama/Meta-Llama-3-8B-Instruct",
         "messages": [{"role": "user", "content": "good simple content"}],
-        "tools": [{"type": "function", "function": {"name": "required-string"}, "extra": 1}],
-        "tool_choice": "none"
-    },
-
-    {
-        "model": "meta-llama/Meta-Llama-3-8B-Instruct",
-        "messages": [{"role": "user", "content": "good simple content"}],
         "tools": [{"type": "function", "function": {"name": "name"}}],
         "tool_choice": { "type": "function", "function": {"name": "my_function", "extra": 1} },
         "parallel_tool_calls": true
@@ -1060,41 +1053,6 @@
         "tools": [{"type": "function", "function": {"name": "name"}}],
         "tool_choice": { "type": "function", "extra": 1, "function": {"name": "my_function"} },
         "parallel_tool_calls": true
-    },
-
-    {
-        "model": "gpt-4-turbo",
-        "messages": [
-          {
-            "role": "user",
-            "content": "Whats the weather like in Boston today?"
-          }
-        ],
-        "tools": [
-          {
-            "type": "function",
-            "extra": 1,
-            "function": {
-              "name": "get_current_weather",
-              "description": "Get the current weather in a given location",
-              "parameters": {
-                "type": "object",
-                "properties": {
-                  "location": {
-                    "type": "string",
-                    "description": "The city and state, e.g. San Francisco, CA"
-                  },
-                  "unit": {
-                    "type": "string",
-                    "enum": ["celsius", "fahrenheit"]
-                  }
-                },
-                "required": ["location"]
-              }
-            }
-          }
-        ],
-        "tool_choice": "auto"
     },
 
     {

--- a/resource_server_async/tests/json/invalid_chat_completions.json
+++ b/resource_server_async/tests/json/invalid_chat_completions.json
@@ -1266,37 +1266,14 @@
         "stream": "hello this is not a boolean"
     },
 
-  {
-    "model": "meta-llama/Meta-Llama-3-8B-Instruct",
-    "messages": [
-      {
-        "role": "system",
-        "content": "this is my question?"
-      }
-    ],
-    "extra_body": {"use_beam_search": true, "extra": "should not be allowed"}
-  },
-
-  {
-    "model": "meta-llama/Meta-Llama-3-8B-Instruct",
-    "messages": [
-      {
-        "role": "system",
-        "content": "this is my question?"
-      }
-    ],
-    "extra_body": {"use_beam_search": "not a boolean"}
-  },
-
-  {
-    "model": "meta-llama/Meta-Llama-3-8B-Instruct",
-    "messages": [
-      {
-        "role": "system",
-        "content": "this is my question?"
-      }
-    ],
-    "extra_body": {"not_a_valid_option": true}
-  }
-
+    {
+        "model": "meta-llama/Meta-Llama-3-8B-Instruct",
+        "messages": [
+          {
+            "role": "system",
+            "content": "this is my question?"
+          }
+        ],
+        "extra_body": {"use_beam_search": "not a boolean"}
+    }
 ]


### PR DESCRIPTION
This PR allows the bare minimum of extra fields to the OpenAI Chat Completion schema validation to allow Codex to work with FIRST.