### PR TITLE
alcf-ai: add `agent configure <agent>`

### DIFF
--- a/alcf_ai/pyproject.toml
+++ b/alcf_ai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "alcf-ai"
-version = "0.7.0"
+version = "0.8.0"
 description = "ALCF Inference Gateway SDK"
 authors = [{ name = "Misha Salim", email = "msalim@anl.gov" }]
 requires-python = ">=3.12"

--- a/alcf_ai/pyproject.toml
+++ b/alcf_ai/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "Pillow",
     "tifffile",
     "smart-open",
+    "tomlkit>=0.15.1",
 ]
 
 [project.scripts]

--- a/alcf_ai/src/alcf_ai/agent.py
+++ b/alcf_ai/src/alcf_ai/agent.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import tomlkit
 from pathlib import Path
 from typing import Annotated, Literal
 
@@ -44,7 +45,7 @@ def edit_opencode(service_url: str, api_key: str, endpoints) -> None:
             if not models:
                 continue
 
-            providers[f"inference-service-{cluster_name}-{framework_name}"] = {
+            providers[f"alcf-inference-service-{cluster_name}-{framework_name}"] = {
                 "name": f"ALCF Inference Service ({cluster_name.title()}, {'vLLM' if framework_name == 'vllm' else 'Direct API'})",
                 "npm": "@ai-sdk/openai-compatible",
                 "options": {
@@ -62,8 +63,42 @@ def edit_opencode(service_url: str, api_key: str, endpoints) -> None:
     logging.info(f"Updated configuration at {path}")
 
 
+def edit_codex(service_url: str, api_key: str, endpoints) -> None:
+    path = Path.home() / ".codex" / "config.toml"
+    try:
+        with path.open() as f:
+            config = tomlkit.load(f)
+    except (FileNotFoundError, tomlkit.exceptions.ParseError):
+        config = {}
+
+    providers = config.get("model_providers", {})
+    for cluster_name, cluster in endpoints["clusters"].items():
+        for api in cluster["frameworks"].keys():
+            if api not in ("vllm", "api"):
+                continue
+
+            providers[f"alcf-inference-service-{cluster_name}-{api}"] = {
+                "name": f"ALCF Inference Service ({cluster_name.title()}, {'vLLM' if api == 'vllm' else 'Direct API'})",
+                "base_url": f"{service_url}{cluster_name}/{api}/v1",
+                "experimental_bearer_token": f"{api_key}",
+                "wire_api": "chat",
+            }
+
+    config["model_providers"] = providers
+
+    # hardcode default to minerva nemotron
+    config["model"] = "nemotron-3-ultra"
+    config["model_provider"] = "alcf-inference-service-minerva-api"
+
+    path.parent.mkdir(exist_ok=True, parents=True)
+    with path.open("w") as f:
+        tomlkit.dump(config, f)
+
+    logging.info(f"Updated configuration at {path}")
+
+
 @cli.command()
-def configure(agent: Annotated[Literal["opencode"], typer.Argument()]) -> None:
+def configure(agent: Annotated[Literal["opencode", "codex"], typer.Argument()]) -> None:
     """
     Generates a configuration template for a given agent.
     """
@@ -79,3 +114,5 @@ def configure(agent: Annotated[Literal["opencode"], typer.Argument()]) -> None:
     match agent:
         case "opencode":
             edit_opencode(client.base_url, api_key, endpoints)
+        case "codex":
+            edit_codex(client.base_url, api_key, endpoints)

--- a/alcf_ai/src/alcf_ai/agent.py
+++ b/alcf_ai/src/alcf_ai/agent.py
@@ -1,10 +1,11 @@
 import json
 import logging
-import tomlkit
 from pathlib import Path
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
+import tomlkit
 import typer
+from httpx import URL
 
 from alcf_ai.auth import get_inference_authorizer
 
@@ -18,7 +19,7 @@ ALLOWLIST = {
 }
 
 
-def edit_opencode(service_url: str, api_key: str, endpoints) -> None:
+def edit_opencode(service_url: URL, api_key: str, endpoints: dict[str, Any]) -> None:
     path = Path.home() / ".config" / "opencode" / "opencode.jsonc"
     try:
         with path.open() as f:
@@ -63,13 +64,13 @@ def edit_opencode(service_url: str, api_key: str, endpoints) -> None:
     logging.info(f"Updated configuration at {path}")
 
 
-def edit_codex(service_url: str, api_key: str, endpoints) -> None:
+def edit_codex(service_url: URL, api_key: str, endpoints: dict[str, Any]) -> None:
     path = Path.home() / ".codex" / "config.toml"
     try:
         with path.open() as f:
             config = tomlkit.load(f)
     except (FileNotFoundError, tomlkit.exceptions.ParseError):
-        config = {}
+        config = tomlkit.TOMLDocument()
 
     providers = config.get("model_providers", {})
     for cluster_name, cluster in endpoints["clusters"].items():
@@ -108,8 +109,8 @@ def configure(agent: Annotated[Literal["opencode", "codex"], typer.Argument()]) 
     endpoints = client.list_endpoints()
 
     auth = get_inference_authorizer()
-    auth.ensure_valid_token()
-    api_key = auth.access_token
+    auth.ensure_valid_token()  # type: ignore[attr-defined]
+    api_key = auth.access_token  # type: ignore[attr-defined]
 
     match agent:
         case "opencode":

--- a/alcf_ai/src/alcf_ai/agent.py
+++ b/alcf_ai/src/alcf_ai/agent.py
@@ -1,0 +1,74 @@
+import json
+import logging
+import typer
+from pathlib import Path
+from typing import Annotated, Literal
+
+cli = typer.Typer(no_args_is_help=True)
+
+ALLOWLIST = {
+    "sophia": {"openai/gpt-oss-120b": {"limit": {"context": 65536, "output": 0}}},
+    # Metis has a SN-specific sanitization issue w.r.t. tool call outputs, disable for now.
+    # "metis": {"gpt-oss-120b": {"limits": {"context": 65536, "output": 0}}},
+    "minerva": {"nemotron-3-ultra": {"limit": {"context": 96000, "output": 0}}},
+}
+
+
+def edit_opencode(service_url: str, endpoints) -> None:
+    path = Path.home() / ".config" / "opencode" / "opencode.jsonc"
+    try:
+        with path.open() as f:
+            config = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        config = {}
+
+    providers = config.get("provider", {})
+    for cluster_name, cluster in endpoints["clusters"].items():
+        for framework_name, framework in cluster["frameworks"].items():
+            if framework_name not in ("vllm", "api"):
+                continue
+
+            models = {
+                model: {
+                    "name": model,
+                    "timeout": False,
+                    "limit": ALLOWLIST[cluster_name][model]["limit"],
+                }
+                for model in framework["models"]
+                if model in ALLOWLIST.get(cluster_name, {})
+            }
+
+            if not models:
+                continue
+
+            providers[f"inference-service-{cluster_name}-{framework_name}"] = {
+                "name": f"ALCF Inference Service ({cluster_name.title()}, {'vLLM' if framework_name == 'vllm' else 'Direct API'})",
+                "npm": "@ai-sdk/openai-compatible",
+                "options": {
+                    "baseURL": f"{service_url}{cluster_name}/{framework_name}/v1",
+                    "apiKey": "{env:ALCF_AI_TOKEN}",
+                },
+                "models": models,
+            }
+
+    config["provider"] = providers
+    path.parent.mkdir(exist_ok=True, parents=True)
+    with path.open("w") as f:
+        json.dump(config, f, indent=2)
+
+    logging.info(f"Updated configuration at {path}")
+
+
+@cli.command()
+def configure(agent: Annotated[Literal["opencode"], typer.Argument()]) -> None:
+    """
+    Generates a configuration template for a given agent.
+    """
+    from .cli import _cli_state
+
+    client = _cli_state["client"]
+    endpoints = client.list_endpoints()
+
+    match agent:
+        case "opencode":
+            edit_opencode(client.base_url, endpoints)

--- a/alcf_ai/src/alcf_ai/agent.py
+++ b/alcf_ai/src/alcf_ai/agent.py
@@ -1,8 +1,11 @@
 import json
 import logging
-import typer
 from pathlib import Path
 from typing import Annotated, Literal
+
+import typer
+
+from alcf_ai.auth import get_inference_authorizer
 
 cli = typer.Typer(no_args_is_help=True)
 
@@ -14,7 +17,7 @@ ALLOWLIST = {
 }
 
 
-def edit_opencode(service_url: str, endpoints) -> None:
+def edit_opencode(service_url: str, api_key: str, endpoints) -> None:
     path = Path.home() / ".config" / "opencode" / "opencode.jsonc"
     try:
         with path.open() as f:
@@ -46,7 +49,7 @@ def edit_opencode(service_url: str, endpoints) -> None:
                 "npm": "@ai-sdk/openai-compatible",
                 "options": {
                     "baseURL": f"{service_url}{cluster_name}/{framework_name}/v1",
-                    "apiKey": "{env:ALCF_AI_TOKEN}",
+                    "apiKey": f"{api_key}",
                 },
                 "models": models,
             }
@@ -69,6 +72,10 @@ def configure(agent: Annotated[Literal["opencode"], typer.Argument()]) -> None:
     client = _cli_state["client"]
     endpoints = client.list_endpoints()
 
+    auth = get_inference_authorizer()
+    auth.ensure_valid_token()
+    api_key = auth.access_token
+
     match agent:
         case "opencode":
-            edit_opencode(client.base_url, endpoints)
+            edit_opencode(client.base_url, api_key, endpoints)

--- a/alcf_ai/src/alcf_ai/cli.py
+++ b/alcf_ai/src/alcf_ai/cli.py
@@ -11,12 +11,12 @@ from rich.logging import RichHandler
 from rich.markdown import Markdown
 from typer import Typer
 
+from .agent import cli as agent_cli
 from .auth import cli as auth_cli
 from .client import InferenceClient
 from .d3_triton import cli as d3_triton_cli
 from .dinov3 import cli as dinov3_cli
 from .sam3 import cli as sam3_cli
-from .agent import cli as agent_cli
 
 logger = logging.getLogger(__name__)
 console = Console(stderr=True)

--- a/alcf_ai/src/alcf_ai/cli.py
+++ b/alcf_ai/src/alcf_ai/cli.py
@@ -16,6 +16,7 @@ from .client import InferenceClient
 from .d3_triton import cli as d3_triton_cli
 from .dinov3 import cli as dinov3_cli
 from .sam3 import cli as sam3_cli
+from .agent import cli as agent_cli
 
 logger = logging.getLogger(__name__)
 console = Console(stderr=True)
@@ -36,6 +37,7 @@ cli.add_typer(
     dinov3_cli, name="dinov3", help="Use the DINOv3 image segmentation service"
 )
 cli.add_typer(sam3_cli, name="sam3", help="Use the SAM3 image segmentation service")
+cli.add_typer(agent_cli, name="agent", help="Utilities to quick-configure agents")
 
 
 @cli.callback()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ members = ["alcf_ai/"]
 module-name = [
     "resource_server_async",
     "dashboard_async",
-    "utils",
     "alcf_ai",
 ]
 module-root = ""
@@ -91,7 +90,7 @@ extend-exclude = [
 select = ["F", "I"]
 
 [tool.ruff.lint.isort]
-known-first-party = ["alcf_ai", "resource_server_async", "dashboard_async", "utils"]
+known-first-party = ["alcf_ai", "resource_server_async", "dashboard_async"]
 
 
 [tool.mypy]
@@ -103,7 +102,6 @@ exclude = [
     'node_modules',
     '^build/',
     '^dist/',
-    'utils/tests/test.*\.py$',
     'resource_server_async/tests/.*.py$',
     '^compute-functions/.*$',
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -22,6 +22,7 @@ dependencies = [
     { name = "rich" },
     { name = "smart-open" },
     { name = "tifffile" },
+    { name = "tomlkit" },
     { name = "typer" },
 ]
 
@@ -36,6 +37,7 @@ requires-dist = [
     { name = "rich" },
     { name = "smart-open" },
     { name = "tifffile" },
+    { name = "tomlkit", specifier = ">=0.15.1" },
     { name = "typer" },
 ]
 
@@ -1501,6 +1503,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d7/4a/e687f5957fead200faad58dbf9c9431a2bbb118040e96f5fb8a55f7ebc50/tifffile-2026.4.11.tar.gz", hash = "sha256:17758ff0c0d4db385792a083ad3ca51fcb0f4d942642f4d8f8bc1287fdcf17bc", size = 394956, upload-time = "2026-04-12T01:57:28.793Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/9f/74f110b4271ded519c7add4341cbabc824de26817ff1c345b3109df9e99c/tifffile-2026.4.11-py3-none-any.whl", hash = "sha256:9b94ffeddb39e97601af646345e8808f885773de01b299e480ed6d3a41509ec9", size = 248227, upload-time = "2026-04-12T01:57:26.969Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ members = [
 
 [[package]]
 name = "alcf-ai"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "alcf_ai" }
 dependencies = [
     { name = "globus-sdk" },


### PR DESCRIPTION
This PR adds a command to automatically configure common coding agents like `opencode` and `codex` with ALCF Inference service endpoints and an API key.

While storing the API key in plaintext is not ideal, not all agents support pulling a token from an auth helper (i.e. `alcf-ai auth get-access-token`). Additionally, tokens are short-lived (48 hours), meaning the security risk is minimal.

This routine doubles as an idempotent method to pull a fresh token.