### PR TITLE
Make GraphQL PBS job state authoritative

### DIFF
--- a/packages/common/first_common/schema/base_scheduler.py
+++ b/packages/common/first_common/schema/base_scheduler.py
@@ -141,8 +141,8 @@ class SchedulerAdapter(ABC):
         """
         Request termination of a job in the scheduler [qdel].
 
-        Returning means the scheduler accepted the request; callers must
-        observe the job as gone before treating its allocation as released.
+        Returning means the scheduler accepted the request. Scheduler cleanup
+        may continue asynchronously after the acknowledgement.
         """
 
     @abstractmethod

--- a/packages/common/first_common/schema/base_scheduler.py
+++ b/packages/common/first_common/schema/base_scheduler.py
@@ -117,6 +117,25 @@ class SchedulerAdapter(ABC):
         List job statuses from the scheduler [qstat]
         """
 
+    async def get_exact_job_status(self, job_id: str) -> JobStatusInfo | None:
+        """Return one exact job, but never infer absence from a bulk listing.
+
+        Adapters with an authoritative exact-ID lookup should override this and
+        may return ``None`` only when that lookup explicitly proves absence.
+        The conservative default can return an exact match from the ordinary
+        list, but fails closed if it is omitted (for example by pagination).
+        """
+        matches = [
+            status for status in await self.get_job_statuses() if status.id == job_id
+        ]
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            raise RuntimeError(f"scheduler returned duplicate exact job ID {job_id!r}")
+        raise RuntimeError(
+            f"scheduler adapter cannot prove exact job {job_id!r} is absent"
+        )
+
     @abstractmethod
     async def terminate_job(self, job_id: str) -> None:
         """

--- a/packages/common/first_common/schema/base_scheduler.py
+++ b/packages/common/first_common/schema/base_scheduler.py
@@ -118,7 +118,7 @@ class SchedulerAdapter(ABC):
         """
 
     async def get_exact_job_status(self, job_id: str) -> JobStatusInfo | None:
-        """Return one job, returning None only if it is definitively absent. 
+        """Return one job, returning None only if it is definitively absent.
 
         Adapters with an authoritative exact-ID lookup should override this and
         may return ``None`` only when that lookup explicitly proves absence.
@@ -139,7 +139,10 @@ class SchedulerAdapter(ABC):
     @abstractmethod
     async def terminate_job(self, job_id: str) -> None:
         """
-        Terminate a job in the scheduler [qdel]
+        Request termination of a job in the scheduler [qdel].
+
+        Returning means the scheduler accepted the request; callers must
+        observe the job as gone before treating its allocation as released.
         """
 
     @abstractmethod

--- a/packages/common/first_common/schema/base_scheduler.py
+++ b/packages/common/first_common/schema/base_scheduler.py
@@ -118,12 +118,12 @@ class SchedulerAdapter(ABC):
         """
 
     async def get_exact_job_status(self, job_id: str) -> JobStatusInfo | None:
-        """Return one exact job, but never infer absence from a bulk listing.
+        """Return one job, returning None only if it is definitively absent. 
 
         Adapters with an authoritative exact-ID lookup should override this and
         may return ``None`` only when that lookup explicitly proves absence.
-        The conservative default can return an exact match from the ordinary
-        list, but fails closed if it is omitted (for example by pagination).
+        The default returns an exact match from the job listing
+        but fails closed if it is omitted (for example by pagination).
         """
         matches = [
             status for status in await self.get_job_statuses() if status.id == job_id

--- a/packages/common/first_common/schema/base_scheduler.py
+++ b/packages/common/first_common/schema/base_scheduler.py
@@ -142,7 +142,8 @@ class SchedulerAdapter(ABC):
         Request termination of a job in the scheduler [qdel].
 
         Returning means the scheduler accepted the request. Scheduler cleanup
-        may continue asynchronously after the acknowledgement.
+        may continue asynchronously after the acknowledgement; callers that
+        need allocation-release proof must observe the job as gone.
         """
 
     @abstractmethod

--- a/packages/gateway/first_gateway/controllers/workers/pilot_job_controller.py
+++ b/packages/gateway/first_gateway/controllers/workers/pilot_job_controller.py
@@ -17,13 +17,13 @@ from ..controller import Controller, StaleReconcile
 logger = logging.getLogger(__name__)
 
 _RPC_TIMEOUT = 60.0
-_DYING_STATES = frozenset({SchedulerJobState.exiting.value})
-_GONE_STATES = frozenset({SchedulerJobState.gone.value})
+_TERMINAL_STATES = frozenset(
+    {SchedulerJobState.exiting.value, SchedulerJobState.gone.value}
+)
 _ACTIVE_STATES = [
     SchedulerJobState.queued.value,
     SchedulerJobState.starting.value,
     SchedulerJobState.running.value,
-    SchedulerJobState.exiting.value,
 ]
 
 
@@ -67,15 +67,14 @@ class PilotJobController(Controller):
             await self._terminate_and_delete(job, pilot_config)
             return
 
-        if job.scheduler_state in _DYING_STATES | _GONE_STATES:
+        if job.scheduler_state in _TERMINAL_STATES:
             logger.info(
-                "PilotJob %s in dying/gone state %s, scheduling deletion",
+                "PilotJob %s in terminal state %s, scheduling deletion",
                 job.name,
                 job.scheduler_state,
             )
             await self._mark_scheduled_deletion(
-                job,
-                PilotJob.scheduler_state.in_(list(_DYING_STATES | _GONE_STATES)),
+                job, PilotJob.scheduler_state.in_(list(_TERMINAL_STATES))
             )
             return
 
@@ -135,30 +134,20 @@ class PilotJobController(Controller):
     async def _terminate_and_delete(
         self, job: PilotJob, pilot_config: PilotConfig
     ) -> None:
-        if job.scheduler_job_id is None or job.scheduler_state in _GONE_STATES:
-            await self._finalize_deletion(job)
-            return
-
-        if job.scheduler_state in _DYING_STATES:
+        if (
+            job.scheduler_job_id is not None
+            and job.scheduler_state not in _TERMINAL_STATES
+        ):
+            adapter = await build_scheduler(pilot_config, self.client_state)
+            await asyncio.wait_for(
+                adapter.terminate_job(job.scheduler_job_id), timeout=_RPC_TIMEOUT
+            )
             logger.info(
-                "PilotJob %s: waiting for scheduler job %s to become gone",
+                "PilotJob %s: terminated scheduler job %s",
                 job.name,
                 job.scheduler_job_id,
             )
-            return
 
-        adapter = await build_scheduler(pilot_config, self.client_state)
-        await asyncio.wait_for(
-            adapter.terminate_job(job.scheduler_job_id), timeout=_RPC_TIMEOUT
-        )
-        logger.info(
-            "PilotJob %s: requested termination of scheduler job %s",
-            job.name,
-            job.scheduler_job_id,
-        )
-
-        # qdel acknowledgement is not allocation-release evidence. Record the
-        # intermediate state and let PilotJobObserver establish gone/absence.
         async with self.client_state.db_sessionmaker.begin() as sess:
             result = await sess.execute(
                 sa.update(PilotJob)
@@ -166,29 +155,6 @@ class PilotJobController(Controller):
                     PilotJob.uid == job.uid,
                     PilotJob.scheduled_deletion_at.is_not(None),
                     PilotJob.deleted_at.is_(None),
-                    PilotJob.scheduler_state == job.scheduler_state,
-                )
-                .values(scheduler_state=SchedulerJobState.exiting.value)
-            )
-            if result.rowcount == 0:  # type: ignore[attr-defined]
-                raise StaleReconcile(
-                    f"PilotJob {job.name}: scheduler state changed after qdel"
-                )
-
-    async def _finalize_deletion(self, job: PilotJob) -> None:
-        scheduler_gone = (
-            PilotJob.scheduler_job_id.is_(None)
-            if job.scheduler_job_id is None
-            else PilotJob.scheduler_state.in_(list(_GONE_STATES))
-        )
-        async with self.client_state.db_sessionmaker.begin() as sess:
-            result = await sess.execute(
-                sa.update(PilotJob)
-                .where(
-                    PilotJob.uid == job.uid,
-                    PilotJob.scheduled_deletion_at.is_not(None),
-                    PilotJob.deleted_at.is_(None),
-                    scheduler_gone,
                 )
                 .values(
                     deleted_at=datetime.now(timezone.utc),
@@ -196,9 +162,7 @@ class PilotJobController(Controller):
                 )
             )
             if result.rowcount == 0:  # type: ignore[attr-defined]
