### PR TITLE
Add Minerva session affinity and cache isolation

### DIFF
--- a/docs/admin-guide/gateway-setup/configuration.md
+++ b/docs/admin-guide/gateway-setup/configuration.md
@@ -65,6 +65,11 @@ All configuration is done through environment variables, typically stored in a `
 | `MAX_BATCHES_PER_USER` | No | `2` | Maximum concurrent batch jobs per user |
 | `STREAMING_SERVER_HOST` | No | - | Internal streaming server host:port |
 | `INTERNAL_STREAMING_SECRET` | No | - | Secret for internal streaming authentication |
+| `MINERVA_AFFINITY_HMAC_KEY` | For Minerva inference | - | Dedicated secret of at least 32 bytes used to derive opaque Minerva session-affinity keys and per-user/model cache salts |
+
+Rotating `MINERVA_AFFINITY_HMAC_KEY` remaps all Minerva sessions and cache
+namespaces. Treat rotation as a planned cold-cache event. See
+[Minerva Direct API Affinity](../inference-setup/minerva.md).
 
 ### Metis (Direct API) Configuration
 

--- a/docs/admin-guide/inference-setup/index.md
+++ b/docs/admin-guide/inference-setup/index.md
@@ -83,6 +83,10 @@ Connect to existing OpenAI-compatible APIs without any local inference infrastru
 
 [→ Setup Direct API Connection](direct-api.md)
 
+For replicated Minerva backends, also configure
+[Minerva Direct API Affinity](minerva.md) to preserve replica-local KV-cache
+reuse with per-user cache isolation.
+
 ---
 
 ## Comparison Matrix
@@ -191,4 +195,3 @@ After setup:
 
 - [Production Best Practices](../deployment/production.md)
 - [Monitoring & Troubleshooting](../monitoring.md)
-

--- a/docs/admin-guide/inference-setup/minerva.md
+++ b/docs/admin-guide/inference-setup/minerva.md
@@ -1,0 +1,115 @@
+# Minerva Direct API Affinity
+
+FIRST exposes one endpoint per logical Minerva model even when the Minerva
+gateway runs several vLLM replicas. FIRST derives opaque routing and cache
+values on every request so NGINX can preserve replica-local KV-cache reuse
+without learning the authenticated user or caller's raw session identifier.
+
+## Required Secret
+
+Provision a dedicated secret in FIRST's normal secret store:
+
+```bash
+openssl rand -base64 48
+```
+
+Set the generated value as `MINERVA_AFFINITY_HMAC_KEY` in the production
+environment. It must contain at least 32 bytes and must be separate from
+`SECRET_KEY`, `MINERVA_DIRECT_API_KEY`, and all TLS private keys. Restart FIRST
+workers after changing it. A missing or short value fails closed only for
+Minerva inference and returns an actionable configuration error.
+
+Rotation changes every derived routing key and cache namespace. Treat rotation
+as a planned cold-cache event: drain or announce the change, rotate the secret,
+restart FIRST, then validate non-streaming and streaming Minerva requests.
+
+## Client Session Header
+
+Clients may add this optional header to a FIRST inference request:
+
+```text
+X-ALCF-Session-ID: conversation-or-branch-id
+```
+
+Use the same value for every turn in one conversation. Use different values
+for independent conversations or parallel branches when they may use different
+replicas. The value may contain at most 128 visible ASCII bytes; spaces,
+control characters, non-ASCII text, and longer values are rejected with HTTP
+400. An absent or empty value produces a stable user-level fallback.
+
+Do not use the OpenAI `user` request field for this purpose. The session value
+is always namespaced by the authenticated FIRST user and logical model. FIRST
+does not forward or log the raw user or session value.
+
+Example:
+
+```bash
+curl -X POST "$FIRST_URL/resource_server/v1/chat/completions" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -H 'X-ALCF-Session-ID: project-a-conversation-17' \
+  -d '{
+    "model": "nemotron-3-ultra",
+    "messages": [{"role": "user", "content": "Continue our analysis."}]
+  }'
+```
+
+## Forwarding And Cache Isolation
+
+For Minerva requests, FIRST derives and overwrites:
+
+- `X-Minerva-Affinity-Key`, an opaque user/model/session HMAC used only for
+  consistent-hash replica selection;
+- `X-Request-ID`, the existing FIRST access-log request ID; and
+- `cache_salt`, an opaque stable user/model HMAC when the selected vLLM request
+  schema supports it.
+
+Caller-supplied affinity headers or `cache_salt` fields cannot override these
+server-derived values. The values are built in per-request dictionaries;
+cached endpoint adapters and shared HTTP client defaults are not mutated.
+Streaming captures an immutable request body and headers before returning its
+generator, preventing another request from changing them.
+
+The installed compatibility policy is:
+
+| vLLM operation | Session affinity header | `cache_salt` |
+| --- | --- | --- |
+| chat/completions, completions, responses | yes | yes |
+| embeddings, pooling, classify, score | yes | yes |
+| Anthropic messages | yes | no |
+| health, metrics, unknown operations | yes when routed through the Minerva adapter | no |
+
+Anthropic messages can retain replica-local reuse through affinity, but FIRST
+does not claim salted cross-user cache isolation for that protocol. Do not add
+unknown body fields or a vLLM monkeypatch to change this table; update it only
+when the installed vLLM request schema explicitly supports the field.
+
+## Endpoint Fixtures And Capacity
+
+A fixture row represents a logical model, not a replica. Its `api_url` remains
+the one NGINX route, for example:
+
+```text
+https://minerva-login-01.minerva.alcf.anl.gov:9443/models/nemotron-3-ultra/v1
+```
+
+Adding or removing Minerva replicas requires no FIRST fixture or database
+change. Retiring a logical model does require targeted deletion of its endpoint
+row plus endpoint-cache invalidation; restore the row only after its Minerva
+route is healthy again.
+
+## Security And Validation
+
+Keep TLS hostname checking enabled and retain the configured client
+certificate, private key, and CA. FIRST sends only opaque derived values to
+Minerva. Logs must not contain bearer tokens, TLS keys or certificates, raw
+session IDs, raw user IDs, affinity keys, cache salts, prompts, or bodies.
+
+After a deployment or secret rotation, verify:
+
+1. the same authenticated user/model/session derives stable behavior;
+2. different sessions can reach different replicas;
+3. different users cannot share the same cache namespace;
+4. both non-streaming and streaming requests succeed; and
+5. non-Minerva Direct API adapters receive no Minerva-specific headers or body
+   fields.

--- a/env.example
+++ b/env.example
@@ -75,3 +75,8 @@ MAX_BATCHES_PER_USER=2
 RATE_LIMIT_PER_SEC_PER_USER=10
 STREAMING_SERVER_HOST="localhost:8080"
 INTERNAL_STREAMING_SECRET="your-internal-streaming-secret-key"
+
+# Dedicated secret for opaque Minerva user/model/session routing values.
+# Generate at least 32 random bytes and manage it separately from API keys and
+# Django's SECRET_KEY. Rotating it intentionally causes a Minerva cold-cache event.
+MINERVA_AFFINITY_HMAC_KEY="generate-a-dedicated-random-secret"

--- a/inference_gateway/settings.py
+++ b/inference_gateway/settings.py
@@ -37,6 +37,10 @@ load_dotenv(override=True)
 # Django secret key
 SECRET_KEY = os.getenv("SECRET_KEY")
 
+# Dedicated Minerva affinity/cache namespace key. It is validated only when a
+# Minerva inference request is forwarded so unrelated adapters remain usable.
+MINERVA_AFFINITY_HMAC_KEY = os.getenv("MINERVA_AFFINITY_HMAC_KEY")
+
 # Define whether we are in the automated test suite mode
 RUNNING_AUTOMATED_TEST_SUITE = os.getenv(
     "RUNNING_AUTOMATED_TEST_SUITE", "False"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
           - Globus Compute + vLLM: admin-guide/inference-setup/globus-compute.md
           - Local vLLM Setup: admin-guide/inference-setup/local-vllm.md
           - Direct API Connection: admin-guide/inference-setup/direct-api.md
+          - Minerva Direct API Affinity: admin-guide/inference-setup/minerva.md
       - Connecting Gateway to Backends:
           - Overview: admin-guide/connecting-gateway-to-backend/index.md
           - Globus Compute Adaptors: admin-guide/connecting-gateway-to-backend/globus-compute.md
@@ -104,4 +105,3 @@ extra:
       link: https://doi.org/10.1145/3731599.3767346
 
 copyright: Copyright &copy; 2025 Argonne National Laboratory - Apache 2.0 License
-

--- a/resource_server_async/endpoints/direct_api.py
+++ b/resource_server_async/endpoints/direct_api.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import json
 import logging
 import os
@@ -97,13 +98,24 @@ class DirectAPIEndpoint(BaseEndpoint):
 
     # Submit task
     async def submit_task(self, data: dict[str, Any]) -> SubmitTaskResult:
+        return await self._submit_task_with_headers(data)
+
+    async def _submit_task_with_headers(
+        self,
+        data: dict[str, Any],
+        request_headers: dict[str, str] | None = None,
+    ) -> SubmitTaskResult:
         """Submits a single interactive task to the compute resource."""
-        endpoint = data.pop("openai_endpoint", "chat/completions").strip("/")
+        request_data = copy.deepcopy(data)
+        endpoint = request_data.pop("openai_endpoint", "chat/completions").strip("/")
         url = f"{self.config.api_url.rstrip('/')}/{endpoint}"
+        captured_headers = dict(request_headers) if request_headers else None
 
         # Submit POST call and wait for the response
         try:
-            response = await self.httpx_client.post(url, data=data)
+            response = await self.httpx_client.post(
+                url, data=request_data, headers=captured_headers
+            )
         except httpx.HTTPStatusError as e:
             raise EndpointError(
                 f"Upstream endpoint returned {e.response.status_code}: {e.response.content[:256]!r}.",
@@ -126,7 +138,24 @@ class DirectAPIEndpoint(BaseEndpoint):
     async def submit_streaming_task(
         self, data: dict[str, Any]
     ) -> SubmitStreamingTaskResponse:
+        return await self._submit_streaming_task_with_headers(data)
+
+    async def _submit_streaming_task_with_headers(
+        self,
+        data: dict[str, Any],
+        request_headers: dict[str, str] | None = None,
+    ) -> SubmitStreamingTaskResponse:
         """Submits a single interactive task to the compute resource with streaming enabled."""
+
+        # Capture request-local state before returning the lazy streaming
+        # generator. Endpoint adapters and HTTP clients are shared objects.
+        request_data = copy.deepcopy(data)
+        endpoint = request_data.pop("openai_endpoint", "chat/completions").strip("/")
+        url = f"{self.config.api_url.rstrip('/')}/{endpoint}"
+        captured_headers = {
+            **self.httpx_client.headers,
+            **dict(request_headers or {}),
+        }
 
         # Shared state for tracking streaming (optimized - minimal memory)
         streaming_state: StreamingState = {
@@ -143,7 +172,9 @@ class DirectAPIEndpoint(BaseEndpoint):
 
             # For each streaming chunk ...
             try:
-                async for chunk in self.__get_stream_chunks(data):
+                async for chunk in self.__get_stream_chunks(
+                    url, request_data, captured_headers
+                ):
                     if chunk:
                         # Send chunk
                         streaming_state["total_chunks"] += 1
@@ -205,12 +236,12 @@ class DirectAPIEndpoint(BaseEndpoint):
 
     # Get stream chunks
     async def __get_stream_chunks(
-        self, data: dict[str, Any]
+        self,
+        url: str,
+        data: dict[str, Any],
+        headers: dict[str, str],
     ) -> AsyncGenerator[str, None]:
         """Make a direct API streaming call to the endpoint."""
-        endpoint = data.pop("openai_endpoint", "chat/completions").strip("/")
-        url = f"{self.config.api_url.rstrip('/')}/{endpoint}"
-
         # Create an async HTTPx client
         try:
             async with httpx.AsyncClient(
@@ -228,7 +259,7 @@ class DirectAPIEndpoint(BaseEndpoint):
                     "POST",
                     url,
                     json=data,
-                    headers=self.httpx_client.headers,
+                    headers=headers,
                 ) as response:
                     # Return error if something went wrong
                     if response.status_code != 200:

--- a/resource_server_async/endpoints/direct_api.py
+++ b/resource_server_async/endpoints/direct_api.py
@@ -1,5 +1,4 @@
 import asyncio
-import copy
 import json
 import logging
 import os
@@ -106,7 +105,7 @@ class DirectAPIEndpoint(BaseEndpoint):
         request_headers: dict[str, str] | None = None,
     ) -> SubmitTaskResult:
         """Submits a single interactive task to the compute resource."""
-        request_data = copy.deepcopy(data)
+        request_data = dict(data)
         endpoint = request_data.pop("openai_endpoint", "chat/completions").strip("/")
         url = f"{self.config.api_url.rstrip('/')}/{endpoint}"
         captured_headers = dict(request_headers) if request_headers else None
@@ -149,7 +148,7 @@ class DirectAPIEndpoint(BaseEndpoint):
 
         # Capture request-local state before returning the lazy streaming
         # generator. Endpoint adapters and HTTP clients are shared objects.
-        request_data = copy.deepcopy(data)
+        request_data = dict(data)
         endpoint = request_data.pop("openai_endpoint", "chat/completions").strip("/")
         url = f"{self.config.api_url.rstrip('/')}/{endpoint}"
         captured_headers = {

--- a/resource_server_async/endpoints/direct_api.py
+++ b/resource_server_async/endpoints/direct_api.py
@@ -24,6 +24,34 @@ from ..schemas.endpoints import (
 
 log = logging.getLogger(__name__)
 
+_FORWARDED_REQUEST_HEADER_ALLOWLIST = {
+    "x-minerva-affinity-key": "X-Minerva-Affinity-Key",
+    "x-request-id": "X-Request-ID",
+}
+
+
+def _merge_forwarded_request_headers(
+    request_headers: dict[str, str] | None,
+    default_headers: dict[str, str],
+) -> dict[str, str]:
+    """Validate per-request headers and keep configured defaults authoritative."""
+    forwarded: dict[str, str] = {}
+    for name, value in (request_headers or {}).items():
+        canonical_name = _FORWARDED_REQUEST_HEADER_ALLOWLIST.get(name.casefold())
+        if canonical_name is None:
+            raise EndpointError(
+                "Only X-Minerva-Affinity-Key and X-Request-ID may be forwarded.",
+                status_code=400,
+            )
+        forwarded[canonical_name] = value
+
+    for name, value in default_headers.items():
+        for forwarded_name in tuple(forwarded):
+            if forwarded_name.casefold() == name.casefold():
+                del forwarded[forwarded_name]
+        forwarded[name] = value
+    return forwarded
+
 
 class DirectAPIEndpointConfig(BaseModel):
     api_url: str
@@ -108,7 +136,11 @@ class DirectAPIEndpoint(BaseEndpoint):
         request_data = dict(data)
         endpoint = request_data.pop("openai_endpoint", "chat/completions").strip("/")
         url = f"{self.config.api_url.rstrip('/')}/{endpoint}"
-        captured_headers = dict(request_headers) if request_headers else None
+        captured_headers = (
+            _merge_forwarded_request_headers(request_headers, self.httpx_client.headers)
+            if request_headers is not None
+            else None
+        )
 
         # Submit POST call and wait for the response
         try:
@@ -151,10 +183,9 @@ class DirectAPIEndpoint(BaseEndpoint):
         request_data = dict(data)
         endpoint = request_data.pop("openai_endpoint", "chat/completions").strip("/")
         url = f"{self.config.api_url.rstrip('/')}/{endpoint}"
-        captured_headers = {
-            **self.httpx_client.headers,
-            **dict(request_headers or {}),
-        }
+        captured_headers = _merge_forwarded_request_headers(
+            request_headers, self.httpx_client.headers
+        )
 
         # Shared state for tracking streaming (optimized - minimal memory)
         streaming_state: StreamingState = {

--- a/resource_server_async/endpoints/minerva.py
+++ b/resource_server_async/endpoints/minerva.py
@@ -3,6 +3,12 @@ from typing import Any
 
 from resource_server_async.clusters.minerva import MinervaCluster
 from resource_server_async.endpoints.direct_api import DirectAPIEndpoint
+from resource_server_async.logging import get_request_context
+from resource_server_async.minerva_affinity import (
+    CACHE_SALT_ENDPOINTS,
+    MinervaAffinityConfigurationError,
+    derive_minerva_request_values,
+)
 
 from ..errors import EndpointError
 from ..schemas.endpoints import (
@@ -35,20 +41,50 @@ class MinervaEndpoint(DirectAPIEndpoint):
 
     async def submit_task(self, data: dict[str, Any]) -> SubmitTaskResult:
         await self.check_endpoint_status()
-        api_request_data = {**data["model_params"]}
-        api_request_data["stream"] = False
-        api_request_data.pop("api_port", None)
+        api_request_data, request_headers = self._prepare_request(data, stream=False)
         log.info(
             f"Making Minerva Direct API call for model {self.model} (stream=False)"
         )
-        return await super().submit_task(api_request_data)
+        return await self._submit_task_with_headers(
+            api_request_data, request_headers=request_headers
+        )
 
     async def submit_streaming_task(
         self, data: dict[str, Any]
     ) -> SubmitStreamingTaskResponse:
         await self.check_endpoint_status()
-        api_request_data = {**data["model_params"]}
-        api_request_data["stream"] = True
-        api_request_data.pop("api_port", None)
+        api_request_data, request_headers = self._prepare_request(data, stream=True)
         log.info(f"Making Minerva Direct API call for model {self.model} (stream=True)")
-        return await super().submit_streaming_task(api_request_data)
+        return await self._submit_streaming_task_with_headers(
+            api_request_data, request_headers=request_headers
+        )
+
+    def _prepare_request(
+        self,
+        data: dict[str, Any],
+        *,
+        stream: bool,
+    ) -> tuple[dict[str, Any], dict[str, str]]:
+        api_request_data = {**data["model_params"]}
+        api_request_data["stream"] = stream
+        api_request_data.pop("api_port", None)
+        endpoint = str(
+            api_request_data.get("openai_endpoint", "chat/completions")
+        ).strip("/")
+
+        try:
+            request_headers, cache_salt = derive_minerva_request_values(
+                get_request_context(), self.model
+            )
+        except MinervaAffinityConfigurationError as exc:
+            raise EndpointError(
+                f"Minerva affinity configuration error: {exc}", status_code=500
+            ) from exc
+
+        if endpoint in CACHE_SALT_ENDPOINTS:
+            # A caller value, if its public request schema ever accepts one,
+            # cannot replace the server-derived namespace.
+            api_request_data["cache_salt"] = cache_salt
+        else:
+            api_request_data.pop("cache_salt", None)
+        return api_request_data, request_headers

--- a/resource_server_async/httpx_client.py
+++ b/resource_server_async/httpx_client.py
@@ -55,8 +55,13 @@ class AsyncHttpClient:
         response.raise_for_status()
         return response.json()
 
-    async def post(self, url: str, data: Any = None) -> Any:
-        response = await self._client.post(url, json=data)
+    async def post(
+        self,
+        url: str,
+        data: Any = None,
+        headers: dict[str, str] | None = None,
+    ) -> Any:
+        response = await self._client.post(url, json=data, headers=headers)
         response.raise_for_status()
         return response.json()
 

--- a/resource_server_async/logging.py
+++ b/resource_server_async/logging.py
@@ -8,7 +8,7 @@ from inspect import iscoroutinefunction
 from logging import getLogger
 
 from asgiref.sync import async_to_sync, markcoroutinefunction, sync_to_async
-from django.http import HttpRequest, HttpResponse, StreamingHttpResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse, StreamingHttpResponse
 
 from resource_server_async.schemas.structured_logs import (
     AccessLogPydantic,
@@ -17,6 +17,7 @@ from resource_server_async.schemas.structured_logs import (
 )
 
 from .cache import should_throttle
+from .minerva_affinity import SESSION_HEADER, validate_session_id
 
 logger = getLogger(__name__)
 
@@ -26,6 +27,7 @@ class RequestContext:
     access_log: AccessLogPydantic
     user: UserPydantic | None = None
     request_log: RequestLogPydantic | None = None
+    minerva_session_id: str | None = None
 
 
 _request_context: ContextVar[RequestContext] = ContextVar("_request_context")
@@ -107,10 +109,19 @@ class AccessLogMiddleware:
         self, request: HttpRequest
     ) -> HttpResponse | StreamingHttpResponse:
 
-        token = _request_context.set(RequestContext(initialize_access_log(request)))
+        context = RequestContext(initialize_access_log(request))
+        token = _request_context.set(context)
+        response: HttpResponse | StreamingHttpResponse
 
         try:
-            response = await self.get_response(request)
+            try:
+                context.minerva_session_id = validate_session_id(
+                    request.headers.get(SESSION_HEADER)
+                )
+            except ValueError as exc:
+                response = JsonResponse({"detail": str(exc)}, status=400)
+            else:
+                response = await self.get_response(request)
             ctx_data = _request_context.get()
         finally:
             _request_context.reset(token)

--- a/resource_server_async/minerva_affinity.py
+++ b/resource_server_async/minerva_affinity.py
@@ -1,0 +1,119 @@
+"""Request-scoped identity derivation for Minerva replica affinity and cache isolation."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+from typing import TYPE_CHECKING
+
+from django.conf import settings
+
+if TYPE_CHECKING:
+    from resource_server_async.logging import RequestContext
+
+
+SESSION_HEADER = "X-ALCF-Session-ID"
+MAX_SESSION_ID_BYTES = 128
+AFFINITY_HEADER = "X-Minerva-Affinity-Key"
+REQUEST_ID_HEADER = "X-Request-ID"
+
+# vLLM 0.26.0 request protocols whose validated JSON schemas expose cache_salt.
+# Anthropic messages, health, and metrics intentionally remain absent.
+CACHE_SALT_ENDPOINTS = frozenset(
+    {
+        "chat/completions",
+        "completions",
+        "responses",
+        "embeddings",
+        "pooling",
+        "classify",
+        "score",
+    }
+)
+
+
+class MinervaAffinityConfigurationError(RuntimeError):
+    pass
+
+
+def validate_session_id(value: str | None) -> str | None:
+    """Validate an optional visible-ASCII conversation/branch identifier."""
+    if value is None or value == "":
+        return None
+    try:
+        encoded = value.encode("ascii")
+    except UnicodeEncodeError as exc:
+        raise ValueError(
+            f"{SESSION_HEADER} must contain at most {MAX_SESSION_ID_BYTES} visible ASCII bytes"
+        ) from exc
+    if len(encoded) > MAX_SESSION_ID_BYTES or any(
+        byte < 0x21 or byte > 0x7E for byte in encoded
+    ):
+        raise ValueError(
+            f"{SESSION_HEADER} must contain at most {MAX_SESSION_ID_BYTES} visible ASCII bytes"
+        )
+    return value
+
+
+def affinity_secret() -> bytes:
+    value = getattr(settings, "MINERVA_AFFINITY_HMAC_KEY", None)
+    if isinstance(value, str):
+        secret = value.encode("utf-8")
+    elif isinstance(value, bytes):
+        secret = value
+    else:
+        secret = b""
+    if len(secret) < 32:
+        raise MinervaAffinityConfigurationError(
+            "MINERVA_AFFINITY_HMAC_KEY must contain at least 32 bytes"
+        )
+    return secret
+
+
+def hmac_base64url(secret: bytes, fields: tuple[str, ...]) -> str:
+    message = b"\0".join(field.encode("utf-8") for field in fields)
+    digest = hmac.new(secret, message, hashlib.sha256).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def derive_cache_salt(secret: bytes, user_id: str, model_slug: str) -> str:
+    return hmac_base64url(secret, ("minerva-cache-v1", user_id, model_slug))
+
+
+def derive_affinity_key(
+    secret: bytes,
+    user_id: str,
+    model_slug: str,
+    session_id: str | None,
+) -> str:
+    return hmac_base64url(
+        secret,
+        (
+            "minerva-affinity-v1",
+            user_id,
+            model_slug,
+            session_id if session_id is not None else "user-default",
+        ),
+    )
+
+
+def derive_minerva_request_values(
+    context: RequestContext,
+    model_slug: str,
+) -> tuple[dict[str, str], str]:
+    if context.user is None:
+        raise MinervaAffinityConfigurationError(
+            "authenticated user identity is unavailable for Minerva affinity"
+        )
+    secret = affinity_secret()
+    user_id = context.user.id
+    affinity_key = derive_affinity_key(
+        secret, user_id, model_slug, context.minerva_session_id
+    )
+    cache_salt = derive_cache_salt(secret, user_id, model_slug)
+    headers = {
+        AFFINITY_HEADER: affinity_key,
+        REQUEST_ID_HEADER: context.access_log.id,
+    }
+    return headers, cache_salt

--- a/resource_server_async/tests/test_minerva_affinity.py
+++ b/resource_server_async/tests/test_minerva_affinity.py
@@ -400,7 +400,7 @@ class DirectAPIIsolationChecks(SimpleTestCase):
         endpoint._BaseEndpoint__endpoint_slug = "direct-test"
         return endpoint
 
-    async def test_stream_captures_body_and_per_call_headers_before_iteration(
+    async def test_stream_captures_top_level_body_and_headers_before_iteration(
         self,
     ) -> None:
         endpoint = self.direct_endpoint()
@@ -419,7 +419,7 @@ class DirectAPIIsolationChecks(SimpleTestCase):
             result = await endpoint._submit_streaming_task_with_headers(
                 data, request_headers=headers
             )
-            data["messages"][0]["content"] = "mutated"
+            data["messages"] = [{"role": "user", "content": "mutated"}]
             data["cache_salt"] = "mutated-salt"
             headers[AFFINITY_HEADER] = "mutated-affinity"
             chunks = [chunk async for chunk in result.response.streaming_content]
@@ -430,7 +430,7 @@ class DirectAPIIsolationChecks(SimpleTestCase):
         self.assertEqual(capture["headers"][AFFINITY_HEADER], "original-affinity")
         self.assertEqual(capture["headers"]["Authorization"], "Bearer test-key")
 
-    async def test_nonstream_copies_per_call_body_and_headers(self) -> None:
+    async def test_nonstream_copies_top_level_body_and_headers(self) -> None:
         endpoint = self.direct_endpoint()
         endpoint.httpx_client.post = AsyncMock(return_value={"ok": True})
         data = {
@@ -441,10 +441,11 @@ class DirectAPIIsolationChecks(SimpleTestCase):
         headers = {AFFINITY_HEADER: "original-affinity"}
 
         await endpoint._submit_task_with_headers(data, request_headers=headers)
-        data["messages"][0]["content"] = "mutated"
+        data["messages"] = [{"role": "user", "content": "mutated"}]
         headers[AFFINITY_HEADER] = "mutated-affinity"
 
         sent = endpoint.httpx_client.post.await_args
+        self.assertIsNot(sent.kwargs["data"], data)
         self.assertEqual(sent.kwargs["data"]["messages"][0]["content"], "original")
         self.assertEqual(sent.kwargs["headers"][AFFINITY_HEADER], "original-affinity")
         self.assertNotIn(AFFINITY_HEADER, endpoint.httpx_client.headers)

--- a/resource_server_async/tests/test_minerva_affinity.py
+++ b/resource_server_async/tests/test_minerva_affinity.py
@@ -400,10 +400,17 @@ class DirectAPIIsolationChecks(SimpleTestCase):
         endpoint._BaseEndpoint__endpoint_slug = "direct-test"
         return endpoint
 
+    @staticmethod
+    def header_value(headers: dict[str, str], name: str) -> str:
+        return {key.casefold(): value for key, value in headers.items()}[
+            name.casefold()
+        ]
+
     async def test_stream_captures_top_level_body_and_headers_before_iteration(
         self,
     ) -> None:
         endpoint = self.direct_endpoint()
+        endpoint.httpx_client.headers["x-rEqUeSt-Id"] = "configured-request-id"
         capture: dict = {}
         data = {
             "model": "model-a",
@@ -411,7 +418,11 @@ class DirectAPIIsolationChecks(SimpleTestCase):
             "messages": [{"role": "user", "content": "original"}],
             "cache_salt": "original-salt",
         }
-        headers = {AFFINITY_HEADER: "original-affinity"}
+        affinity_name = "x-MiNeRvA-aFfInItY-kEy"
+        headers = {
+            affinity_name: "original-affinity",
+            "X-ReQuEsT-ID": "request-local-id",
+        }
         with patch(
             "resource_server_async.endpoints.direct_api.httpx.AsyncClient",
             side_effect=lambda **kwargs: FakeStreamingClient(capture, **kwargs),
@@ -421,34 +432,94 @@ class DirectAPIIsolationChecks(SimpleTestCase):
             )
             data["messages"] = [{"role": "user", "content": "mutated"}]
             data["cache_salt"] = "mutated-salt"
-            headers[AFFINITY_HEADER] = "mutated-affinity"
+            headers[affinity_name] = "mutated-affinity"
             chunks = [chunk async for chunk in result.response.streaming_content]
 
         self.assertEqual(chunks, [b"data: captured\n\n", b"data: [DONE]\n\n"])
         self.assertEqual(capture["json"]["messages"][0]["content"], "original")
         self.assertEqual(capture["json"]["cache_salt"], "original-salt")
-        self.assertEqual(capture["headers"][AFFINITY_HEADER], "original-affinity")
-        self.assertEqual(capture["headers"]["Authorization"], "Bearer test-key")
+        self.assertEqual(
+            self.header_value(capture["headers"], AFFINITY_HEADER),
+            "original-affinity",
+        )
+        self.assertEqual(
+            self.header_value(capture["headers"], REQUEST_ID_HEADER),
+            "configured-request-id",
+        )
+        self.assertEqual(
+            self.header_value(capture["headers"], "Authorization"),
+            "Bearer test-key",
+        )
 
     async def test_nonstream_copies_top_level_body_and_headers(self) -> None:
         endpoint = self.direct_endpoint()
+        endpoint.httpx_client.headers["x-rEqUeSt-Id"] = "configured-request-id"
         endpoint.httpx_client.post = AsyncMock(return_value={"ok": True})
         data = {
             "model": "model-a",
             "openai_endpoint": "chat/completions",
             "messages": [{"role": "user", "content": "original"}],
         }
-        headers = {AFFINITY_HEADER: "original-affinity"}
+        affinity_name = "x-MiNeRvA-aFfInItY-kEy"
+        headers = {
+            affinity_name: "original-affinity",
+            "X-ReQuEsT-ID": "request-local-id",
+        }
 
         await endpoint._submit_task_with_headers(data, request_headers=headers)
         data["messages"] = [{"role": "user", "content": "mutated"}]
-        headers[AFFINITY_HEADER] = "mutated-affinity"
+        headers[affinity_name] = "mutated-affinity"
 
         sent = endpoint.httpx_client.post.await_args
         self.assertIsNot(sent.kwargs["data"], data)
         self.assertEqual(sent.kwargs["data"]["messages"][0]["content"], "original")
-        self.assertEqual(sent.kwargs["headers"][AFFINITY_HEADER], "original-affinity")
+        self.assertEqual(
+            self.header_value(sent.kwargs["headers"], AFFINITY_HEADER),
+            "original-affinity",
+        )
+        self.assertEqual(
+            self.header_value(sent.kwargs["headers"], REQUEST_ID_HEADER),
+            "configured-request-id",
+        )
+        self.assertEqual(
+            self.header_value(sent.kwargs["headers"], "Authorization"),
+            "Bearer test-key",
+        )
         self.assertNotIn(AFFINITY_HEADER, endpoint.httpx_client.headers)
+
+    async def test_nonstream_rejects_mixed_case_default_header_overrides(
+        self,
+    ) -> None:
+        endpoint = self.direct_endpoint()
+        endpoint.httpx_client.post = AsyncMock(return_value={"ok": True})
+        data = {"model": "model-a"}
+
+        for name in ("aUtHoRiZaTiOn", "cOnTeNt-TyPe"):
+            with self.subTest(name=name):
+                supplied_value = f"caller-value-for-{name}"
+                with self.assertRaises(EndpointError) as raised:
+                    await endpoint._submit_task_with_headers(
+                        data, request_headers={name: supplied_value}
+                    )
+                self.assertEqual(raised.exception.status_code, 400)
+                self.assertNotIn(supplied_value, str(raised.exception))
+        endpoint.httpx_client.post.assert_not_awaited()
+
+    async def test_stream_rejects_mixed_case_default_header_overrides(
+        self,
+    ) -> None:
+        endpoint = self.direct_endpoint()
+        data = {"model": "model-a"}
+
+        for name in ("aUtHoRiZaTiOn", "cOnTeNt-TyPe"):
+            with self.subTest(name=name):
+                supplied_value = f"caller-value-for-{name}"
+                with self.assertRaises(EndpointError) as raised:
+                    await endpoint._submit_streaming_task_with_headers(
+                        data, request_headers={name: supplied_value}
+                    )
+                self.assertEqual(raised.exception.status_code, 400)
+                self.assertNotIn(supplied_value, str(raised.exception))
 
     async def test_non_minerva_direct_request_gets_no_minerva_values(self) -> None:
         endpoint = self.direct_endpoint()

--- a/resource_server_async/tests/test_minerva_affinity.py
+++ b/resource_server_async/tests/test_minerva_affinity.py
@@ -1,0 +1,464 @@
+import asyncio
+import re
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from django.http import JsonResponse
+from django.test import RequestFactory, SimpleTestCase, override_settings
+
+from resource_server_async.endpoints.direct_api import (
+    DirectAPIEndpoint,
+    DirectAPIEndpointConfig,
+)
+from resource_server_async.endpoints.minerva import MinervaEndpoint
+from resource_server_async.errors import EndpointError
+from resource_server_async.logging import (
+    AccessLogMiddleware,
+    RequestContext,
+    _request_context,
+    get_request_context,
+)
+from resource_server_async.minerva_affinity import (
+    AFFINITY_HEADER,
+    CACHE_SALT_ENDPOINTS,
+    REQUEST_ID_HEADER,
+    derive_affinity_key,
+    derive_cache_salt,
+    derive_minerva_request_values,
+    validate_session_id,
+)
+from resource_server_async.schemas.structured_logs import (
+    AccessLogPydantic,
+    UserPydantic,
+)
+
+TEST_SECRET = "0123456789abcdef0123456789abcdef-test-secret"
+
+
+def request_context(
+    *,
+    user_id: str = "user-a",
+    session_id: str | None = "session-a",
+    request_id: str = "request-a",
+) -> RequestContext:
+    return RequestContext(
+        access_log=AccessLogPydantic(
+            id=request_id,
+            timestamp_request="2026-08-04T00:00:00Z",
+            api_route="/minerva/api/v1/chat/completions",
+            origin_ip="127.0.0.1",
+        ),
+        user=UserPydantic(
+            id=user_id,
+            name="Test User",
+            username=f"{user_id}@example.test",
+            user_group_uuids=[],
+            idp_id="test-idp",
+            idp_name="Test IDP",
+            auth_service="test",
+        ),
+        minerva_session_id=session_id,
+    )
+
+
+def minerva_endpoint(model: str = "model-a") -> MinervaEndpoint:
+    endpoint = object.__new__(MinervaEndpoint)
+    endpoint._BaseEndpoint__model = model
+    return endpoint
+
+
+class SessionIdentifierChecks(SimpleTestCase):
+    def test_visible_ascii_and_empty_fallback(self) -> None:
+        self.assertEqual(
+            validate_session_id("conversation-42/branch_a"), "conversation-42/branch_a"
+        )
+        self.assertIsNone(validate_session_id(None))
+        self.assertIsNone(validate_session_id(""))
+
+    def test_invalid_or_overlength_values_are_rejected_without_echo(self) -> None:
+        for value in ("contains space", "control\tvalue", "é", "x" * 129):
+            with (
+                self.subTest(value=repr(value)),
+                self.assertRaises(ValueError) as raised,
+            ):
+                validate_session_id(value)
+            self.assertNotIn(value, str(raised.exception))
+
+    async def test_middleware_captures_valid_value_and_rejects_invalid_value(
+        self,
+    ) -> None:
+        observed: list[str | None] = []
+
+        async def get_response(_request):
+            observed.append(get_request_context().minerva_session_id)
+            return JsonResponse({"ok": True})
+
+        middleware = AccessLogMiddleware(get_response)
+        factory = RequestFactory()
+        with patch(
+            "resource_server_async.logging.should_skip_logging",
+            new=AsyncMock(return_value=True),
+        ):
+            valid = factory.get("/test", HTTP_X_ALCF_SESSION_ID="session-valid")
+            response = await middleware(valid)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(observed, ["session-valid"])
+
+            invalid = factory.get("/test")
+            invalid.META["HTTP_X_ALCF_SESSION_ID"] = "invalid\tvalue"
+            response = await middleware(invalid)
+            self.assertEqual(response.status_code, 400)
+            self.assertEqual(observed, ["session-valid"])
+            self.assertNotIn("invalid", response.content.decode("utf-8"))
+
+    @override_settings(MINERVA_AFFINITY_HMAC_KEY=TEST_SECRET)
+    async def test_caller_affinity_header_is_not_forwarded(self) -> None:
+        observed: list[str] = []
+
+        async def get_response(_request):
+            context = get_request_context()
+            context.user = request_context().user
+            headers, _salt = derive_minerva_request_values(context, "model-a")
+            observed.append(headers[AFFINITY_HEADER])
+            return JsonResponse({"ok": True})
+
+        middleware = AccessLogMiddleware(get_response)
+        request = RequestFactory().get(
+            "/resource_server/v1/chat/completions",
+            HTTP_X_ALCF_SESSION_ID="session-valid",
+            HTTP_X_MINERVA_AFFINITY_KEY="caller-must-not-win",
+        )
+        with patch(
+            "resource_server_async.logging.should_skip_logging",
+            new=AsyncMock(return_value=True),
+        ):
+            response = await middleware(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(observed), 1)
+        self.assertNotEqual(observed[0], "caller-must-not-win")
+        self.assertRegex(observed[0], re.compile(r"^[A-Za-z0-9_-]{43}$"))
+
+
+@override_settings(MINERVA_AFFINITY_HMAC_KEY=TEST_SECRET)
+class DerivationChecks(SimpleTestCase):
+    def test_affinity_namespaces_user_model_and_session(self) -> None:
+        secret = TEST_SECRET.encode("utf-8")
+        base = derive_affinity_key(secret, "user-a", "model-a", "session-a")
+        self.assertEqual(
+            base,
+            derive_affinity_key(secret, "user-a", "model-a", "session-a"),
+        )
+        self.assertNotEqual(
+            base,
+            derive_affinity_key(secret, "user-a", "model-a", "session-b"),
+        )
+        self.assertNotEqual(
+            base,
+            derive_affinity_key(secret, "user-b", "model-a", "session-a"),
+        )
+        self.assertNotEqual(
+            base,
+            derive_affinity_key(secret, "user-a", "model-b", "session-a"),
+        )
+
+    def test_missing_session_has_stable_user_level_fallback(self) -> None:
+        secret = TEST_SECRET.encode("utf-8")
+        first = derive_affinity_key(secret, "user-a", "model-a", None)
+        second = derive_affinity_key(secret, "user-a", "model-a", None)
+        self.assertEqual(first, second)
+        self.assertNotEqual(
+            first, derive_affinity_key(secret, "user-b", "model-a", None)
+        )
+
+    def test_cache_salt_is_stable_across_sessions_and_isolated(self) -> None:
+        first_headers, first_salt = derive_minerva_request_values(
+            request_context(session_id="session-a"), "model-a"
+        )
+        second_headers, second_salt = derive_minerva_request_values(
+            request_context(session_id="session-b"), "model-a"
+        )
+        other_user_headers, other_user_salt = derive_minerva_request_values(
+            request_context(user_id="user-b", session_id="session-a"), "model-a"
+        )
+        _, other_model_salt = derive_minerva_request_values(
+            request_context(session_id="session-a"), "model-b"
+        )
+        self.assertEqual(first_salt, second_salt)
+        self.assertNotEqual(
+            first_headers[AFFINITY_HEADER], second_headers[AFFINITY_HEADER]
+        )
+        self.assertNotEqual(
+            first_headers[AFFINITY_HEADER], other_user_headers[AFFINITY_HEADER]
+        )
+        self.assertNotEqual(first_salt, other_user_salt)
+        self.assertNotEqual(first_salt, other_model_salt)
+
+    def test_values_are_256_bit_unpadded_base64url_and_request_id_is_preserved(
+        self,
+    ) -> None:
+        headers, salt = derive_minerva_request_values(
+            request_context(request_id="first-access-request-id"), "model-a"
+        )
+        for value in (headers[AFFINITY_HEADER], salt):
+            self.assertEqual(len(value), 43)
+            self.assertRegex(value, re.compile(r"^[A-Za-z0-9_-]{43}$"))
+            self.assertNotIn("=", value)
+        self.assertEqual(headers[REQUEST_ID_HEADER], "first-access-request-id")
+
+
+@override_settings(MINERVA_AFFINITY_HMAC_KEY=TEST_SECRET)
+class MinervaRequestPreparationChecks(SimpleTestCase):
+    def setUp(self) -> None:
+        self.endpoint = minerva_endpoint()
+        self.context_token = _request_context.set(request_context())
+
+    def tearDown(self) -> None:
+        _request_context.reset(self.context_token)
+
+    def test_supported_protocols_receive_server_derived_cache_salt(self) -> None:
+        expected_salt = derive_cache_salt(
+            TEST_SECRET.encode("utf-8"), "user-a", "model-a"
+        )
+        for endpoint in sorted(CACHE_SALT_ENDPOINTS):
+            with self.subTest(endpoint=endpoint):
+                body, headers = self.endpoint._prepare_request(
+                    {
+                        "model_params": {
+                            "model": "model-a",
+                            "openai_endpoint": endpoint,
+                            "cache_salt": "caller-must-not-win",
+                        }
+                    },
+                    stream=False,
+                )
+                self.assertEqual(body["cache_salt"], expected_salt)
+                self.assertNotEqual(headers[AFFINITY_HEADER], "caller-must-not-win")
+
+    def test_messages_health_metrics_and_unknown_protocols_omit_salt(self) -> None:
+        for endpoint in ("messages", "health", "metrics", "future-protocol"):
+            with self.subTest(endpoint=endpoint):
+                body, headers = self.endpoint._prepare_request(
+                    {
+                        "model_params": {
+                            "model": "model-a",
+                            "openai_endpoint": endpoint,
+                            "cache_salt": "caller-must-be-removed",
+                        }
+                    },
+                    stream=True,
+                )
+                self.assertNotIn("cache_salt", body)
+                self.assertTrue(body["stream"])
+                self.assertIn(AFFINITY_HEADER, headers)
+
+    @override_settings(MINERVA_AFFINITY_HMAC_KEY=None)
+    def test_missing_key_fails_closed_only_when_minerva_is_prepared(self) -> None:
+        with self.assertRaises(EndpointError) as raised:
+            self.endpoint._prepare_request(
+                {"model_params": {"model": "model-a"}}, stream=False
+            )
+        self.assertEqual(raised.exception.status_code, 500)
+        self.assertIn("MINERVA_AFFINITY_HMAC_KEY", str(raised.exception))
+
+    async def test_streaming_and_nonstreaming_pass_local_headers_and_body(self) -> None:
+        self.endpoint.check_endpoint_status = AsyncMock(return_value=True)
+        data = {
+            "model_params": {
+                "model": "model-a",
+                "messages": [{"role": "user", "content": "hello"}],
+                "openai_endpoint": "chat/completions",
+            }
+        }
+        with patch.object(
+            DirectAPIEndpoint,
+            "_submit_task_with_headers",
+            new=AsyncMock(return_value="non-stream-result"),
+        ) as submit_task:
+            result = await self.endpoint.submit_task(data)
+            self.assertEqual(result, "non-stream-result")
+            body = submit_task.await_args.args[0]
+            headers = submit_task.await_args.kwargs["request_headers"]
+            self.assertFalse(body["stream"])
+            self.assertIn("cache_salt", body)
+            self.assertIn(AFFINITY_HEADER, headers)
+
+        with patch.object(
+            DirectAPIEndpoint,
+            "_submit_streaming_task_with_headers",
+            new=AsyncMock(return_value="stream-result"),
+        ) as submit_stream:
+            result = await self.endpoint.submit_streaming_task(data)
+            self.assertEqual(result, "stream-result")
+            body = submit_stream.await_args.args[0]
+            headers = submit_stream.await_args.kwargs["request_headers"]
+            self.assertTrue(body["stream"])
+            self.assertIn("cache_salt", body)
+            self.assertIn(AFFINITY_HEADER, headers)
+
+    async def test_concurrent_users_do_not_contaminate_shared_endpoint_headers(
+        self,
+    ) -> None:
+        self.endpoint.check_endpoint_status = AsyncMock(return_value=True)
+        captures: dict[str, tuple[dict, dict]] = {}
+
+        async def capture(_endpoint, body, request_headers=None):
+            await asyncio.sleep(0)
+            user = get_request_context().user
+            assert user is not None
+            captures[user.id] = (dict(body), dict(request_headers or {}))
+            return user.id
+
+        data = {
+            "model_params": {
+                "model": "model-a",
+                "messages": [{"role": "user", "content": "hello"}],
+                "openai_endpoint": "chat/completions",
+            }
+        }
+
+        async def invoke(user_id: str):
+            token = _request_context.set(
+                request_context(user_id=user_id, session_id="same-session")
+            )
+            try:
+                return await self.endpoint.submit_task(data)
+            finally:
+                _request_context.reset(token)
+
+        with patch.object(DirectAPIEndpoint, "_submit_task_with_headers", new=capture):
+            await asyncio.gather(invoke("user-one"), invoke("user-two"))
+
+        self.assertEqual(set(captures), {"user-one", "user-two"})
+        first_body, first_headers = captures["user-one"]
+        second_body, second_headers = captures["user-two"]
+        self.assertNotEqual(
+            first_headers[AFFINITY_HEADER], second_headers[AFFINITY_HEADER]
+        )
+        self.assertNotEqual(first_body["cache_salt"], second_body["cache_salt"])
+
+
+class FakeStreamResponse:
+    status_code = 200
+
+    async def aread(self):
+        return b""
+
+    async def aiter_text(self):
+        yield "data: captured\n\n"
+        yield "data: [DONE]\n\n"
+
+
+class FakeAsyncContext:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class FakeStreamingClient:
+    def __init__(self, capture: dict, **_kwargs):
+        self.capture = capture
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    def stream(self, method, url, *, json, headers):
+        self.capture.update(
+            {
+                "method": method,
+                "url": url,
+                "json": json,
+                "headers": headers,
+            }
+        )
+        return FakeAsyncContext(FakeStreamResponse())
+
+
+class DirectAPIIsolationChecks(SimpleTestCase):
+    def direct_endpoint(self) -> DirectAPIEndpoint:
+        endpoint = object.__new__(DirectAPIEndpoint)
+        endpoint._DirectAPIEndpoint__config = DirectAPIEndpointConfig(
+            api_url="https://api.example/v1",
+            api_key_env_name="TEST_API_KEY",
+            trust_env=False,
+        )
+        endpoint._DirectAPIEndpoint__httpx_client = SimpleNamespace(
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": "Bearer test-key",
+            }
+        )
+        endpoint._BaseEndpoint__model = "model-a"
+        endpoint._BaseEndpoint__endpoint_slug = "direct-test"
+        return endpoint
+
+    async def test_stream_captures_body_and_per_call_headers_before_iteration(
+        self,
+    ) -> None:
+        endpoint = self.direct_endpoint()
+        capture: dict = {}
+        data = {
+            "model": "model-a",
+            "openai_endpoint": "chat/completions",
+            "messages": [{"role": "user", "content": "original"}],
+            "cache_salt": "original-salt",
+        }
+        headers = {AFFINITY_HEADER: "original-affinity"}
+        with patch(
+            "resource_server_async.endpoints.direct_api.httpx.AsyncClient",
+            side_effect=lambda **kwargs: FakeStreamingClient(capture, **kwargs),
+        ):
+            result = await endpoint._submit_streaming_task_with_headers(
+                data, request_headers=headers
+            )
+            data["messages"][0]["content"] = "mutated"
+            data["cache_salt"] = "mutated-salt"
+            headers[AFFINITY_HEADER] = "mutated-affinity"
+            chunks = [chunk async for chunk in result.response.streaming_content]
+
+        self.assertEqual(chunks, [b"data: captured\n\n", b"data: [DONE]\n\n"])
+        self.assertEqual(capture["json"]["messages"][0]["content"], "original")
+        self.assertEqual(capture["json"]["cache_salt"], "original-salt")
+        self.assertEqual(capture["headers"][AFFINITY_HEADER], "original-affinity")
+        self.assertEqual(capture["headers"]["Authorization"], "Bearer test-key")
+
+    async def test_nonstream_copies_per_call_body_and_headers(self) -> None:
+        endpoint = self.direct_endpoint()
+        endpoint.httpx_client.post = AsyncMock(return_value={"ok": True})
+        data = {
+            "model": "model-a",
+            "openai_endpoint": "chat/completions",
+            "messages": [{"role": "user", "content": "original"}],
+        }
+        headers = {AFFINITY_HEADER: "original-affinity"}
+
+        await endpoint._submit_task_with_headers(data, request_headers=headers)
+        data["messages"][0]["content"] = "mutated"
+        headers[AFFINITY_HEADER] = "mutated-affinity"
+
+        sent = endpoint.httpx_client.post.await_args
+        self.assertEqual(sent.kwargs["data"]["messages"][0]["content"], "original")
+        self.assertEqual(sent.kwargs["headers"][AFFINITY_HEADER], "original-affinity")
+        self.assertNotIn(AFFINITY_HEADER, endpoint.httpx_client.headers)
+
+    async def test_non_minerva_direct_request_gets_no_minerva_values(self) -> None:
+        endpoint = self.direct_endpoint()
+        endpoint.httpx_client.post = AsyncMock(return_value={"ok": True})
+        data = {
+            "model": "model-a",
+            "openai_endpoint": "chat/completions",
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+        await endpoint.submit_task(data)
+        sent = endpoint.httpx_client.post.await_args
+        self.assertIsNone(sent.kwargs["headers"])
+        self.assertNotIn("cache_salt", sent.kwargs["data"])
+        self.assertNotIn(AFFINITY_HEADER, endpoint.httpx_client.headers)


### PR DESCRIPTION
## Summary

Adds cache-aware routing for Minerva so related requests stay on the same vLLM replica while prefix-cache data remains isolated between users.

## Changes

- Accepts an optional X-ALCF-Session-ID.
- Derives opaque, server-controlled affinity keys from the authenticated user, model, and session.
- Adds per-user/model cache_salt values for supported vLLM operations.
- Prevents callers from overriding internal affinity or cache-isolation values.
- Keeps streaming and concurrent requests isolated.
- Applies only to Minerva adapters; other backends are unchanged.
- Documents the required MINERVA_AFFINITY_HMAC_KEY secret.

  ## Validation

- Full FIRST suite: 493 tests passed.
- Deployed and tested on the dev VM.
- Verified non-streaming, streaming, concurrency, user isolation, and that sensitive values do not appear in logs.