### PR TITLE
Add v2->v1 bridge

### DIFF
--- a/deploy/first_v2_bridge.md
+++ b/deploy/first_v2_bridge.md
@@ -1,0 +1,93 @@
+# First V2 → V1 Bridge Deployment
+
+The bridge is a long-lived sidecar (`manage.py first_v2_bridge`) that polls the
+V2 controller's Redis for its `router-cfg` blob and reconciles V1 `Endpoint`
+rows.
+
+The V1 gateway proxies inference to V2-managed pilot backends over
+mTLS (optionally through a SOCKS/HTTP proxy in the absence of a conduit).
+Requests to `/{cluster}/api/v1/...` and `/{cluster}/jobs` are then served by the
+`FirstV2Endpoint` / `TaraCluster` adapters.
+
+Note that the bridge and the V1 gateway use **two distinct Redis instances**!
+The bridge reads `router-cfg` from V2's Redis; it never writes to it. All
+writes go to the V1 Postgres `Endpoint`/`Cluster` tables.
+
+
+## Environment variables
+
+Both the gateway and the bridge run with the same workdir, and the same
+`inference_gateway.settings` module loads the `.env` file for both.
+Here are the new environment variables for the V2-V1 bridge.
+
+### Required
+
+| Variable                    | Example                         | Notes |
+| --------------------------- | ------------------------------- | ----- |
+| `FIRST_V2_REDIS_URL`        | `redis://v2-host:6379/1`        | Dedicated connection to V2's Redis. Must differ from `REDIS_URL`. |
+| `FIRST_V2_CA_CERT_PATH`     | `/etc/first/pki/ca.crt`         | CA that signed the backend server certs. |
+| `FIRST_V2_CLIENT_CERT_PATH` | `/etc/first/pki/first-pilot.crt`| Client cert presented to backends (mTLS). |
+| `FIRST_V2_CLIENT_KEY_PATH`  | `/etc/first/pki/first-pilot.key`| Private key for the client cert. Must be readable by the service `User`. |
+
+`REDIS_URL` (V1's own Redis) is required by the gateway independently and is assumed already set.
+
+### Optional
+
+| Variable                    | Default | Notes |
+| --------------------------- | ------- | ----- |
+| `FIRST_V2_PROXY_URL`        | *(unset → direct)* | SOCKS/HTTP proxy to reach backends, e.g. `socks5h://localhost:1080`. `socks5h://` requires httpx ≥ 0.28 (pinned in `uv.lock`). |
+| `FIRST_V2_CHECK_HOSTNAME`   | `false` | TLS hostname verification. Off because backends are reached by IP (mirrors V2's own client). |
+| `FIRST_V2_POLL_INTERVAL_SEC`| `10`    | Seconds between reconcile ticks. |
+
+The cert/proxy values are baked into each managed `Endpoint`'s `config` at
+reconcile time, so the gateway process reads them from the DB row at request
+time.
+
+## Systemd unit
+
+The unit is `deploy/first_v2_bridge.service`. It mirrors
+`gateway_async.service`: same `User`/`Group`/`WorkingDirectory`, runs the
+management command directly from the venv, `Restart=always`.
+
+Because config comes from `.env` (loaded by `load_dotenv`), the unit itself
+declares no `FIRST_V2_*` variables — it only sets `PATH` and
+`PYTHONUNBUFFERED`.
+
+### Install
+
+```sh
+# From the repo root on the gateway host (adjust paths if not /home/webportal):
+sudo cp deploy/first_v2_bridge.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now first_v2_bridge.service
+```
+
+### Verify
+
+```sh
+systemctl status first_v2_bridge.service
+journalctl -u first_v2_bridge.service -f
+# Healthy ticks log e.g.:
+#   first_v2_bridge tick: version=12 desired=1 created=0 updated=1 deleted=0
+```
+
+### One-shot dry run
+
+Before enabling the service, confirm connectivity and reconciliation with a
+single tick:
+
+```sh
+cd /home/webportal/inference-gateway
+.venv/bin/python manage.py first_v2_bridge --once
+```
+
+### Operations
+
+```sh
+sudo systemctl restart first_v2_bridge.service   # after changing .env or certs
+sudo systemctl stop first_v2_bridge.service      # pause reconciliation
+```
+
+Stopping the bridge leaves the last-reconciled `Endpoint` rows in place; the
+gateway keeps serving them until the bridge runs again and reconciles (deletes
+rows whose backends have disappeared).

--- a/deploy/first_v2_bridge.service
+++ b/deploy/first_v2_bridge.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=First V2 -> V1 endpoint registration bridge (sidecar)
+After=network.target
+
+[Service]
+User=webportal
+Group=webportal
+WorkingDirectory=/home/webportal/inference-gateway
+Environment=PATH=/home/webportal/inference-gateway/.venv/bin/
+Environment="PYTHONUNBUFFERED=1"
+ExecStart=/home/webportal/inference-gateway/.venv/bin/python manage.py first_v2_bridge
+KillMode=mixed
+TimeoutStopSec=5
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/pg-docker.sh
+++ b/deploy/pg-docker.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 set -eu
-docker run --name inference-gateway-db -e POSTGRES_PASSWORD=dataportaldevpwd123 -e POSTGRES_USER=dataportaldev -e POSTGRES_DB=postgres -p 5432:5432 -d postgres
+docker run --name inference-gateway-db -e POSTGRES_PASSWORD=dataportaldevpwd123 -e POSTGRES_USER=dataportaldev -e POSTGRES_DB=postgres -p 6432:5432 -d postgres

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "globus-sdk>=3.65.0,<4",
     "gunicorn",
     "h11",
-    "httpx",
+    "httpx[socks]",
     "psycopg-pool>=3.2.7,<4",
     "psycopg>=3.2.12,<4",
     "pyjwt>=2.12.0",

--- a/resource_server_async/clusters/__init__.py
+++ b/resource_server_async/clusters/__init__.py
@@ -3,6 +3,7 @@ from .direct_api import DirectAPICluster
 from .globus_compute import GlobusComputeCluster
 from .metis import MetisCluster
 from .minerva import MinervaCluster
+from .tara import TaraCluster
 
 __all__ = [
     "BaseCluster",
@@ -10,4 +11,5 @@ __all__ = [
     "DirectAPICluster",
     "MetisCluster",
     "MinervaCluster",
+    "TaraCluster",
 ]

--- a/resource_server_async/clusters/tara.py
+++ b/resource_server_async/clusters/tara.py
@@ -56,11 +56,15 @@ class TaraCluster(BaseCluster):
         except Exception as e:
             raise GetJobsError(f"Failed to read Tara router config: {e}")
 
-        desired = [
-            d
-            for d in desired_endpoints(cfg, settings)
-            if d.cluster == self.cluster_name
-        ]
+        desired = (
+            [
+                d
+                for d in desired_endpoints(cfg, settings)
+                if d.cluster == self.cluster_name
+            ]
+            if cfg
+            else []
+        )
 
         formatted = JobsByStatus()
         for d in desired:

--- a/resource_server_async/clusters/tara.py
+++ b/resource_server_async/clusters/tara.py
@@ -1,0 +1,86 @@
+import logging
+from typing import Any, List, override
+
+from asgiref.sync import sync_to_async
+
+from resource_server_async.clusters.cluster import BaseCluster
+from resource_server_async.first_v2_bridge.mapping import desired_endpoints
+from resource_server_async.first_v2_bridge.router_config import (
+    RouterConfig,
+    get_bridge_redis_client,
+)
+from resource_server_async.first_v2_bridge.settings import BridgeSettings
+
+from ..errors import GetJobsError
+from ..schemas.clusters import JobInfo, JobsByStatus
+from ..schemas.structured_logs import UserPydantic
+
+log = logging.getLogger(__name__)
+
+
+class TaraCluster(BaseCluster):
+    """Cluster adapter backed by the V2 RouterConfig blob."""
+
+    def __init__(
+        self,
+        id: str,
+        cluster_name: str,
+        cluster_adapter: str,
+        frameworks: List[str],
+        openai_endpoints: List[str],
+        config: dict[str, Any],
+        allowed_globus_groups: List[str] = [],
+        allowed_domains: List[str] = [],
+    ):
+        # config is accepted for fixture compatibility but unused: get_jobs
+        # reads the RouterConfig blob directly.
+        super().__init__(
+            id,
+            cluster_name,
+            cluster_adapter,
+            frameworks,
+            openai_endpoints,
+            allowed_globus_groups=allowed_globus_groups,
+            allowed_domains=allowed_domains,
+        )
+
+    @override
+    async def get_jobs(self, _auth: UserPydantic | None) -> JobsByStatus:
+        return await sync_to_async(self._load_status)()
+
+    def _load_status(self) -> JobsByStatus:
+        settings = BridgeSettings()
+        try:
+            redis_client = get_bridge_redis_client(settings.redis_url)
+            cfg = RouterConfig.load(redis_client)
+        except Exception as e:
+            raise GetJobsError(f"Failed to read Tara router config: {e}")
+
+        desired = [
+            d
+            for d in desired_endpoints(cfg, settings)
+            if d.cluster == self.cluster_name
+        ]
+
+        formatted = JobsByStatus()
+        for d in desired:
+            formatted.running.append(
+                JobInfo(
+                    **{
+                        "Models": d.model,
+                        "Framework": d.framework,
+                        "Cluster": d.cluster,
+                        "Model Status": "running",
+                        "Description": f"{d.model} on {self.cluster_name}",
+                        "Model Version": d.model,
+                    }
+                )
+            )
+
+        formatted.cluster_status = {
+            "cluster": self.cluster_name,
+            "total_models": len(desired),
+            "live_models": len(desired),
+            "stopped_models": 0,
+        }
+        return formatted

--- a/resource_server_async/endpoints/__init__.py
+++ b/resource_server_async/endpoints/__init__.py
@@ -1,5 +1,6 @@
 from .direct_api import DirectAPIEndpoint
 from .endpoint import BaseEndpoint
+from .first_v2 import FirstV2Endpoint
 from .globus_compute import GlobusComputeEndpoint
 from .metis import MetisEndpoint
 from .minerva import MinervaEndpoint
@@ -8,6 +9,7 @@ __all__ = [
     "BaseEndpoint",
     "GlobusComputeEndpoint",
     "DirectAPIEndpoint",
+    "FirstV2Endpoint",
     "MetisEndpoint",
     "MinervaEndpoint",
 ]

--- a/resource_server_async/endpoints/first_v2.py
+++ b/resource_server_async/endpoints/first_v2.py
@@ -1,0 +1,178 @@
+"""Isolated endpoint adapter for V2-managed (pilot) backends."""
+
+import json
+import logging
+import random
+import time
+from typing import Any, AsyncGenerator
+
+import httpx
+from django.http import StreamingHttpResponse
+from pydantic import BaseModel
+
+from resource_server_async.endpoints.direct_api import DirectAPIEndpoint
+from resource_server_async.endpoints.endpoint import BaseEndpoint
+from resource_server_async.httpx_client import create_ssl_context
+from resource_server_async.streaming import create_streaming_response_headers
+
+from ..errors import EndpointError
+from ..schemas.endpoints import (
+    SubmitStreamingTaskResponse,
+    SubmitTaskResult,
+)
+
+log = logging.getLogger(__name__)
+
+# Bridge backends can serve long generations; match the DirectAPI default.
+_REQUEST_TIMEOUT = 120
+
+
+class FirstV2EndpointConfig(BaseModel):
+    model_urls: list[str]
+    backend_model_name: str
+    ca_cert_path: str | None = None
+    client_cert_path: str | None = None
+    client_key_path: str | None = None
+    proxy_url: str | None = None
+    check_hostname: bool = False
+    trust_env: bool = False
+
+
+class FirstV2Endpoint(DirectAPIEndpoint):
+    """Endpoint adapter proxying to V2-managed pilot backends over mTLS."""
+
+    def __init__(
+        self,
+        id: str,
+        endpoint_slug: str,
+        cluster: str,
+        framework: str,
+        model: str,
+        endpoint_adapter: str,
+        tpm_model: int,
+        tpm_user: int,
+        config: dict[str, Any],
+        allowed_globus_groups: list[str] | None = None,
+        allowed_domains: list[str] | None = None,
+    ):
+        self._cfg = FirstV2EndpointConfig(**config)
+
+        # Isolated client: mTLS via client cert, optional proxy, no bearer.
+        verify = create_ssl_context(
+            ca_cert_path=self._cfg.ca_cert_path,
+            client_cert_path=self._cfg.client_cert_path,
+            client_key_path=self._cfg.client_key_path,
+            check_hostname=self._cfg.check_hostname,
+        )
+        self._client = httpx.AsyncClient(
+            timeout=_REQUEST_TIMEOUT,
+            headers={"Content-Type": "application/json"},
+            verify=verify,
+            proxy=self._cfg.proxy_url or None,
+            trust_env=self._cfg.trust_env,
+        )
+
+        # Initialize common attrs/permissions/token-limiter only; bypass
+        # DirectAPIEndpoint.__init__ so its own client/config are not built.
+        BaseEndpoint.__init__(
+            self,
+            id,
+            endpoint_slug,
+            cluster,
+            framework,
+            model,
+            endpoint_adapter,
+            tpm_model,
+            tpm_user,
+            config,
+            allowed_globus_groups,
+            allowed_domains,
+        )
+
+    def _pick_url(self) -> str:
+        return random.choice(self._cfg.model_urls)
+
+    def _build_request(
+        self, data: dict[str, Any], *, stream: bool
+    ) -> tuple[str, dict[str, Any]]:
+        """Unwrap model_params (Metis/Minerva pattern) and build the target URL."""
+        body = {**data["model_params"]}
+        body["stream"] = stream
+        body.pop("api_port", None)
+        openai_endpoint = str(body.pop("openai_endpoint", "chat/completions")).strip(
+            "/"
+        )
+        # Backends expect their own model name, not the alias.
+        body["model"] = self._cfg.backend_model_name
+        url = f"{self._pick_url().rstrip('/')}/v1/{openai_endpoint}"
+        return url, body
+
+    async def submit_task(self, data: dict[str, Any]) -> SubmitTaskResult:
+        url, body = self._build_request(data, stream=False)
+        log.info(f"Making First V2 API call for model {self.model} (stream=False)")
+        try:
+            response = await self._client.post(url, json=body)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            raise EndpointError(
+                f"Upstream endpoint returned {e.response.status_code}: {e.response.content[:256]!r}.",
+                status_code=e.response.status_code,
+            )
+        except httpx.TimeoutException:
+            raise EndpointError(
+                f"Timeout calling {url}.",
+                status_code=504,
+                info={"timeout": _REQUEST_TIMEOUT},
+            )
+        except httpx.HTTPError as e:
+            raise EndpointError(
+                f"HTTP error calling API at {url}: {e}", status_code=500
+            )
+
+        return SubmitTaskResult(result=response.json(), task_id=None)
+
+    async def submit_streaming_task(
+        self, data: dict[str, Any]
+    ) -> SubmitStreamingTaskResponse:
+        url, body = self._build_request(data, stream=True)
+        log.info(f"Making First V2 API call for model {self.model} (stream=True)")
+
+        async def sse_generator() -> AsyncGenerator[str, None]:
+            try:
+                async with self._client.stream("POST", url, json=body) as response:
+                    if response.status_code != 200:
+                        error_text = await response.aread()
+                        raise ValueError(
+                            f"Upstream endpoint returned {response.status_code}: "
+                            f"{error_text.decode(errors='replace').strip()[:256]}"
+                        )
+                    async for chunk in response.aiter_text():
+                        if chunk:
+                            yield chunk
+            except Exception as e:
+                error_chunk = {
+                    "id": "chatcmpl-api-error",
+                    "object": "chat.completion.chunk",
+                    "created": int(time.time()),
+                    "model": self.model,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "role": "assistant",
+                                "content": f"\n\n[ERROR] {e}",
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                }
+                yield f"data: {json.dumps(error_chunk)}\n\n"
+                yield "data: [DONE]\n\n"
+
+        response = StreamingHttpResponse(
+            streaming_content=sse_generator(), content_type="text/event-stream"
+        )
+        for key, value in create_streaming_response_headers().items():
+            response[key] = value
+
+        return SubmitStreamingTaskResponse(response=response, task_id=None)

--- a/resource_server_async/first_v2_bridge/mapping.py
+++ b/resource_server_async/first_v2_bridge/mapping.py
@@ -1,0 +1,131 @@
+"""Pure mapping functions from a parsed RouterConfig to desired V1 Endpoint rows."""
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any
+
+from django.utils.text import slugify
+
+from .router_config import ModelConfig, RouterConfig
+from .settings import BridgeSettings
+
+ENDPOINT_ADAPTER = "resource_server_async.endpoints.first_v2.FirstV2Endpoint"
+
+# Bridge-managed rows use a deterministic high PK range so they never collide
+# with fixture-loaded admin rows.
+PK_BASE = 2**40
+_PK_SPAN = 2**40
+
+# V2 lists only healthy replicas, and only pilot deployments are proxied by the
+# bridge.
+_PILOT_KIND = "pilot"
+
+
+def deterministic_pk(cluster: str, model: str) -> int:
+    """Stable high PK keyed on the model identity (not backend id).
+
+    Keying on ``(cluster, model)`` means replica churn is an in-place UPDATE of
+    ``model_urls`` rather than a slug-thrashing delete+insert.
+    """
+    digest = hashlib.sha1(f"{cluster}/{model}".encode()).hexdigest()
+    return PK_BASE + int(digest, 16) % _PK_SPAN
+
+
+@dataclass
+class DesiredEndpoint:
+    pk: int
+    endpoint_slug: str
+    cluster: str
+    framework: str
+    model: str
+    endpoint_adapter: str
+    allowed_globus_groups: list[str]
+    allowed_domains: list[str]
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+def _resolve_prefix(
+    deployment_name: str, prefix_map: dict[str, tuple[str, str]]
+) -> tuple[str, str] | None:
+    """Return the (cluster, framework) for a deployment name, or None if it
+    matches no configured prefix."""
+    for prefix, target in prefix_map.items():
+        if deployment_name.startswith(prefix):
+            return target
+    return None
+
+
+def desired_endpoints(
+    cfg: RouterConfig, bridge_settings: BridgeSettings
+) -> list[DesiredEndpoint]:
+    """Compute the set of V1 Endpoint rows that should exist for a config.
+
+    One row per ``(cluster, framework, model)``, carrying every healthy pilot
+    backend URL. Models with no matching healthy backend produce no row (so a
+    reconcile deletes any stale row).
+    """
+    desired: list[DesiredEndpoint] = []
+
+    for model in cfg.models:
+        # Group healthy pilot backends by the resolved (cluster, framework).
+        grouped: dict[tuple[str, str], list[str]] = {}
+        backend_model_name: dict[tuple[str, str], str] = {}
+
+        for deployment in model.deployments:
+            if deployment.kind != _PILOT_KIND:
+                continue
+            target = _resolve_prefix(deployment.name, bridge_settings.prefix_map)
+            if target is None:
+                continue
+            for backend in deployment.backends:
+                grouped.setdefault(target, []).append(backend.model_url)
+                # All backends of a deployment share a backend_model_name;
+                # first one wins for the group.
+                backend_model_name.setdefault(target, backend.backend_model_name)
+
+        for (cluster, framework), model_urls in grouped.items():
+            if not model_urls:
+                continue
+            desired.append(
+                _build_desired_endpoint(
+                    cluster=cluster,
+                    framework=framework,
+                    model=model,
+                    model_urls=model_urls,
+                    backend_model_name=backend_model_name[(cluster, framework)],
+                    bridge_settings=bridge_settings,
+                )
+            )
+
+    return desired
+
+
+def _build_desired_endpoint(
+    *,
+    cluster: str,
+    framework: str,
+    model: ModelConfig,
+    model_urls: list[str],
+    backend_model_name: str,
+    bridge_settings: BridgeSettings,
+) -> DesiredEndpoint:
+    return DesiredEndpoint(
+        pk=deterministic_pk(cluster, model.name),
+        endpoint_slug=slugify(f"{cluster} {framework} {model.name.lower()}"),
+        cluster=cluster,
+        framework=framework,
+        model=model.name,
+        endpoint_adapter=ENDPOINT_ADAPTER,
+        allowed_globus_groups=list(model.allowed_groups),
+        allowed_domains=list(model.allowed_domains),
+        config={
+            "model_urls": model_urls,
+            "backend_model_name": backend_model_name,
+            "ca_cert_path": bridge_settings.ca_cert_path,
+            "client_cert_path": bridge_settings.client_cert_path,
+            "client_key_path": bridge_settings.client_key_path,
+            "proxy_url": bridge_settings.proxy_url,
+            "check_hostname": bridge_settings.check_hostname,
+            "trust_env": bridge_settings.trust_env,
+        },
+    )

--- a/resource_server_async/first_v2_bridge/router_config.py
+++ b/resource_server_async/first_v2_bridge/router_config.py
@@ -68,10 +68,10 @@ class RouterConfig(BaseModel):
     models: list[ModelConfig] = []
 
     @classmethod
-    def load(cls, client: "redis.Redis") -> "RouterConfig":
+    def load(cls, client: "redis.Redis") -> "RouterConfig | None":
         """Read and parse the router config blob from Redis (sync client)."""
         raw = client.get(ROUTER_CONFIG_KEY)
         if not raw:
-            return cls()
+            return None
         assert isinstance(raw, (str, bytes, bytearray))
         return cls.model_validate_json(raw)

--- a/resource_server_async/first_v2_bridge/router_config.py
+++ b/resource_server_async/first_v2_bridge/router_config.py
@@ -1,0 +1,77 @@
+"""Trimmed, duplicated copy of V2's RouterConfig parser.
+
+Only the fields the bridge reads are modeled. extra="ignore" drops the many
+V2 fields we don't care about.
+"""
+
+import redis
+from pydantic import BaseModel, ConfigDict
+
+# The single JSON blob key written by the V2 control plane.
+ROUTER_CONFIG_KEY = "router-cfg"
+
+# Dedicated connection to V2's Redis, kept separate from V1's own cache/broker
+# client (resource_server_async.cache.get_redis_client) so the two deployments
+# never share a database. Cached singleton, keyed on the URL.
+_bridge_redis: dict[str, "redis.Redis"] = {}
+
+
+def get_bridge_redis_client(redis_url: str | None) -> "redis.Redis":
+    """Return a Redis client for V2's Redis.
+
+    Raises if ``redis_url`` is unset: the bridge must never silently fall back
+    to V1's Redis (that would read the wrong, empty database).
+    """
+    if not redis_url:
+        raise RuntimeError(
+            "FIRST_V2_REDIS_URL is not set; the bridge requires a dedicated "
+            "connection to V2's Redis and must not fall back to V1's."
+        )
+    client = _bridge_redis.get(redis_url)
+    if client is None:
+        client = redis.Redis.from_url(redis_url)
+        _bridge_redis[redis_url] = client
+    return client
+
+
+class BackendConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    model_url: str
+    backend_model_name: str
+    api_key: str | None = None
+
+
+class DeploymentConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    kind: str
+    name: str
+    backends: list[BackendConfig] = []
+
+
+class ModelConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    name: str
+    aliases: list[str] = []
+    allowed_groups: list[str] = []
+    allowed_domains: list[str] = []
+    deployments: list[DeploymentConfig] = []
+
+
+class RouterConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    version: int = 0
+    models: list[ModelConfig] = []
+
+    @classmethod
+    def load(cls, client: "redis.Redis") -> "RouterConfig":
+        """Read and parse the router config blob from Redis (sync client)."""
+        raw = client.get(ROUTER_CONFIG_KEY)
+        if not raw:
+            return cls()
+        assert isinstance(raw, (str, bytes, bytearray))
+        return cls.model_validate_json(raw)

--- a/resource_server_async/first_v2_bridge/settings.py
+++ b/resource_server_async/first_v2_bridge/settings.py
@@ -1,0 +1,32 @@
+import os
+
+# Mapping of V2 deployment-name prefix -> (V1 cluster, V1 framework).
+PrefixMap = dict[str, tuple[str, str]]
+
+
+def _default_prefix_map() -> PrefixMap:
+    return {"tara/": ("tara", "api")}
+
+
+class BridgeSettings:
+    """Bridge configuration snapshot, resolved from the environment."""
+
+    def __init__(self) -> None:
+        self.redis_url = os.environ.get("FIRST_V2_REDIS_URL") or None
+        self.ca_cert_path = os.environ.get("FIRST_V2_CA_CERT_PATH") or None
+        self.client_cert_path = os.environ.get("FIRST_V2_CLIENT_CERT_PATH") or None
+        self.client_key_path = os.environ.get("FIRST_V2_CLIENT_KEY_PATH") or None
+
+        # Optional SOCKS/HTTP proxy (e.g. socks5h://localhost:1080).
+        self.proxy_url = os.environ.get("FIRST_V2_PROXY_URL") or None
+        self.check_hostname = _env_bool("FIRST_V2_CHECK_HOSTNAME", False)
+        self.trust_env = False
+        self.poll_interval_sec = int(os.environ.get("FIRST_V2_POLL_INTERVAL_SEC", "10"))
+        self.prefix_map: PrefixMap = _default_prefix_map()
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")

--- a/resource_server_async/management/commands/first_v2_bridge.py
+++ b/resource_server_async/management/commands/first_v2_bridge.py
@@ -1,0 +1,120 @@
+"""Sidecar that mirrors V2-managed models into V1 Endpoint rows.
+
+Runs as a long-lived systemd service. Every ``FIRST_V2_POLL_INTERVAL_SEC`` it
+reads the V2 RouterConfig blob from Redis and reconciles the bridge-managed
+``Endpoint`` rows (scoped to the FirstV2Endpoint adapter) so V1 can proxy
+inference to the V2 backends.
+
+Usage:
+    python manage.py first_v2_bridge            # run forever
+    python manage.py first_v2_bridge --once     # one reconcile tick, then exit
+"""
+
+import logging
+import time
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+from resource_server_async.first_v2_bridge.mapping import (
+    ENDPOINT_ADAPTER,
+    DesiredEndpoint,
+    desired_endpoints,
+)
+from resource_server_async.first_v2_bridge.router_config import (
+    RouterConfig,
+    get_bridge_redis_client,
+)
+from resource_server_async.first_v2_bridge.settings import BridgeSettings
+from resource_server_async.models import Endpoint
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Mirror V2-managed models into V1 Endpoint rows"
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument(
+            "--once",
+            action="store_true",
+            help="Run a single reconcile tick and exit.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        settings = BridgeSettings()
+
+        if options.get("once", False):
+            self.stdout.write("first_v2_bridge running once")
+            return self._tick(settings)
+
+        self.stdout.write(
+            f"first_v2_bridge starting poll={settings.poll_interval_sec}s"
+        )
+
+        while True:
+            try:
+                self._tick(settings)
+            except Exception as e:
+                log.exception("first_v2_bridge tick failed: %s", e)
+            time.sleep(settings.poll_interval_sec)
+
+    def _tick(self, settings: BridgeSettings) -> None:
+        redis_client = get_bridge_redis_client(settings.redis_url)
+        cfg = RouterConfig.load(redis_client)
+        desired = desired_endpoints(cfg, settings)
+
+        created, updated, deleted = self._reconcile_endpoints(desired)
+
+        log.info(
+            "first_v2_bridge tick: version=%s desired=%s created=%s updated=%s deleted=%s",
+            cfg.version,
+            len(desired),
+            created,
+            updated,
+            deleted,
+        )
+
+    def _reconcile_endpoints(
+        self, desired: list[DesiredEndpoint]
+    ) -> tuple[int, int, int]:
+        """Upsert desired rows and delete stale bridge-managed rows.
+
+        Only rows using the FirstV2Endpoint adapter are ever touched.
+        """
+        desired_by_slug = {d.endpoint_slug: d for d in desired}
+
+        existing_slugs = set(
+            Endpoint.objects.filter(endpoint_adapter=ENDPOINT_ADAPTER).values_list(
+                "endpoint_slug", flat=True
+            )
+        )
+
+        created = updated = 0
+        for slug, d in desired_by_slug.items():
+            _, was_created = Endpoint.objects.update_or_create(
+                endpoint_slug=slug,
+                defaults={
+                    "id": d.pk,
+                    "cluster": d.cluster,
+                    "framework": d.framework,
+                    "model": d.model,
+                    "endpoint_adapter": d.endpoint_adapter,
+                    "allowed_globus_groups": d.allowed_globus_groups,
+                    "allowed_domains": d.allowed_domains,
+                    "config": repr(d.config),
+                },
+            )
+            if was_created:
+                created += 1
+            else:
+                updated += 1
+
+        stale = existing_slugs - set(desired_by_slug)
+        deleted = 0
+        if stale:
+            deleted, _ = Endpoint.objects.filter(
+                endpoint_adapter=ENDPOINT_ADAPTER, endpoint_slug__in=stale
+            ).delete()
+
+        return created, updated, deleted

--- a/resource_server_async/management/commands/first_v2_bridge.py
+++ b/resource_server_async/management/commands/first_v2_bridge.py
@@ -62,6 +62,9 @@ class Command(BaseCommand):
     def _tick(self, settings: BridgeSettings) -> None:
         redis_client = get_bridge_redis_client(settings.redis_url)
         cfg = RouterConfig.load(redis_client)
+        if cfg is None:
+            log.warning("No RouterConfig; skipping tick")
+            return
         desired = desired_endpoints(cfg, settings)
 
         created, updated, deleted = self._reconcile_endpoints(desired)

--- a/uv.lock
+++ b/uv.lock
@@ -584,18 +584,22 @@ wheels = [
 
 [[package]]
 name = "httpx"
-version = "0.27.2"
+version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "certifi" },
     { name = "httpcore" },
     { name = "idna" },
-    { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/82/08f8c936781f67d9e6b9eeb8a0c8b4e406136ea4c3d1f89a5db71d42e0e6/httpx-0.27.2.tar.gz", hash = "sha256:f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2", size = 144189, upload-time = "2024-08-27T12:54:01.334Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/95/9377bcb415797e44274b51d46e3249eba641711cf3348050f76ee7b15ffc/httpx-0.27.2-py3-none-any.whl", hash = "sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0", size = 76395, upload-time = "2024-08-27T12:53:59.653Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
 ]
 
 [[package]]
@@ -632,7 +636,7 @@ dependencies = [
     { name = "globus-sdk" },
     { name = "gunicorn" },
     { name = "h11" },
-    { name = "httpx" },
+    { name = "httpx", extra = ["socks"] },
     { name = "psycopg" },
     { name = "psycopg-pool" },
     { name = "pydantic" },
@@ -678,7 +682,7 @@ requires-dist = [
     { name = "globus-sdk", specifier = ">=3.65.0,<4" },
     { name = "gunicorn" },
     { name = "h11" },
-    { name = "httpx" },
+    { name = "httpx", extras = ["socks"] },
     { name = "psycopg", specifier = ">=3.2.12,<4" },
     { name = "psycopg-pool", specifier = ">=3.2.7,<4" },
     { name = "pydantic", specifier = ">=2.12" },
@@ -1464,6 +1468,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds a small bridge service to V1 (`main`) that reads the V2 controller's `RouterConfig` JSON blob and automates the create/update/delete of V1 `Endpoints`. 

- New `FirstV2Endpoint` Direct API endpoint class with mTLS passthrough and optional/temporary http proxying for development.  One endpoint's config holds multiple backend URLs and randomly chooses a backend URL at request time.
- New `TaraCluster` Cluster adapter class which reflects the RouterConfig into `get_jobs()` output
- bridge entrypoint shares the main Django app's dotenv settings and `manage.py` runner
- A systemd unit to run the bridge persistently
- V2->V1 Endpoint mapping with deterministic PKs derived from SHA1 of `(cluster, model)` and pass-through of allowed Globus groups and domains