-                raise StaleReconcile(
-                    f"PilotJob {job.name}: scheduler absence changed before deletion"
-                )
+                raise StaleReconcile(f"PilotJob {job.name}: terminate_and_delete stale")
 
     async def _mark_scheduled_deletion(
         self,

--- a/packages/gateway/first_gateway/controllers/workers/pilot_job_controller.py
+++ b/packages/gateway/first_gateway/controllers/workers/pilot_job_controller.py
@@ -17,10 +17,9 @@ from ..controller import Controller, StaleReconcile
 logger = logging.getLogger(__name__)
 
 _RPC_TIMEOUT = 60.0
-_TERMINAL_STATES = frozenset(
-    {SchedulerJobState.exiting.value, SchedulerJobState.gone.value}
-)
-_ACTIVE_STATES = [
+_DYING_STATES = frozenset({SchedulerJobState.exiting.value})
+_GONE_STATES = frozenset({SchedulerJobState.gone.value})
+_SUBMISSION_CAPACITY_STATES = [
     SchedulerJobState.queued.value,
     SchedulerJobState.starting.value,
     SchedulerJobState.running.value,
@@ -67,14 +66,15 @@ class PilotJobController(Controller):
             await self._terminate_and_delete(job, pilot_config)
             return
 
-        if job.scheduler_state in _TERMINAL_STATES:
+        if job.scheduler_state in _DYING_STATES | _GONE_STATES:
             logger.info(
-                "PilotJob %s in terminal state %s, scheduling deletion",
+                "PilotJob %s in dying/gone state %s, scheduling deletion",
                 job.name,
                 job.scheduler_state,
             )
             await self._mark_scheduled_deletion(
-                job, PilotJob.scheduler_state.in_(list(_TERMINAL_STATES))
+                job,
+                PilotJob.scheduler_state.in_(list(_DYING_STATES | _GONE_STATES)),
             )
             return
 
@@ -134,20 +134,30 @@ class PilotJobController(Controller):
     async def _terminate_and_delete(
         self, job: PilotJob, pilot_config: PilotConfig
     ) -> None:
-        if (
-            job.scheduler_job_id is not None
-            and job.scheduler_state not in _TERMINAL_STATES
-        ):
-            adapter = await build_scheduler(pilot_config, self.client_state)
-            await asyncio.wait_for(
-                adapter.terminate_job(job.scheduler_job_id), timeout=_RPC_TIMEOUT
-            )
+        if job.scheduler_job_id is None or job.scheduler_state in _GONE_STATES:
+            await self._finalize_deletion(job)
+            return
+
+        if job.scheduler_state in _DYING_STATES:
             logger.info(
-                "PilotJob %s: terminated scheduler job %s",
+                "PilotJob %s: waiting for scheduler job %s to become gone",
                 job.name,
                 job.scheduler_job_id,
             )
+            return
 
+        adapter = await build_scheduler(pilot_config, self.client_state)
+        await asyncio.wait_for(
+            adapter.terminate_job(job.scheduler_job_id), timeout=_RPC_TIMEOUT
+        )
+        logger.info(
+            "PilotJob %s: requested termination of scheduler job %s",
+            job.name,
+            job.scheduler_job_id,
+        )
+
+        # Keep observing the scheduler after qdel acknowledgement, but release
+        # this job's FIRST submission slot by moving it to the exiting state.
         async with self.client_state.db_sessionmaker.begin() as sess:
             result = await sess.execute(
                 sa.update(PilotJob)
@@ -155,6 +165,29 @@ class PilotJobController(Controller):
                     PilotJob.uid == job.uid,
                     PilotJob.scheduled_deletion_at.is_not(None),
                     PilotJob.deleted_at.is_(None),
+                    PilotJob.scheduler_state == job.scheduler_state,
+                )
+                .values(scheduler_state=SchedulerJobState.exiting.value)
+            )
+            if result.rowcount == 0:  # type: ignore[attr-defined]
+                raise StaleReconcile(
+                    f"PilotJob {job.name}: scheduler state changed after qdel"
+                )
+
+    async def _finalize_deletion(self, job: PilotJob) -> None:
+        scheduler_gone = (
+            PilotJob.scheduler_job_id.is_(None)
+            if job.scheduler_job_id is None
+            else PilotJob.scheduler_state.in_(list(_GONE_STATES))
+        )
+        async with self.client_state.db_sessionmaker.begin() as sess:
+            result = await sess.execute(
+                sa.update(PilotJob)
+                .where(
+                    PilotJob.uid == job.uid,
+                    PilotJob.scheduled_deletion_at.is_not(None),
+                    PilotJob.deleted_at.is_(None),
+                    scheduler_gone,
                 )
                 .values(
                     deleted_at=datetime.now(timezone.utc),
@@ -162,7 +195,9 @@ class PilotJobController(Controller):
                 )
             )
             if result.rowcount == 0:  # type: ignore[attr-defined]
-                raise StaleReconcile(f"PilotJob {job.name}: terminate_and_delete stale")
+                raise StaleReconcile(
+                    f"PilotJob {job.name}: scheduler absence changed before deletion"
+                )
 
     async def _mark_scheduled_deletion(
         self,
@@ -191,7 +226,7 @@ class PilotJobController(Controller):
                 .select_from(PilotJob)
                 .where(
                     PilotJob.cluster_name == job.cluster_name,
-                    PilotJob.scheduler_state.in_(_ACTIVE_STATES),
+                    PilotJob.scheduler_state.in_(_SUBMISSION_CAPACITY_STATES),
                     PilotJob.deleted_at.is_(None),
                 )
             )
@@ -209,7 +244,7 @@ class PilotJobController(Controller):
             active_nodes = await sess.scalar(
                 sa.select(sa.func.coalesce(sa.func.sum(PilotJob.num_nodes), 0)).where(
                     PilotJob.cluster_name == job.cluster_name,
-                    PilotJob.scheduler_state.in_(_ACTIVE_STATES),
+                    PilotJob.scheduler_state.in_(_SUBMISSION_CAPACITY_STATES),
                     PilotJob.deleted_at.is_(None),
                 )
             )

--- a/packages/gateway/first_gateway/controllers/workers/pilot_job_controller.py
+++ b/packages/gateway/first_gateway/controllers/workers/pilot_job_controller.py
@@ -17,13 +17,13 @@ from ..controller import Controller, StaleReconcile
 logger = logging.getLogger(__name__)
 
 _RPC_TIMEOUT = 60.0
-_TERMINAL_STATES = frozenset(
-    {SchedulerJobState.exiting.value, SchedulerJobState.gone.value}
-)
+_DYING_STATES = frozenset({SchedulerJobState.exiting.value})
+_GONE_STATES = frozenset({SchedulerJobState.gone.value})
 _ACTIVE_STATES = [
     SchedulerJobState.queued.value,
     SchedulerJobState.starting.value,
     SchedulerJobState.running.value,
+    SchedulerJobState.exiting.value,
 ]
 
 
@@ -67,14 +67,15 @@ class PilotJobController(Controller):
             await self._terminate_and_delete(job, pilot_config)
             return
 
-        if job.scheduler_state in _TERMINAL_STATES:
+        if job.scheduler_state in _DYING_STATES | _GONE_STATES:
             logger.info(
-                "PilotJob %s in terminal state %s, scheduling deletion",
+                "PilotJob %s in dying/gone state %s, scheduling deletion",
                 job.name,
                 job.scheduler_state,
             )
             await self._mark_scheduled_deletion(
-                job, PilotJob.scheduler_state.in_(list(_TERMINAL_STATES))
+                job,
+                PilotJob.scheduler_state.in_(list(_DYING_STATES | _GONE_STATES)),
             )
             return
 
@@ -134,20 +135,30 @@ class PilotJobController(Controller):
     async def _terminate_and_delete(
         self, job: PilotJob, pilot_config: PilotConfig
     ) -> None:
-        if (
-            job.scheduler_job_id is not None
-            and job.scheduler_state not in _TERMINAL_STATES
-        ):
-            adapter = await build_scheduler(pilot_config, self.client_state)
-            await asyncio.wait_for(
-                adapter.terminate_job(job.scheduler_job_id), timeout=_RPC_TIMEOUT
-            )
+        if job.scheduler_job_id is None or job.scheduler_state in _GONE_STATES:
+            await self._finalize_deletion(job)
+            return
+
+        if job.scheduler_state in _DYING_STATES:
             logger.info(
-                "PilotJob %s: terminated scheduler job %s",
+                "PilotJob %s: waiting for scheduler job %s to become gone",
                 job.name,
                 job.scheduler_job_id,
             )
+            return
 
+        adapter = await build_scheduler(pilot_config, self.client_state)
+        await asyncio.wait_for(
+            adapter.terminate_job(job.scheduler_job_id), timeout=_RPC_TIMEOUT
+        )
+        logger.info(
+            "PilotJob %s: requested termination of scheduler job %s",
+            job.name,
+            job.scheduler_job_id,
+        )
+
+        # qdel acknowledgement is not allocation-release evidence. Record the
+        # intermediate state and let PilotJobObserver establish gone/absence.
         async with self.client_state.db_sessionmaker.begin() as sess:
             result = await sess.execute(
                 sa.update(PilotJob)
@@ -155,6 +166,29 @@ class PilotJobController(Controller):
                     PilotJob.uid == job.uid,
                     PilotJob.scheduled_deletion_at.is_not(None),
                     PilotJob.deleted_at.is_(None),
+                    PilotJob.scheduler_state == job.scheduler_state,
+                )
+                .values(scheduler_state=SchedulerJobState.exiting.value)
+            )
+            if result.rowcount == 0:  # type: ignore[attr-defined]
+                raise StaleReconcile(
+                    f"PilotJob {job.name}: scheduler state changed after qdel"
+                )
+
+    async def _finalize_deletion(self, job: PilotJob) -> None:
+        scheduler_gone = (
+            PilotJob.scheduler_job_id.is_(None)
+            if job.scheduler_job_id is None
+            else PilotJob.scheduler_state.in_(list(_GONE_STATES))
+        )
+        async with self.client_state.db_sessionmaker.begin() as sess:
+            result = await sess.execute(
+                sa.update(PilotJob)
+                .where(
+                    PilotJob.uid == job.uid,
+                    PilotJob.scheduled_deletion_at.is_not(None),
+                    PilotJob.deleted_at.is_(None),
+                    scheduler_gone,
                 )
                 .values(
                     deleted_at=datetime.now(timezone.utc),
@@ -162,7 +196,9 @@ class PilotJobController(Controller):
                 )
             )
             if result.rowcount == 0:  # type: ignore[attr-defined]
-                raise StaleReconcile(f"PilotJob {job.name}: terminate_and_delete stale")
+                raise StaleReconcile(
+                    f"PilotJob {job.name}: scheduler absence changed before deletion"
+                )
 
     async def _mark_scheduled_deletion(
         self,

--- a/packages/gateway/first_gateway/platforms/schedulers/graphql_pbs.py
+++ b/packages/gateway/first_gateway/platforms/schedulers/graphql_pbs.py
@@ -271,11 +271,7 @@ class GraphQLPBSAdapter(SchedulerAdapter):
                     seen_ids.add(status.id)
                     results.append(status)
 
-            page_info = connection.get("pageInfo")
-            if not isinstance(page_info, dict) or not isinstance(
-                page_info.get("hasNextPage"), bool
-            ):
-                raise RuntimeError("GraphQL jobs query returned malformed pageInfo")
+            page_info = data["jobs"]["pageInfo"]
             if not page_info["hasNextPage"]:
                 return results
             next_cursor = page_info.get("endCursor")

--- a/packages/gateway/first_gateway/platforms/schedulers/graphql_pbs.py
+++ b/packages/gateway/first_gateway/platforms/schedulers/graphql_pbs.py
@@ -364,7 +364,10 @@ class GraphQLPBSAdapter(SchedulerAdapter):
         }
         """
         data = await self._post(query, {"jobId": job_id})
-        edge = data["jobs"]["edges"][0]
+        edges = data["jobs"]["edges"]
+        if not edges:
+            return None
+        edge = edges[0]
         if edge.get("error"):
             raise RuntimeError(f"GraphQL exact-job edge failed:\n{edge['error']}")
         node = edge["node"]

--- a/packages/gateway/first_gateway/platforms/schedulers/graphql_pbs.py
+++ b/packages/gateway/first_gateway/platforms/schedulers/graphql_pbs.py
@@ -261,27 +261,15 @@ class GraphQLPBSAdapter(SchedulerAdapter):
                 query,
                 {"owner": self.owner, "cursor": cursor},
             )
-            connection = data.get("jobs")
-            if not isinstance(connection, dict):
-                raise RuntimeError("GraphQL jobs query returned no connection")
-            edges = connection.get("edges")
-            if not isinstance(edges, list):
-                raise RuntimeError("GraphQL jobs query returned malformed edges")
+            edges: list[dict[str, Any]] = data["jobs"]["edges"]
             for edge in edges:
-                if not isinstance(edge, dict):
-                    raise RuntimeError("GraphQL jobs query returned a malformed edge")
                 if edge.get("error"):
                     raise RuntimeError(f"GraphQL jobs edge failed:\n{edge['error']}")
-                node = edge.get("node")
-                if not isinstance(node, dict):
-                    raise RuntimeError("GraphQL jobs edge returned no node")
+                node: dict[str, Any] = edge["node"]
                 status = _job_status_from_node(node)
-                if status.id in seen_ids:
-                    raise RuntimeError(
-                        f"GraphQL jobs pages duplicated job ID {status.id!r}"
-                    )
-                seen_ids.add(status.id)
-                results.append(status)
+                if status.id not in seen_ids:
+                    seen_ids.add(status.id)
+                    results.append(status)
 
             page_info = connection.get("pageInfo")
             if not isinstance(page_info, dict) or not isinstance(

--- a/packages/gateway/first_gateway/platforms/schedulers/graphql_pbs.py
+++ b/packages/gateway/first_gateway/platforms/schedulers/graphql_pbs.py
@@ -1,4 +1,3 @@
-import asyncio
 import base64
 import logging
 import re
@@ -44,8 +43,6 @@ _ACTIVE_STATES = frozenset({5, 6, 7, 8, 9})
 
 _HSN_RESOURCE_NAME = "hsn_ips"
 _PBS_JOB_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
-_DELETE_POLL_ATTEMPTS = 45
-_DELETE_POLL_INTERVAL_SEC = 1.0
 _STATUS_PAGE_SIZE = 500
 _STATUS_MAX_PAGES = 10
 
@@ -322,19 +319,9 @@ class GraphQLPBSAdapter(SchedulerAdapter):
                 f"expected {job_id!r}, got {returned_id!r}"
             )
 
-        # A successful mutation is only an acknowledgement. Retain the DB
-        # allocation until this exact scheduler ID is terminal or absent.
-        for attempt in range(_DELETE_POLL_ATTEMPTS):
-            state = await self._get_exact_job_state(job_id)
-            if state is None or state == SchedulerJobState.gone:
-                return
-            if attempt + 1 < _DELETE_POLL_ATTEMPTS:
-                await asyncio.sleep(_DELETE_POLL_INTERVAL_SEC)
-
-        raise TimeoutError(
-            f"scheduler job {job_id!r} did not become absent/gone after "
-            f"{_DELETE_POLL_ATTEMPTS} polls"
-        )
+        # The mutation acknowledges qdel; it does not prove that PBS has
+        # released the allocation. The controller records the job as exiting,
+        # and the scheduler observer completes deletion after it observes gone.
 
     async def get_exact_job_status(self, job_id: str) -> JobStatusInfo | None:
         job_id = job_id.strip()

--- a/packages/gateway/first_gateway/platforms/schedulers/graphql_pbs.py
+++ b/packages/gateway/first_gateway/platforms/schedulers/graphql_pbs.py
@@ -326,10 +326,6 @@ class GraphQLPBSAdapter(SchedulerAdapter):
         data = await self._post(query, {"jobId": job_id})
         payload = data["deleteJob"]
         if payload.get("error"):
-            # A retry after a lost acknowledgement can legitimately receive a
-            # not-found mutation error.  The error alone is never release
-            # evidence; accept it only if a separate exact lookup proves the
-            # same ID absent or gone.
             state = await self._get_exact_job_state(job_id)
             if state is None or state == SchedulerJobState.gone:
                 logger.warning(f"terminate {job_id=} error: job is already gone.")

--- a/packages/gateway/first_gateway/platforms/schedulers/graphql_pbs.py
+++ b/packages/gateway/first_gateway/platforms/schedulers/graphql_pbs.py
@@ -332,6 +332,7 @@ class GraphQLPBSAdapter(SchedulerAdapter):
             # same ID absent or gone.
             state = await self._get_exact_job_state(job_id)
             if state is None or state == SchedulerJobState.gone:
+                logger.warning(f"terminate {job_id=} error: job is already gone.")
                 return
             raise RuntimeError(f"GraphQL deleteJob failed:\n{payload['error']}")
         returned_id = ((payload.get("node") or {}).get("jobId") or "").strip()

--- a/packages/gateway/first_gateway/platforms/schedulers/graphql_pbs.py
+++ b/packages/gateway/first_gateway/platforms/schedulers/graphql_pbs.py
@@ -104,7 +104,7 @@ def _job_status_from_node(node: dict[str, Any]) -> JobStatusInfo:
 
     return JobStatusInfo(
         id=job_id,
-        name=node.get("name") or "",
+        name=node["name"],
         state=state,
         created_at=_parse_epoch_micros(node.get("submitTime"))
         or datetime.now(timezone.utc),

--- a/packages/gateway/first_gateway/platforms/schedulers/graphql_pbs.py
+++ b/packages/gateway/first_gateway/platforms/schedulers/graphql_pbs.py
@@ -1,5 +1,7 @@
+import asyncio
 import base64
 import logging
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Self
@@ -27,7 +29,7 @@ _STATE_MAP: dict[int, SchedulerJobState] = {
     5: SchedulerJobState.starting,  # StagingIn
     6: SchedulerJobState.exiting,  # StagingOut
     7: SchedulerJobState.running,  # Running
-    8: SchedulerJobState.gone,  # Suspended
+    8: SchedulerJobState.exiting,  # Suspended; allocation release is unproven
     9: SchedulerJobState.exiting,  # Exiting
     10: SchedulerJobState.gone,  # Done
     11: SchedulerJobState.gone,  # Failed
@@ -38,9 +40,14 @@ _STATE_MAP: dict[int, SchedulerJobState] = {
 
 # States in which the job is actually placed on machines, so allocatedMachines
 # (and thus hsn_ips) is meaningful
-_ACTIVE_STATES = frozenset({5, 6, 7, 9})
+_ACTIVE_STATES = frozenset({5, 6, 7, 8, 9})
 
 _HSN_RESOURCE_NAME = "hsn_ips"
+_PBS_JOB_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
+_DELETE_POLL_ATTEMPTS = 45
+_DELETE_POLL_INTERVAL_SEC = 1.0
+_STATUS_PAGE_SIZE = 500
+_STATUS_MAX_PAGES = 10
 
 
 def _parse_epoch_micros(raw: int | None) -> datetime | None:
@@ -74,6 +81,40 @@ def _head_node_hostname(machines: list[dict[str, Any]]) -> str | None:
     return machines[0].get("hostname") or None
 
 
+def _job_status_from_node(node: dict[str, Any]) -> JobStatusInfo:
+    job_id = (node.get("jobId") or "").strip()
+    if not job_id:
+        raise RuntimeError("GraphQL jobs query returned an empty jobId")
+
+    state_code: int | None = (node.get("status") or {}).get("state")
+    state = _STATE_MAP.get(state_code) if state_code is not None else None
+    if state is None:
+        raise RuntimeError(
+            f"unknown GraphQL job state {state_code!r} for job {job_id!r}"
+        )
+
+    resources = (node.get("resourcesRequested") or {}).get("jobResources") or {}
+    walltime_sec = resources.get("wallClockTime") or 0
+    head_ip = None
+    head_hostname = None
+    if state_code in _ACTIVE_STATES:
+        machines = node.get("allocatedMachines") or []
+        head_ip = _head_node_ip(machines)
+        head_hostname = _head_node_hostname(machines)
+
+    return JobStatusInfo(
+        id=job_id,
+        name=node.get("name") or "",
+        state=state,
+        created_at=_parse_epoch_micros(node.get("submitTime"))
+        or datetime.now(timezone.utc),
+        started_at=_parse_epoch_micros(node.get("startTime")),
+        walltime_minutes=walltime_sec // 60,
+        head_node_ip_address=head_ip,
+        head_node_hostname=head_hostname,
+    )
+
+
 class GraphQLPBSAdapter(SchedulerAdapter):
     def __init__(self, client: AsyncClient, owner: str, url: str) -> None:
         self.client = client
@@ -94,8 +135,13 @@ class GraphQLPBSAdapter(SchedulerAdapter):
         graphql_url = config["graphql_url"]
         return cls(client=deps.keycloak_clients[name], owner=owner, url=graphql_url)
 
-    async def _post(self, query: str) -> dict[str, Any]:
-        resp = await self.client.post(self.url, json={"query": query})
+    async def _post(
+        self, query: str, variables: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        request: dict[str, Any] = {"query": query}
+        if variables is not None:
+            request["variables"] = variables
+        resp = await self.client.post(self.url, json=request)
         resp.raise_for_status()
         body: dict[str, Any] = resp.json()
         if body.get("errors"):
@@ -165,8 +211,12 @@ class GraphQLPBSAdapter(SchedulerAdapter):
 
     async def get_job_statuses(self) -> list[JobStatusInfo]:
         query = f"""
-        query {{
-            jobs ( filter: {{owner: "{self.owner}", withHistoryJobs: true}} ) {{
+        query ActiveJobs($owner: String!, $cursor: Cursor) {{
+            jobs (
+                filter: {{owner: $owner, withHistoryJobs: false}}
+                count: {_STATUS_PAGE_SIZE}
+                from: $cursor
+            ) {{
                 edges {{
                     node {{
                         jobId
@@ -193,71 +243,189 @@ class GraphQLPBSAdapter(SchedulerAdapter):
                         errorCode
                         errorMessage
                     }}
+                    cursor
+                }}
+                pageInfo {{
+                    hasNextPage
+                    endCursor
                 }}
             }}
         }}
         """
-        data = await self._post(query)
-        edges = data.get("jobs", {}).get("edges") or []
-
         results: list[JobStatusInfo] = []
-        for edge in edges:
-            if edge.get("error"):
-                logger.warning("Skipping job with error: %s", edge["error"])
-                continue
-            node = edge["node"]
-            job_id = (node["jobId"] or "").strip()
-
-            state_code: int | None = (node.get("status") or {}).get("state")
-            state = _STATE_MAP.get(state_code) if state_code is not None else None
-            if state is None:
-                logger.warning("Unknown job state %r for job %r", state_code, job_id)
-                state = SchedulerJobState.gone
-
-            resources = (node.get("resourcesRequested") or {}).get("jobResources") or {}
-            walltime_sec = resources.get("wallClockTime") or 0
-
-            head_ip = None
-            head_hostname = None
-            if state_code in _ACTIVE_STATES:
-                machines = node.get("allocatedMachines") or []
-                head_ip = _head_node_ip(machines)
-                head_hostname = _head_node_hostname(machines)
-
-            results.append(
-                JobStatusInfo(
-                    id=job_id,
-                    name=node["name"],
-                    state=state,
-                    created_at=_parse_epoch_micros(node.get("submitTime"))
-                    or datetime.now(timezone.utc),
-                    started_at=_parse_epoch_micros(node.get("startTime")),
-                    walltime_minutes=walltime_sec // 60,
-                    head_node_ip_address=head_ip,
-                    head_node_hostname=head_hostname,
-                )
+        seen_ids: set[str] = set()
+        seen_cursors: set[str] = set()
+        cursor: str | None = None
+        for _ in range(_STATUS_MAX_PAGES):
+            data = await self._post(
+                query,
+                {"owner": self.owner, "cursor": cursor},
             )
+            connection = data.get("jobs")
+            if not isinstance(connection, dict):
+                raise RuntimeError("GraphQL jobs query returned no connection")
+            edges = connection.get("edges")
+            if not isinstance(edges, list):
+                raise RuntimeError("GraphQL jobs query returned malformed edges")
+            for edge in edges:
+                if not isinstance(edge, dict):
+                    raise RuntimeError("GraphQL jobs query returned a malformed edge")
+                if edge.get("error"):
+                    raise RuntimeError(f"GraphQL jobs edge failed:\n{edge['error']}")
+                node = edge.get("node")
+                if not isinstance(node, dict):
+                    raise RuntimeError("GraphQL jobs edge returned no node")
+                status = _job_status_from_node(node)
+                if status.id in seen_ids:
+                    raise RuntimeError(
+                        f"GraphQL jobs pages duplicated job ID {status.id!r}"
+                    )
+                seen_ids.add(status.id)
+                results.append(status)
 
-        return results
+            page_info = connection.get("pageInfo")
+            if not isinstance(page_info, dict) or not isinstance(
+                page_info.get("hasNextPage"), bool
+            ):
+                raise RuntimeError("GraphQL jobs query returned malformed pageInfo")
+            if not page_info["hasNextPage"]:
+                return results
+            next_cursor = page_info.get("endCursor")
+            if (
+                not isinstance(next_cursor, str)
+                or not next_cursor
+                or next_cursor in seen_cursors
+            ):
+                raise RuntimeError("GraphQL jobs pagination cursor did not advance")
+            seen_cursors.add(next_cursor)
+            cursor = next_cursor
+
+        raise RuntimeError(
+            "GraphQL active-job listing exceeded bounded pagination "
+            f"({_STATUS_MAX_PAGES} pages)"
+        )
 
     async def terminate_job(self, job_id: str) -> None:
-        query = f"""
-        mutation {{
-            deleteJob (jobId: "{job_id}", input: {{force: true}}) {{
-                node {{
+        job_id = job_id.strip()
+        if _PBS_JOB_ID.fullmatch(job_id) is None:
+            raise ValueError(f"invalid PBS scheduler job ID: {job_id!r}")
+
+        query = """
+        mutation DeleteJob($jobId: String!) {
+            deleteJob (jobId: $jobId, input: {force: true}) {
+                node {
                     jobId
-                }}
-                error {{
+                }
+                error {
                     errorCode
                     errorMessage
-                }}
-            }}
-        }}
+                }
+            }
+        }
         """
-        data = await self._post(query)
+        data = await self._post(query, {"jobId": job_id})
         payload = data["deleteJob"]
         if payload.get("error"):
+            # A retry after a lost acknowledgement can legitimately receive a
+            # not-found mutation error.  The error alone is never release
+            # evidence; accept it only if a separate exact lookup proves the
+            # same ID absent or gone.
+            state = await self._get_exact_job_state(job_id)
+            if state is None or state == SchedulerJobState.gone:
+                return
             raise RuntimeError(f"GraphQL deleteJob failed:\n{payload['error']}")
+        returned_id = ((payload.get("node") or {}).get("jobId") or "").strip()
+        if returned_id and returned_id != job_id:
+            raise RuntimeError(
+                "GraphQL deleteJob returned a different job ID: "
+                f"expected {job_id!r}, got {returned_id!r}"
+            )
+
+        # A successful mutation is only an acknowledgement. Retain the DB
+        # allocation until this exact scheduler ID is terminal or absent.
+        for attempt in range(_DELETE_POLL_ATTEMPTS):
+            state = await self._get_exact_job_state(job_id)
+            if state is None or state == SchedulerJobState.gone:
+                return
+            if attempt + 1 < _DELETE_POLL_ATTEMPTS:
+                await asyncio.sleep(_DELETE_POLL_INTERVAL_SEC)
+
+        raise TimeoutError(
+            f"scheduler job {job_id!r} did not become absent/gone after "
+            f"{_DELETE_POLL_ATTEMPTS} polls"
+        )
+
+    async def get_exact_job_status(self, job_id: str) -> JobStatusInfo | None:
+        job_id = job_id.strip()
+        if _PBS_JOB_ID.fullmatch(job_id) is None:
+            raise ValueError(f"invalid PBS scheduler job ID: {job_id!r}")
+        query = """
+        query ExactJobState($jobId: String!) {
+            jobs(
+                filter: {jobIds: [$jobId], withHistoryJobs: true}
+                count: 1
+            ) {
+                edges {
+                    node {
+                        jobId
+                        name
+                        submitTime
+                        startTime
+                        status { state }
+                        resourcesRequested {
+                            jobResources { wallClockTime }
+                        }
+                        allocatedMachines {
+                            name
+                            hostname
+                            resourcesAvail {
+                                customResources { name value }
+                            }
+                        }
+                    }
+                    error {
+                        errorCode
+                        errorMessage
+                    }
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+            }
+        }
+        """
+        data = await self._post(query, {"jobId": job_id})
+        connection = data.get("jobs")
+        if not isinstance(connection, dict):
+            raise RuntimeError("GraphQL exact-job query returned no connection")
+        edges = connection.get("edges")
+        if not isinstance(edges, list):
+            raise RuntimeError("GraphQL exact-job query returned malformed edges")
+        page_info = connection.get("pageInfo")
+        if not isinstance(page_info, dict) or page_info.get("hasNextPage") is not False:
+            raise RuntimeError("GraphQL exact-job query was not an exact page")
+        if not edges:
+            return None
+        if len(edges) != 1 or not isinstance(edges[0], dict):
+            raise RuntimeError("GraphQL exact-job query returned non-exact edges")
+        edge = edges[0]
+        if edge.get("error"):
+            raise RuntimeError(f"GraphQL exact-job edge failed:\n{edge['error']}")
+        node = edge.get("node")
+        if not isinstance(node, dict):
+            raise RuntimeError("GraphQL exact-job edge returned no node")
+        status = _job_status_from_node(node)
+        if status.id != job_id:
+            raise RuntimeError(
+                "GraphQL exact-job query returned a different job ID: "
+                f"expected {job_id!r}, got {status.id!r}"
+            )
+        return status
+
+    async def _get_exact_job_state(self, job_id: str) -> SchedulerJobState | None:
+        status = await self.get_exact_job_status(job_id)
+        return None if status is None else status.state
 
     async def put_file(self, content: str, path: Path, mode: int) -> None:
         raise NotImplementedError

--- a/packages/gateway/first_gateway/platforms/schedulers/graphql_pbs.py
+++ b/packages/gateway/first_gateway/platforms/schedulers/graphql_pbs.py
@@ -364,25 +364,10 @@ class GraphQLPBSAdapter(SchedulerAdapter):
         }
         """
         data = await self._post(query, {"jobId": job_id})
-        connection = data.get("jobs")
-        if not isinstance(connection, dict):
-            raise RuntimeError("GraphQL exact-job query returned no connection")
-        edges = connection.get("edges")
-        if not isinstance(edges, list):
-            raise RuntimeError("GraphQL exact-job query returned malformed edges")
-        page_info = connection.get("pageInfo")
-        if not isinstance(page_info, dict) or page_info.get("hasNextPage") is not False:
-            raise RuntimeError("GraphQL exact-job query was not an exact page")
-        if not edges:
-            return None
-        if len(edges) != 1 or not isinstance(edges[0], dict):
-            raise RuntimeError("GraphQL exact-job query returned non-exact edges")
-        edge = edges[0]
+        edge = data["jobs"]["edges"][0]
         if edge.get("error"):
             raise RuntimeError(f"GraphQL exact-job edge failed:\n{edge['error']}")
-        node = edge.get("node")
-        if not isinstance(node, dict):
-            raise RuntimeError("GraphQL exact-job edge returned no node")
+        node = edge["node"]
         status = _job_status_from_node(node)
         if status.id != job_id:
             raise RuntimeError(

--- a/packages/gateway/first_gateway/services/pilot_submitter.py
+++ b/packages/gateway/first_gateway/services/pilot_submitter.py
@@ -152,7 +152,11 @@ class PilotSubmitter:
     async def get_endpoint(self, job_name: str) -> AddressInfo:
         if isinstance(self.adapter, GraphQLPBSAdapter):
             for s in await self.get_statuses():
-                if s.name == job_name and s.head_node_ip_address:
+                if (
+                    s.name == job_name
+                    and s.state == SchedulerJobState.running
+                    and s.head_node_ip_address
+                ):
                     ip = s.head_node_ip_address
                     return AddressInfo(
                         hostname=s.head_node_hostname or ip,

--- a/tests/test_graphql_pbs.py
+++ b/tests/test_graphql_pbs.py
@@ -1,0 +1,308 @@
+import json
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from first_common.schema.base_scheduler import (
+    JobStatusInfo,
+    SchedulerJobState,
+)
+from first_common.schema.types import PilotConfig
+from first_gateway.platforms.schedulers import graphql_pbs
+from first_gateway.platforms.schedulers.graphql_pbs import GraphQLPBSAdapter
+from first_gateway.services.pilot_submitter import PilotSubmitter
+
+
+def _job_node(job_id: str, state: int) -> dict[str, object]:
+    return {
+        "jobId": job_id,
+        "name": "__FIRST_PILOT_nemotron-canary",
+        "submitTime": 1_700_000_000_000_000,
+        "startTime": 1_700_000_100_000_000,
+        "status": {"state": state},
+        "resourcesRequested": {"jobResources": {"wallClockTime": 5400}},
+        "allocatedMachines": [
+            {
+                "hostname": "x3001",
+                "resourcesAvail": {
+                    "customResources": [{"name": "hsn_ips", "value": "10.1.2.3"}]
+                },
+            }
+        ],
+    }
+
+
+def _jobs_payload(
+    edges: list[dict[str, object]], *, has_next: bool = False, cursor: str = ""
+) -> dict[str, object]:
+    return {
+        "data": {
+            "jobs": {
+                "edges": edges,
+                "pageInfo": {
+                    "hasNextPage": has_next,
+                    "endCursor": cursor,
+                },
+            }
+        }
+    }
+
+
+async def test_graphql_active_statuses_paginate_and_never_query_history() -> None:
+    requests: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        requests.append(body)
+        cursor = body["variables"]["cursor"]
+        if cursor is None:
+            payload = _jobs_payload(
+                [{"node": _job_node("101.tara", 7), "error": None}],
+                has_next=True,
+                cursor="page-2",
+            )
+        else:
+            payload = _jobs_payload([{"node": _job_node("102.tara", 9), "error": None}])
+        return httpx.Response(200, json=payload)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        statuses = await GraphQLPBSAdapter(
+            client, "openinference_svc", "https://bridge"
+        ).get_job_statuses()
+
+    assert [status.id for status in statuses] == ["101.tara", "102.tara"]
+    assert [status.state for status in statuses] == [
+        SchedulerJobState.running,
+        SchedulerJobState.exiting,
+    ]
+    assert [request["variables"]["cursor"] for request in requests] == [
+        None,
+        "page-2",
+    ]
+    assert all(
+        "withHistoryJobs: false" in str(request["query"]) for request in requests
+    )
+
+
+async def test_graphql_statuses_fail_closed_on_edge_unknown_and_duplicate() -> None:
+    responses = [
+        _jobs_payload(
+            [
+                {
+                    "node": None,
+                    "error": {"errorCode": 7, "errorMessage": "denied"},
+                }
+            ]
+        ),
+        _jobs_payload([{"node": _job_node("101.tara", 99), "error": None}]),
+        _jobs_payload(
+            [
+                {"node": _job_node("101.tara", 7), "error": None},
+                {"node": _job_node("101.tara", 7), "error": None},
+            ]
+        ),
+    ]
+    for payload, message in zip(
+        responses,
+        ("edge failed", "unknown GraphQL job state", "duplicated job ID"),
+        strict=True,
+    ):
+        transport = httpx.MockTransport(
+            lambda _request, payload=payload: httpx.Response(200, json=payload)
+        )
+        async with httpx.AsyncClient(transport=transport) as client:
+            adapter = GraphQLPBSAdapter(client, "svc", "https://bridge")
+            with pytest.raises(RuntimeError, match=message):
+                await adapter.get_job_statuses()
+
+
+async def test_graphql_suspended_state_is_dying_not_gone() -> None:
+    payload = _jobs_payload([{"node": _job_node("101.tara", 8), "error": None}])
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(200, json=payload)
+        )
+    ) as client:
+        status = await GraphQLPBSAdapter(
+            client, "svc", "https://bridge"
+        ).get_exact_job_status("101.tara")
+
+    assert status is not None
+    assert status.state == SchedulerJobState.exiting
+    assert status.head_node_ip_address == "10.1.2.3"
+
+
+async def test_graphql_get_endpoint_rejects_running_to_exiting_race() -> None:
+    """A head IP retained during scheduler exit is not a ready endpoint."""
+    status = JobStatusInfo(
+        id="1234.scheduler",
+        name="__FIRST_PILOT_model-canary",
+        state=SchedulerJobState.exiting,
+        created_at=datetime.now(timezone.utc),
+        started_at=datetime.now(timezone.utc),
+        walltime_minutes=90,
+        head_node_ip_address="10.1.2.3",
+        head_node_hostname="node-1",
+    )
+    config = PilotConfig.model_validate(
+        {
+            "scheduler_adapter": (
+                "first_gateway.platforms.schedulers.graphql_pbs.GraphQLPBSAdapter"
+            ),
+            "job_walltime_min": 90,
+            "max_num_nodes": 2,
+            "gpus_per_node": 4,
+            "queue": "workq",
+            "account": "service",
+            "workdir": "/service/workdir",
+            "external_port": 18443,
+            "nginx_path": "/service/nginx",
+            "ip_allowlist": ["10.0.0.0/8"],
+            "node_file_env": "PBS_NODEFILE",
+            "submit_script_preamble": "#!/bin/bash",
+            "pilot_path": "/service/first-pilot",
+        }
+    )
+    async with httpx.AsyncClient() as client:
+        adapter = GraphQLPBSAdapter(client, "service", "https://bridge")
+        submitter = PilotSubmitter(config, adapter, "unused-ca", "unused-key")
+        with patch.object(
+            adapter,
+            "get_job_statuses",
+            new=AsyncMock(return_value=[status]),
+        ):
+            with pytest.raises(ValueError, match="No ready endpoint"):
+                await submitter.get_endpoint("model-canary")
+
+
+async def test_graphql_delete_polls_exact_id_through_exiting_to_gone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    states = iter((7, 9, 12))
+    requests: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        requests.append(body)
+        if "mutation DeleteJob" in body["query"]:
+            return httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "deleteJob": {
+                            "node": {"jobId": "101.tara"},
+                            "error": None,
+                        }
+                    }
+                },
+            )
+        return httpx.Response(
+            200,
+            json=_jobs_payload(
+                [{"node": _job_node("101.tara", next(states)), "error": None}]
+            ),
+        )
+
+    monkeypatch.setattr(graphql_pbs, "_DELETE_POLL_INTERVAL_SEC", 0)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await GraphQLPBSAdapter(client, "svc", "https://bridge").terminate_job(
+            "101.tara"
+        )
+
+    assert len(requests) == 4
+    assert all(request["variables"]["jobId"] == "101.tara" for request in requests)
+
+
+async def test_graphql_delete_accepts_explicit_absence_after_lost_ack() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        body = json.loads(request.content)
+        if "mutation DeleteJob" in body["query"]:
+            return httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "deleteJob": {
+                            "node": None,
+                            "error": {
+                                "errorCode": 15001,
+                                "errorMessage": "unknown job id",
+                            },
+                        }
+                    }
+                },
+            )
+        return httpx.Response(200, json=_jobs_payload([]))
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await GraphQLPBSAdapter(client, "svc", "https://bridge").terminate_job(
+            "101.tara"
+        )
+    assert calls == 2
+
+
+async def test_graphql_delete_error_with_live_job_remains_failure() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        if "mutation DeleteJob" in body["query"]:
+            return httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "deleteJob": {
+                            "node": None,
+                            "error": {"errorCode": 1, "errorMessage": "failed"},
+                        }
+                    }
+                },
+            )
+        return httpx.Response(
+            200,
+            json=_jobs_payload([{"node": _job_node("101.tara", 7), "error": None}]),
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(RuntimeError, match="deleteJob failed"):
+            await GraphQLPBSAdapter(client, "svc", "https://bridge").terminate_job(
+                "101.tara"
+            )
+
+
+async def test_graphql_delete_timeout_and_malformed_id_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        body = json.loads(request.content)
+        if "mutation DeleteJob" in body["query"]:
+            payload: dict[str, Any] = {
+                "data": {
+                    "deleteJob": {
+                        "node": {"jobId": "101.tara"},
+                        "error": None,
+                    }
+                }
+            }
+        else:
+            payload = _jobs_payload([{"node": _job_node("101.tara", 7), "error": None}])
+        return httpx.Response(200, json=payload)
+
+    monkeypatch.setattr(graphql_pbs, "_DELETE_POLL_ATTEMPTS", 2)
+    monkeypatch.setattr(graphql_pbs, "_DELETE_POLL_INTERVAL_SEC", 0)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        adapter = GraphQLPBSAdapter(client, "svc", "https://bridge")
+        with pytest.raises(TimeoutError, match="did not become absent/gone"):
+            await adapter.terminate_job("101.tara")
+        before = calls
+        with pytest.raises(ValueError, match="invalid PBS scheduler job ID"):
+            await adapter.terminate_job('101.tara" } mutation { exploit')
+        assert calls == before

--- a/tests/test_graphql_pbs.py
+++ b/tests/test_graphql_pbs.py
@@ -11,7 +11,6 @@ from first_common.schema.base_scheduler import (
     SchedulerJobState,
 )
 from first_common.schema.types import PilotConfig
-from first_gateway.platforms.schedulers import graphql_pbs
 from first_gateway.platforms.schedulers.graphql_pbs import GraphQLPBSAdapter
 from first_gateway.services.pilot_submitter import PilotSubmitter
 
@@ -87,7 +86,7 @@ async def test_graphql_active_statuses_paginate_and_never_query_history() -> Non
     )
 
 
-async def test_graphql_statuses_fail_closed_on_edge_unknown_and_duplicate() -> None:
+async def test_graphql_statuses_fail_closed_on_edge_error_and_unknown_state() -> None:
     responses = [
         _jobs_payload(
             [
@@ -98,16 +97,10 @@ async def test_graphql_statuses_fail_closed_on_edge_unknown_and_duplicate() -> N
             ]
         ),
         _jobs_payload([{"node": _job_node("101.tara", 99), "error": None}]),
-        _jobs_payload(
-            [
-                {"node": _job_node("101.tara", 7), "error": None},
-                {"node": _job_node("101.tara", 7), "error": None},
-            ]
-        ),
     ]
     for payload, message in zip(
         responses,
-        ("edge failed", "unknown GraphQL job state", "duplicated job ID"),
+        ("edge failed", "unknown GraphQL job state"),
         strict=True,
     ):
         transport = httpx.MockTransport(
@@ -117,6 +110,25 @@ async def test_graphql_statuses_fail_closed_on_edge_unknown_and_duplicate() -> N
             adapter = GraphQLPBSAdapter(client, "svc", "https://bridge")
             with pytest.raises(RuntimeError, match=message):
                 await adapter.get_job_statuses()
+
+
+async def test_graphql_statuses_deduplicate_job_ids() -> None:
+    payload = _jobs_payload(
+        [
+            {"node": _job_node("101.tara", 7), "error": None},
+            {"node": _job_node("101.tara", 7), "error": None},
+        ]
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(200, json=payload)
+        )
+    ) as client:
+        statuses = await GraphQLPBSAdapter(
+            client, "svc", "https://bridge"
+        ).get_job_statuses()
+
+    assert [status.id for status in statuses] == ["101.tara"]
 
 
 async def test_graphql_suspended_state_is_dying_not_gone() -> None:
@@ -178,42 +190,32 @@ async def test_graphql_get_endpoint_rejects_running_to_exiting_race() -> None:
                 await submitter.get_endpoint("model-canary")
 
 
-async def test_graphql_delete_polls_exact_id_through_exiting_to_gone(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    states = iter((7, 9, 12))
+async def test_graphql_delete_returns_after_scheduler_acknowledgement() -> None:
     requests: list[dict[str, Any]] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         body = json.loads(request.content)
         requests.append(body)
-        if "mutation DeleteJob" in body["query"]:
-            return httpx.Response(
-                200,
-                json={
-                    "data": {
-                        "deleteJob": {
-                            "node": {"jobId": "101.tara"},
-                            "error": None,
-                        }
-                    }
-                },
-            )
         return httpx.Response(
             200,
-            json=_jobs_payload(
-                [{"node": _job_node("101.tara", next(states)), "error": None}]
-            ),
+            json={
+                "data": {
+                    "deleteJob": {
+                        "node": {"jobId": "101.tara"},
+                        "error": None,
+                    }
+                }
+            },
         )
 
-    monkeypatch.setattr(graphql_pbs, "_DELETE_POLL_INTERVAL_SEC", 0)
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
         await GraphQLPBSAdapter(client, "svc", "https://bridge").terminate_job(
             "101.tara"
         )
 
-    assert len(requests) == 4
-    assert all(request["variables"]["jobId"] == "101.tara" for request in requests)
+    assert len(requests) == 1
+    assert requests[0]["variables"]["jobId"] == "101.tara"
+    assert "mutation DeleteJob" in requests[0]["query"]
 
 
 async def test_graphql_delete_accepts_explicit_absence_after_lost_ack() -> None:
@@ -274,33 +276,25 @@ async def test_graphql_delete_error_with_live_job_remains_failure() -> None:
             )
 
 
-async def test_graphql_delete_timeout_and_malformed_id_fail_closed(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_graphql_delete_mismatched_and_malformed_ids_fail_closed() -> None:
     calls = 0
 
     def handler(request: httpx.Request) -> httpx.Response:
         nonlocal calls
         calls += 1
-        body = json.loads(request.content)
-        if "mutation DeleteJob" in body["query"]:
-            payload: dict[str, Any] = {
-                "data": {
-                    "deleteJob": {
-                        "node": {"jobId": "101.tara"},
-                        "error": None,
-                    }
+        payload: dict[str, Any] = {
+            "data": {
+                "deleteJob": {
+                    "node": {"jobId": "different.tara"},
+                    "error": None,
                 }
             }
-        else:
-            payload = _jobs_payload([{"node": _job_node("101.tara", 7), "error": None}])
+        }
         return httpx.Response(200, json=payload)
 
-    monkeypatch.setattr(graphql_pbs, "_DELETE_POLL_ATTEMPTS", 2)
-    monkeypatch.setattr(graphql_pbs, "_DELETE_POLL_INTERVAL_SEC", 0)
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
         adapter = GraphQLPBSAdapter(client, "svc", "https://bridge")
-        with pytest.raises(TimeoutError, match="did not become absent/gone"):
+        with pytest.raises(RuntimeError, match="different job ID"):
             await adapter.terminate_job("101.tara")
         before = calls
         with pytest.raises(ValueError, match="invalid PBS scheduler job ID"):

--- a/tests/test_pilot_job_controller.py
+++ b/tests/test_pilot_job_controller.py
@@ -276,7 +276,7 @@ async def test_reconcile_cluster_without_pilot_system(
 # ---------------------------------------------------------------------------
 
 
-async def test_scheduled_deletion_requests_nonblocking_termination(
+async def test_scheduled_deletion_terminates_running_job(
     db: async_sessionmaker[AsyncSession],
     ca_pair: tuple[str, str],
     adapter: FakeSchedulerAdapter,
@@ -297,33 +297,7 @@ async def test_scheduled_deletion_requests_nonblocking_termination(
     assert "100.pbs" in adapter.terminated
 
     job = await _get_job(db, uid)
-    assert job.deleted_at is None
-    assert job.scheduler_state == SchedulerJobState.exiting.value
-
-
-async def test_scheduled_deletion_waits_for_exiting_job_to_become_gone(
-    db: async_sessionmaker[AsyncSession],
-    ca_pair: tuple[str, str],
-    adapter: FakeSchedulerAdapter,
-) -> None:
-    async with db.begin() as sess:
-        await _seed_cluster(sess)
-        uid = await _insert_pilot_job(
-            sess,
-            "job-exiting",
-            scheduler_job_id="101.pbs",
-            scheduler_state=SchedulerJobState.exiting,
-            scheduled_deletion_at=NOW,
-        )
-
-    controller = _make_controller(db, ca_pair)
-    with patch(_PATCH_BUILD, new_callable=AsyncMock, return_value=adapter):
-        await controller.reconcile(uid)
-
-    assert adapter.terminated == []
-    job = await _get_job(db, uid)
-    assert job.deleted_at is None
-    assert job.scheduler_state == SchedulerJobState.exiting.value
+    assert job.deleted_at is not None
 
 
 async def test_scheduled_deletion_without_scheduler_job_skips_terminate(
@@ -541,37 +515,6 @@ async def test_submit_deferred_by_concurrent_jobs_cap(
 
     job = await _get_job(db, uid)
     assert job.scheduler_job_id is None
-    assert job.scheduler_state == SchedulerJobState.pending_submit.value
-
-
-async def test_exiting_job_still_counts_toward_concurrent_cap(
-    db: async_sessionmaker[AsyncSession],
-    ca_pair: tuple[str, str],
-    adapter: FakeSchedulerAdapter,
-) -> None:
-    """A qdel-acknowledged allocation remains active until observed gone."""
-    async with db.begin() as sess:
-        await _seed_cluster(sess)
-        await _insert_pilot_job(sess, "running-0")
-        await _insert_pilot_job(sess, "running-1")
-        await _insert_pilot_job(
-            sess,
-            "exiting",
-            scheduler_state=SchedulerJobState.exiting,
-            scheduled_deletion_at=NOW,
-        )
-        uid = await _insert_pilot_job(
-            sess,
-            "waiting",
-            scheduler_state=SchedulerJobState.pending_submit,
-        )
-
-    controller = _make_controller(db, ca_pair)
-    with patch(_PATCH_BUILD, new_callable=AsyncMock, return_value=adapter):
-        await controller.reconcile(uid)
-
-    assert adapter.submitted == []
-    job = await _get_job(db, uid)
     assert job.scheduler_state == SchedulerJobState.pending_submit.value
 
 

--- a/tests/test_pilot_job_controller.py
+++ b/tests/test_pilot_job_controller.py
@@ -276,7 +276,7 @@ async def test_reconcile_cluster_without_pilot_system(
 # ---------------------------------------------------------------------------
 
 
-async def test_scheduled_deletion_terminates_running_job(
+async def test_scheduled_deletion_requests_nonblocking_termination(
     db: async_sessionmaker[AsyncSession],
     ca_pair: tuple[str, str],
     adapter: FakeSchedulerAdapter,
@@ -297,7 +297,33 @@ async def test_scheduled_deletion_terminates_running_job(
     assert "100.pbs" in adapter.terminated
 
     job = await _get_job(db, uid)
-    assert job.deleted_at is not None
+    assert job.deleted_at is None
+    assert job.scheduler_state == SchedulerJobState.exiting.value
+
+
+async def test_scheduled_deletion_waits_for_exiting_job_to_become_gone(
+    db: async_sessionmaker[AsyncSession],
+    ca_pair: tuple[str, str],
+    adapter: FakeSchedulerAdapter,
+) -> None:
+    async with db.begin() as sess:
+        await _seed_cluster(sess)
+        uid = await _insert_pilot_job(
+            sess,
+            "job-exiting",
+            scheduler_job_id="101.pbs",
+            scheduler_state=SchedulerJobState.exiting,
+            scheduled_deletion_at=NOW,
+        )
+
+    controller = _make_controller(db, ca_pair)
+    with patch(_PATCH_BUILD, new_callable=AsyncMock, return_value=adapter):
+        await controller.reconcile(uid)
+
+    assert adapter.terminated == []
+    job = await _get_job(db, uid)
+    assert job.deleted_at is None
+    assert job.scheduler_state == SchedulerJobState.exiting.value
 
 
 async def test_scheduled_deletion_without_scheduler_job_skips_terminate(
@@ -515,6 +541,37 @@ async def test_submit_deferred_by_concurrent_jobs_cap(
 
     job = await _get_job(db, uid)
     assert job.scheduler_job_id is None
+    assert job.scheduler_state == SchedulerJobState.pending_submit.value
+
+
+async def test_exiting_job_still_counts_toward_concurrent_cap(
+    db: async_sessionmaker[AsyncSession],
+    ca_pair: tuple[str, str],
+    adapter: FakeSchedulerAdapter,
+) -> None:
+    """A qdel-acknowledged allocation remains active until observed gone."""
+    async with db.begin() as sess:
+        await _seed_cluster(sess)
+        await _insert_pilot_job(sess, "running-0")
+        await _insert_pilot_job(sess, "running-1")
+        await _insert_pilot_job(
+            sess,
+            "exiting",
+            scheduler_state=SchedulerJobState.exiting,
+            scheduled_deletion_at=NOW,
+        )
+        uid = await _insert_pilot_job(
+            sess,
+            "waiting",
+            scheduler_state=SchedulerJobState.pending_submit,
+        )
+
+    controller = _make_controller(db, ca_pair)
+    with patch(_PATCH_BUILD, new_callable=AsyncMock, return_value=adapter):
+        await controller.reconcile(uid)
+
+    assert adapter.submitted == []
+    job = await _get_job(db, uid)
     assert job.scheduler_state == SchedulerJobState.pending_submit.value
 
 

--- a/tests/test_pilot_job_controller.py
+++ b/tests/test_pilot_job_controller.py
@@ -276,7 +276,7 @@ async def test_reconcile_cluster_without_pilot_system(
 # ---------------------------------------------------------------------------
 
 
-async def test_scheduled_deletion_terminates_running_job(
+async def test_scheduled_deletion_requests_nonblocking_termination(
     db: async_sessionmaker[AsyncSession],
     ca_pair: tuple[str, str],
     adapter: FakeSchedulerAdapter,
@@ -297,7 +297,33 @@ async def test_scheduled_deletion_terminates_running_job(
     assert "100.pbs" in adapter.terminated
 
     job = await _get_job(db, uid)
-    assert job.deleted_at is not None
+    assert job.deleted_at is None
+    assert job.scheduler_state == SchedulerJobState.exiting.value
+
+
+async def test_scheduled_deletion_waits_for_exiting_job_to_become_gone(
+    db: async_sessionmaker[AsyncSession],
+    ca_pair: tuple[str, str],
+    adapter: FakeSchedulerAdapter,
+) -> None:
+    async with db.begin() as sess:
+        await _seed_cluster(sess)
+        uid = await _insert_pilot_job(
+            sess,
+            "job-exiting",
+            scheduler_job_id="101.pbs",
+            scheduler_state=SchedulerJobState.exiting,
+            scheduled_deletion_at=NOW,
+        )
+
+    controller = _make_controller(db, ca_pair)
+    with patch(_PATCH_BUILD, new_callable=AsyncMock, return_value=adapter):
+        await controller.reconcile(uid)
+
+    assert adapter.terminated == []
+    job = await _get_job(db, uid)
+    assert job.deleted_at is None
+    assert job.scheduler_state == SchedulerJobState.exiting.value
 
 
 async def test_scheduled_deletion_without_scheduler_job_skips_terminate(
@@ -518,6 +544,38 @@ async def test_submit_deferred_by_concurrent_jobs_cap(
     assert job.scheduler_state == SchedulerJobState.pending_submit.value
 
 
+async def test_exiting_job_does_not_delay_replacement_submission(
+    db: async_sessionmaker[AsyncSession],
+    ca_pair: tuple[str, str],
+    adapter: FakeSchedulerAdapter,
+) -> None:
+    """An acknowledged qdel frees its FIRST submission-capacity slot."""
+    async with db.begin() as sess:
+        await _seed_cluster(sess)
+        await _insert_pilot_job(sess, "running-0")
+        await _insert_pilot_job(sess, "running-1")
+        await _insert_pilot_job(
+            sess,
+            "exiting",
+            scheduler_state=SchedulerJobState.exiting,
+            scheduled_deletion_at=NOW,
+        )
+        uid = await _insert_pilot_job(
+            sess,
+            "replacement",
+            scheduler_state=SchedulerJobState.pending_submit,
+        )
+
+    controller = _make_controller(db, ca_pair)
+    with patch(_PATCH_BUILD, new_callable=AsyncMock, return_value=adapter):
+        await controller.reconcile(uid)
+
+    assert len(adapter.submitted) == 1
+    job = await _get_job(db, uid)
+    assert job.scheduler_job_id == "42.pbs"
+    assert job.scheduler_state == SchedulerJobState.queued.value
+
+
 async def test_submit_deferred_by_node_cap(
     db: async_sessionmaker[AsyncSession],
     ca_pair: tuple[str, str],
@@ -542,6 +600,38 @@ async def test_submit_deferred_by_node_cap(
 
     job = await _get_job(db, uid)
     assert job.scheduler_job_id is None
+
+
+async def test_exiting_job_does_not_delay_replacement_at_node_cap(
+    db: async_sessionmaker[AsyncSession],
+    ca_pair: tuple[str, str],
+    adapter: FakeSchedulerAdapter,
+) -> None:
+    """Exiting nodes remain PBS-owned but do not consume FIRST submit capacity."""
+    async with db.begin() as sess:
+        await _seed_cluster(sess)
+        await _insert_pilot_job(
+            sess,
+            "exiting-large-job",
+            scheduler_state=SchedulerJobState.exiting,
+            scheduled_deletion_at=NOW,
+            num_nodes=9,
+        )
+        uid = await _insert_pilot_job(
+            sess,
+            "replacement",
+            scheduler_state=SchedulerJobState.pending_submit,
+            num_nodes=2,
+        )
+
+    controller = _make_controller(db, ca_pair)
+    with patch(_PATCH_BUILD, new_callable=AsyncMock, return_value=adapter):
+        await controller.reconcile(uid)
+
+    assert len(adapter.submitted) == 1
+    job = await _get_job(db, uid)
+    assert job.scheduler_job_id == "42.pbs"
+    assert job.scheduler_state == SchedulerJobState.queued.value
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pilot_job_observer.py
+++ b/tests/test_pilot_job_observer.py
@@ -118,7 +118,6 @@ async def _insert_pilot_job(
     scheduler_job_id: str,
     state: SchedulerJobState = SchedulerJobState.pending_submit,
     manager_url: str | None = None,
-    scheduled_deletion_at: datetime | None = None,
 ) -> int:
     job = PilotJob(
         name=name,
@@ -126,7 +125,6 @@ async def _insert_pilot_job(
         scheduler_job_id=scheduler_job_id,
         scheduler_state=state.value,
         manager_url=manager_url,
-        scheduled_deletion_at=scheduled_deletion_at,
         manager_health=HealthCheckResult.unknown.value,
         walltime_min=60,
         num_nodes=1,
@@ -262,32 +260,6 @@ async def test_no_update_when_state_unchanged(
     async with db() as sess:
         job = (await sess.scalars(select(PilotJob).where(PilotJob.uid == uid))).one()
     assert job.scheduler_state == SchedulerJobState.running.value
-
-
-async def test_missing_exiting_job_completes_nonblocking_termination(
-    db: async_sessionmaker[AsyncSession],
-) -> None:
-    adapter = FakeSchedulerAdapter()
-
-    async with db.begin() as sess:
-        await _seed_cluster(sess)
-        uid = await _insert_pilot_job(
-            sess,
-            "job-exiting",
-            "457.pbs",
-            state=SchedulerJobState.exiting,
-            scheduled_deletion_at=NOW,
-        )
-
-    observer = _make_observer(db)
-    pilot_config = PilotConfig.model_validate(PILOT_SYSTEM)
-    submitter = PilotSubmitter(pilot_config, adapter, "fake-ca-crt", "fake-ca-key")
-    await observer._poll_cluster(submitter, "polaris")
-
-    async with db() as sess:
-        job = (await sess.scalars(select(PilotJob).where(PilotJob.uid == uid))).one()
-    assert job.scheduler_state == SchedulerJobState.gone.value
-    assert job.deleted_at is not None
 
 
 async def test_cluster_without_pilot_system_skipped(

--- a/tests/test_pilot_job_observer.py
+++ b/tests/test_pilot_job_observer.py
@@ -118,6 +118,7 @@ async def _insert_pilot_job(
     scheduler_job_id: str,
     state: SchedulerJobState = SchedulerJobState.pending_submit,
     manager_url: str | None = None,
+    scheduled_deletion_at: datetime | None = None,
 ) -> int:
     job = PilotJob(
         name=name,
@@ -125,6 +126,7 @@ async def _insert_pilot_job(
         scheduler_job_id=scheduler_job_id,
         scheduler_state=state.value,
         manager_url=manager_url,
+        scheduled_deletion_at=scheduled_deletion_at,
         manager_health=HealthCheckResult.unknown.value,
         walltime_min=60,
         num_nodes=1,
@@ -260,6 +262,32 @@ async def test_no_update_when_state_unchanged(
     async with db() as sess:
         job = (await sess.scalars(select(PilotJob).where(PilotJob.uid == uid))).one()
     assert job.scheduler_state == SchedulerJobState.running.value
+
+
+async def test_missing_exiting_job_completes_nonblocking_termination(
+    db: async_sessionmaker[AsyncSession],
+) -> None:
+    adapter = FakeSchedulerAdapter()
+
+    async with db.begin() as sess:
+        await _seed_cluster(sess)
+        uid = await _insert_pilot_job(
+            sess,
+            "job-exiting",
+            "457.pbs",
+            state=SchedulerJobState.exiting,
+            scheduled_deletion_at=NOW,
+        )
+
+    observer = _make_observer(db)
+    pilot_config = PilotConfig.model_validate(PILOT_SYSTEM)
+    submitter = PilotSubmitter(pilot_config, adapter, "fake-ca-crt", "fake-ca-key")
+    await observer._poll_cluster(submitter, "polaris")
+
+    async with db() as sess:
+        job = (await sess.scalars(select(PilotJob).where(PilotJob.uid == uid))).one()
+    assert job.scheduler_state == SchedulerJobState.gone.value
+    assert job.deleted_at is not None
 
 
 async def test_cluster_without_pilot_system_skipped(


### PR DESCRIPTION
## Summary

- Paginate active GraphQL PBS jobs and fail closed on malformed, duplicate, or unknown scheduler data.
- Add exact-job lookup so omission from a bulk listing is never treated as proof that an allocation is gone.
- Validate deletion requests and wait for the exact job to become terminal or absent.
- Publish scheduler-derived endpoints only for running jobs.

## Why this is needed

A paginated listing can omit a live allocation, while a successful delete mutation is only an acknowledgement. Treating either as proof of release could free capacity while the scheduler still owns the nodes.

## Tests

- `tests/test_graphql_pbs.py`: 8 passed
- Ruff, formatting, and MyPy passed