### PR TITLE
Add multi-node PALS pilot inventory

### DIFF
--- a/packages/common/first_common/schema/pilot.py
+++ b/packages/common/first_common/schema/pilot.py
@@ -4,6 +4,7 @@ These schemas describe the communication between first-gateway and first-pilot.
 Do not confuse with admin-created pilot resources inside `resources` subpackage
 """
 
+import json
 import os
 from datetime import datetime
 from pathlib import Path
@@ -11,7 +12,7 @@ from tempfile import TemporaryDirectory
 from typing import Self
 
 import yaml
-from pydantic import BaseModel, PrivateAttr, computed_field
+from pydantic import BaseModel, Field, PrivateAttr, computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from .types import GpuClaim, PilotLaunchSpec, ReplicaState
@@ -123,6 +124,9 @@ class PilotRuntimeConfig(BaseSettings):
     ip_allowlist: list[str]
     workdir: Path
     node_file_env: str
+    pals_path: Path | None = None
+    num_nodes: int = Field(ge=1)
+    gpus_per_node: int = Field(ge=1)
     job_name: str
 
     # Name of the IPv4 network interface (e.g. "hsn0") whose address the pilot
@@ -162,4 +166,35 @@ class PilotRuntimeConfig(BaseSettings):
         """
         yaml_path = os.environ["PILOT_CONFIG_FILE"]
         config_raw = yaml.safe_load(Path(yaml_path).read_text())
+        if not isinstance(config_raw, dict):
+            raise ValueError("pilot runtime config must be a YAML mapping")
+
+        # GraphQL-backed schedulers cannot stage a per-job YAML file. Overlay
+        # the submitted job's identity, topology, runtime paths, and allowlist;
+        # credentials and other static settings remain in the reviewed YAML.
+        for field_name in (
+            "job_name",
+            "external_port",
+            "nginx_path",
+            "workdir",
+            "node_file_env",
+            "pals_path",
+            "num_nodes",
+            "gpus_per_node",
+        ):
+            env_name = f"PILOT_{field_name.upper()}"
+            if env_name in os.environ:
+                value = os.environ[env_name]
+                config_raw[field_name] = None if value == "" else value
+
+        if "PILOT_IP_ALLOWLIST_JSON" in os.environ:
+            try:
+                allowlist = json.loads(os.environ["PILOT_IP_ALLOWLIST_JSON"])
+            except json.JSONDecodeError as exc:
+                raise ValueError("PILOT_IP_ALLOWLIST_JSON is invalid JSON") from exc
+            if not isinstance(allowlist, list) or not all(
+                isinstance(value, str) for value in allowlist
+            ):
+                raise ValueError("PILOT_IP_ALLOWLIST_JSON must be a string list")
+            config_raw["ip_allowlist"] = allowlist
         return cls.model_validate(config_raw)

--- a/packages/common/first_common/schema/pilot.py
+++ b/packages/common/first_common/schema/pilot.py
@@ -4,7 +4,6 @@ These schemas describe the communication between first-gateway and first-pilot.
 Do not confuse with admin-created pilot resources inside `resources` subpackage
 """
 
-import json
 import os
 from datetime import datetime
 from pathlib import Path
@@ -15,7 +14,13 @@ import yaml
 from pydantic import BaseModel, Field, PrivateAttr, computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from .types import GpuClaim, PilotLaunchSpec, ReplicaState
+from .types import (
+    GpuClaim,
+    GpuDiscovery,
+    PilotLaunchSpec,
+    ReplicaState,
+    SSHDiscovery,
+)
 
 
 class ReplicaStartRequest(BaseModel):
@@ -124,7 +129,7 @@ class PilotRuntimeConfig(BaseSettings):
     ip_allowlist: list[str]
     workdir: Path
     node_file_env: str
-    pals_path: Path | None = None
+    gpu_discovery: GpuDiscovery = Field(default_factory=SSHDiscovery)
     num_nodes: int = Field(ge=1)
     gpus_per_node: int = Field(ge=1)
     job_name: str
@@ -169,32 +174,4 @@ class PilotRuntimeConfig(BaseSettings):
         if not isinstance(config_raw, dict):
             raise ValueError("pilot runtime config must be a YAML mapping")
 
-        # GraphQL-backed schedulers cannot stage a per-job YAML file. Overlay
-        # the submitted job's identity, topology, runtime paths, and allowlist;
-        # credentials and other static settings remain in the reviewed YAML.
-        for field_name in (
-            "job_name",
-            "external_port",
-            "nginx_path",
-            "workdir",
-            "node_file_env",
-            "pals_path",
-            "num_nodes",
-            "gpus_per_node",
-        ):
-            env_name = f"PILOT_{field_name.upper()}"
-            if env_name in os.environ:
-                value = os.environ[env_name]
-                config_raw[field_name] = None if value == "" else value
-
-        if "PILOT_IP_ALLOWLIST_JSON" in os.environ:
-            try:
-                allowlist = json.loads(os.environ["PILOT_IP_ALLOWLIST_JSON"])
-            except json.JSONDecodeError as exc:
-                raise ValueError("PILOT_IP_ALLOWLIST_JSON is invalid JSON") from exc
-            if not isinstance(allowlist, list) or not all(
-                isinstance(value, str) for value in allowlist
-            ):
-                raise ValueError("PILOT_IP_ALLOWLIST_JSON must be a string list")
-            config_raw["ip_allowlist"] = allowlist
-        return cls.model_validate(config_raw)
+        return cls(**config_raw)

--- a/packages/common/first_common/schema/types.py
+++ b/packages/common/first_common/schema/types.py
@@ -172,6 +172,7 @@ class PilotConfig(BaseModel):
     nginx_path: Path
     ip_allowlist: list[str]
     node_file_env: str
+    pals_path: Path | None = None
     submit_script_preamble: str
     pilot_path: Path
     job_name_prefix: str = Field("__FIRST_PILOT_", pattern=r"[a-zA-Z0-9_]+")

--- a/packages/common/first_common/schema/types.py
+++ b/packages/common/first_common/schema/types.py
@@ -2,7 +2,7 @@ import os
 from enum import Enum
 from http import HTTPMethod
 from pathlib import Path
-from typing import Any, Callable, ClassVar, Literal, NewType, TypedDict
+from typing import Annotated, Any, Callable, ClassVar, Literal, NewType, TypedDict
 
 from dotenv import dotenv_values
 from jinja2 import Environment, TemplateSyntaxError, meta
@@ -148,6 +148,27 @@ class RouterParams(BaseModel):
     cooldown_bench_sec: int = 60
 
 
+class SSHDiscovery(BaseModel):
+    """Discover each host's GPUs through concurrent SSH commands."""
+
+    method: Literal["ssh"] = "ssh"
+    timeout_sec: float = Field(5.0, gt=0)
+
+
+class PalsDiscovery(BaseModel):
+    """Discover GPUs with one labeled PALS rank per scheduler host."""
+
+    method: Literal["pals"] = "pals"
+    launcher_path: Path
+    timeout_sec: float = Field(35.0, gt=0)
+
+
+GpuDiscovery = Annotated[
+    SSHDiscovery | PalsDiscovery,
+    Field(discriminator="method"),
+]
+
+
 class PilotConfig(BaseModel):
     """
     HPC Cluster-wide configuration for the pilot system.
@@ -172,7 +193,7 @@ class PilotConfig(BaseModel):
     nginx_path: Path
     ip_allowlist: list[str]
     node_file_env: str
-    pals_path: Path | None = None
+    gpu_discovery: GpuDiscovery = Field(default_factory=SSHDiscovery)
     submit_script_preamble: str
     pilot_path: Path
     job_name_prefix: str = Field("__FIRST_PILOT_", pattern=r"[a-zA-Z0-9_]+")

--- a/packages/gateway/first_gateway/services/pilot_submitter.py
+++ b/packages/gateway/first_gateway/services/pilot_submitter.py
@@ -64,11 +64,6 @@ class PilotSubmitter:
         scheduler_name = f"{pc.job_name_prefix}{name}"
         log_path = pc.workdir / "submit_scripts" / f"{name}.log"
 
-        if pilot_job.num_nodes > 1 and pc.pals_path is None:
-            raise ValueError(
-                "multi-node pilot submission requires PilotConfig.pals_path"
-            )
-
         script: str | None = None
         script_path: Path | None = None
 
@@ -85,12 +80,14 @@ class PilotSubmitter:
                 "PILOT_JOB_NAME": name,
                 "PILOT_EXTERNAL_PORT": str(pc.external_port),
                 "PILOT_NGINX_PATH": str(pc.nginx_path),
-                "PILOT_IP_ALLOWLIST_JSON": json.dumps(
+                "PILOT_IP_ALLOWLIST": json.dumps(
                     pc.ip_allowlist, separators=(",", ":")
                 ),
                 "PILOT_WORKDIR": str(pc.workdir),
                 "PILOT_NODE_FILE_ENV": pc.node_file_env,
-                "PILOT_PALS_PATH": str(pc.pals_path) if pc.pals_path else "",
+                "PILOT_GPU_DISCOVERY": json.dumps(
+                    pc.gpu_discovery.model_dump(mode="json"), separators=(",", ":")
+                ),
                 "PILOT_NUM_NODES": str(pilot_job.num_nodes),
                 "PILOT_GPUS_PER_NODE": str(pilot_job.gpus_per_node),
             }
@@ -119,7 +116,7 @@ class PilotSubmitter:
                 ip_allowlist=pc.ip_allowlist,
                 workdir=pc.workdir,
                 node_file_env=pc.node_file_env,
-                pals_path=pc.pals_path,
+                gpu_discovery=pc.gpu_discovery,
                 num_nodes=pilot_job.num_nodes,
                 gpus_per_node=pilot_job.gpus_per_node,
                 job_name=name,

--- a/packages/gateway/first_gateway/services/pilot_submitter.py
+++ b/packages/gateway/first_gateway/services/pilot_submitter.py
@@ -1,6 +1,8 @@
+import json
 from dataclasses import replace
 from math import ceil
 from pathlib import Path
+from shlex import quote
 
 import yaml
 
@@ -62,6 +64,11 @@ class PilotSubmitter:
         scheduler_name = f"{pc.job_name_prefix}{name}"
         log_path = pc.workdir / "submit_scripts" / f"{name}.log"
 
+        if pilot_job.num_nodes > 1 and pc.pals_path is None:
+            raise ValueError(
+                "multi-node pilot submission requires PilotConfig.pals_path"
+            )
+
         script: str | None = None
         script_path: Path | None = None
 
@@ -73,10 +80,26 @@ class PilotSubmitter:
                 raise ValueError(
                     "GraphQLPBSAdapter requires PilotConfig.pilot_config_path"
                 )
+            runtime_env = {
+                "PILOT_CONFIG_FILE": str(pc.pilot_config_path),
+                "PILOT_JOB_NAME": name,
+                "PILOT_EXTERNAL_PORT": str(pc.external_port),
+                "PILOT_NGINX_PATH": str(pc.nginx_path),
+                "PILOT_IP_ALLOWLIST_JSON": json.dumps(
+                    pc.ip_allowlist, separators=(",", ":")
+                ),
+                "PILOT_WORKDIR": str(pc.workdir),
+                "PILOT_NODE_FILE_ENV": pc.node_file_env,
+                "PILOT_PALS_PATH": str(pc.pals_path) if pc.pals_path else "",
+                "PILOT_NUM_NODES": str(pilot_job.num_nodes),
+                "PILOT_GPUS_PER_NODE": str(pilot_job.gpus_per_node),
+            }
+            assignments = " ".join(
+                f"{key}={quote(value)}" for key, value in runtime_env.items()
+            )
             script = (
                 f"{pc.submit_script_preamble}\n"
-                f'PILOT_CONFIG_FILE={pc.pilot_config_path} PILOT_JOB_NAME="{name}" '
-                f"{pc.pilot_path}\n"
+                f"{assignments} {quote(str(pc.pilot_path))}\n"
             )
         else:
             # Filesystem-backed: render the runtime config and submit script
@@ -96,6 +119,9 @@ class PilotSubmitter:
                 ip_allowlist=pc.ip_allowlist,
                 workdir=pc.workdir,
                 node_file_env=pc.node_file_env,
+                pals_path=pc.pals_path,
+                num_nodes=pilot_job.num_nodes,
+                gpus_per_node=pilot_job.gpus_per_node,
                 job_name=name,
             )
             config_yaml = yaml.dump(
@@ -106,7 +132,8 @@ class PilotSubmitter:
             script_path = pc.workdir / "submit_scripts" / f"{name}.sh"
             body = (
                 f"{pc.submit_script_preamble}\n"
-                f"PILOT_CONFIG_FILE={config_path} {pc.pilot_path}\n"
+                f"PILOT_CONFIG_FILE={quote(str(config_path))} "
+                f"{quote(str(pc.pilot_path))}\n"
             )
 
             await self.adapter.put_file(config_yaml, config_path, mode=0o600)

--- a/packages/pilot/first_pilot/control_api.py
+++ b/packages/pilot/first_pilot/control_api.py
@@ -21,7 +21,7 @@ from first_common.schema.pilot import (
 )
 
 from .nginx_manager import NginxManager, ReplicaUpstream
-from .replica_manager import ReplicaManager, safe_getfqdn
+from .replica_manager import ReplicaManager
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +62,7 @@ class _PilotManager:
             )
 
         return AddressInfo(
-            hostname=safe_getfqdn(ip),
+            hostname=socket.gethostname(),
             ip=ip,
             external_port=self.config.external_port,
             control_path=self.nginx.control_path,

--- a/packages/pilot/first_pilot/replica_manager.py
+++ b/packages/pilot/first_pilot/replica_manager.py
@@ -1,11 +1,11 @@
 import logging
 import os
+import re
 import socket
 import subprocess
 import threading
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, wait
-from concurrent.futures import TimeoutError as FutTimeout
 from enum import Enum
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -36,15 +36,9 @@ logger = logging.getLogger(__name__)
 
 
 def safe_getfqdn(name: str = "", *, timeout: float = 2.0) -> str:
-    """getfqdn with a timeout — falls back to *name* (or the raw hostname) on slow rDNS."""
-    pool = ThreadPoolExecutor(1)
-    try:
-        return pool.submit(socket.getfqdn, name).result(timeout=timeout)
-    except FutTimeout:
-        logger.warning("getfqdn(%r) timed out after %ss", name, timeout)
-        return name or socket.gethostname()
-    finally:
-        pool.shutdown(wait=False, cancel_futures=True)
+    """Return a DNS-free address label; retained for the control API contract."""
+    del timeout
+    return name or socket.gethostname()
 
 
 class _ReservedSentinel(Enum):
@@ -55,20 +49,35 @@ ReservedSentinel = Literal[_ReservedSentinel.RESERVED]
 _RESERVED = _ReservedSentinel.RESERVED
 
 
-def _parse_gpu_row(line: str) -> GpuInfo | None:
-    fields = [f.strip() for f in line.split(",")]
+_NVIDIA_SMI_ARGS = [
+    "--query-gpu=index,name,memory.total,memory.used",
+    "--format=csv,noheader,nounits",
+]
+_PALS_LABEL = re.compile(r"^(?P<host>\S+)\s+(?P<rank>\d+):\s?(?P<row>.*)$")
+
+
+def _require_executable(path: Path, *, label: str) -> str:
+    """Return a configured executable path or fail with a useful error."""
+    if not path.is_file() or not os.access(path, os.X_OK):
+        raise RuntimeError(f"required {label} is unavailable: {path}")
+    return str(path)
+
+
+def _parse_gpu_row(line: str) -> GpuInfo:
+    fields = [field.strip() for field in line.split(",")]
     if len(fields) != 4:
-        logger.warning("unexpected nvidia-smi row %r; skipping", line)
-        return None
+        raise ValueError(f"unexpected nvidia-smi row: {line!r}")
 
     index, name, mem_total, mem_used = fields
+    if not index.isdecimal() or not name:
+        raise ValueError(f"invalid GPU index or name in nvidia-smi row: {line!r}")
     try:
         mem_total_mib = int(mem_total)
         mem_used_mib = int(mem_used)
-    except ValueError:
-        logger.warning("unparseable memory fields in nvidia-smi row %r", line)
-        mem_total_mib = None
-        mem_used_mib = None
+    except ValueError as exc:
+        raise ValueError(f"invalid GPU memory in nvidia-smi row: {line!r}") from exc
+    if mem_total_mib <= 0 or not 0 <= mem_used_mib <= mem_total_mib:
+        raise ValueError(f"out-of-range GPU memory in nvidia-smi row: {line!r}")
 
     return GpuInfo(
         index=index,
@@ -78,44 +87,165 @@ def _parse_gpu_row(line: str) -> GpuInfo | None:
     )
 
 
-def query_gpus(hostname: str) -> HostGpus:
+def _validated_host_gpus(
+    hostname: str, gpus: list[GpuInfo], expected_gpus: int
+) -> HostGpus:
+    indices = [gpu.index for gpu in gpus]
+    if len(indices) != len(set(indices)):
+        raise RuntimeError(f"GPU inventory duplicated an index on host {hostname!r}")
+
+    expected_indices = {str(index) for index in range(expected_gpus)}
+    if set(indices) != expected_indices:
+        raise RuntimeError(
+            f"GPU inventory for host {hostname!r} reported indices "
+            f"{sorted(indices)!r}; expected {sorted(expected_indices)!r}"
+        )
+    return HostGpus(
+        hostname=hostname,
+        gpus=sorted(gpus, key=lambda gpu: int(gpu.index)),
+    )
+
+
+def query_gpus(hostname: str, expected_gpus: int) -> HostGpus:
+    """Inventory a single-node pilot locally; never use a remote shell."""
+    nvidia_smi = "nvidia-smi"
     try:
         result = subprocess.run(
-            [
-                "ssh",
-                hostname,
-                "nvidia-smi",
-                "--query-gpu=index,name,memory.total,memory.used",
-                "--format=csv,noheader,nounits",
-            ],
+            [nvidia_smi, *_NVIDIA_SMI_ARGS],
             capture_output=True,
             text=True,
             timeout=5,
         )
-    except subprocess.TimeoutExpired:
-        logger.warning("nvidia-smi timed out after 5s; no GPUs discovered")
-        return HostGpus(hostname=hostname, gpus=[])
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("local GPU inventory timed out after 5s") from exc
 
     if result.returncode != 0:
-        logger.warning(
-            "nvidia-smi exited %d; no GPUs discovered (stderr: %s)",
-            result.returncode,
-            result.stderr.strip(),
+        raise RuntimeError(
+            f"local GPU inventory exited {result.returncode}: "
+            f"{result.stderr.strip()[-2000:]}"
         )
-        return HostGpus(hostname=hostname, gpus=[])
 
-    lines = result.stdout.strip().splitlines()
+    try:
+        gpus = [_parse_gpu_row(line) for line in result.stdout.splitlines() if line]
+    except ValueError as exc:
+        raise RuntimeError(f"local GPU inventory was malformed: {exc}") from exc
+    return _validated_host_gpus(hostname, gpus, expected_gpus)
 
-    gpus = [info for line in lines if line.strip() and (info := _parse_gpu_row(line))]
-    gpus = sorted(gpus, key=lambda gpu: gpu.index)
-    return HostGpus(hostname=hostname, gpus=gpus)
+
+def _normalized_hostname(hostname: str) -> str:
+    return hostname.strip().rstrip(".").lower()
+
+
+def _host_identity(hostname: str) -> str:
+    return _normalized_hostname(hostname).split(".", maxsplit=1)[0]
+
+
+def _host_matches(label: str, expected: str) -> bool:
+    label_identity = _host_identity(label)
+    expected_identity = _host_identity(expected)
+    return bool(label_identity) and label_identity == expected_identity
+
+
+def _deduplicate_hosts(hostnames: list[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for hostname in hostnames:
+        identity = _host_identity(hostname)
+        if not identity:
+            raise RuntimeError("scheduler node inventory contains an empty hostname")
+        if identity not in seen:
+            seen.add(identity)
+            result.append(hostname)
+    return result
+
+
+def query_gpus_pals(
+    hostnames: list[str], pals_path: Path, expected_gpus: int
+) -> list[HostGpus]:
+    """Run one labeled inventory rank per host through the site PALS launcher."""
+    nvidia_smi = "nvidia-smi"
+    pals = _require_executable(pals_path, label="PALS launcher")
+
+    command = [
+        pals,
+        "--pmi=pmix",
+        "--genvnone",
+        "--no-transfer",
+        "--line-buffer",
+        "--label",
+        "--abort-on-failure",
+        "--timeout",
+        "30",
+        "-n",
+        str(len(hostnames)),
+        "--ppn",
+        "1",
+        "--cpu-bind=none",
+        nvidia_smi,
+        *_NVIDIA_SMI_ARGS,
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=35,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("PALS GPU inventory timed out after 35s") from exc
+
+    if result.returncode != 0:
+        diagnostics = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(
+            f"PALS GPU inventory exited {result.returncode}: {diagnostics[-2000:]}"
+        )
+
+    gpus_by_rank: dict[int, list[GpuInfo]] = {
+        rank: [] for rank in range(len(hostnames))
+    }
+    seen_ranks: set[int] = set()
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        match = _PALS_LABEL.fullmatch(line)
+        if match is None:
+            raise RuntimeError(
+                f"PALS GPU inventory returned an unlabeled row: {line!r}"
+            )
+
+        rank = int(match.group("rank"))
+        if rank not in gpus_by_rank:
+            raise RuntimeError(f"PALS GPU inventory returned unexpected rank {rank}")
+        expected_host = hostnames[rank]
+        reported_host = match.group("host")
+        if not _host_matches(reported_host, expected_host):
+            raise RuntimeError(
+                f"PALS GPU inventory rank {rank} reported host {reported_host!r}; "
+                f"expected {expected_host!r}"
+            )
+        try:
+            gpu = _parse_gpu_row(match.group("row"))
+        except ValueError as exc:
+            raise RuntimeError(f"PALS GPU inventory was malformed: {exc}") from exc
+        gpus_by_rank[rank].append(gpu)
+        seen_ranks.add(rank)
+
+    expected_ranks = set(range(len(hostnames)))
+    if seen_ranks != expected_ranks:
+        missing = sorted(expected_ranks - seen_ranks)
+        raise RuntimeError(f"PALS GPU inventory is incomplete; missing ranks {missing}")
+
+    return [
+        _validated_host_gpus(hostname, gpus_by_rank[rank], expected_gpus)
+        for rank, hostname in enumerate(hostnames)
+    ]
 
 
 def discover_hosts(node_file_env: str) -> list[str]:
     node_file = os.environ.get(node_file_env)
-    localhost = safe_getfqdn()
 
     if not node_file:
+        localhost = socket.gethostname()
         logger.info(
             "%s not set; assuming single-host deployment (%s)",
             node_file_env,
@@ -127,6 +257,7 @@ def discover_hosts(node_file_env: str) -> list[str]:
         with open(node_file) as f:
             lines = f.readlines()
     except (FileNotFoundError, OSError) as exc:
+        localhost = socket.gethostname()
         logger.warning(
             "node file %s=%s not read (%s); falling back to single host %s",
             node_file_env,
@@ -138,6 +269,7 @@ def discover_hosts(node_file_env: str) -> list[str]:
 
     hosts = [l.strip() for l in lines if l.strip()]
     if not hosts:
+        localhost = socket.gethostname()
         logger.warning(
             "node file %s was empty; falling back to single host %s",
             node_file,
@@ -154,15 +286,27 @@ class ReplicaManager:
     def __init__(self, config: PilotRuntimeConfig) -> None:
         self.config = config
 
-        self.node_hostnames = sorted(discover_hosts(self.config.node_file_env))
+        # PBS nodefiles may repeat a hostname once per assigned resource.  Keep
+        # the scheduler's first-occurrence order because it is also the PALS
+        # rank order used by gpus_by_host in the replica launch context.
+        self.node_hostnames = _deduplicate_hosts(
+            discover_hosts(self.config.node_file_env)
+        )
+        if len(self.node_hostnames) != self.config.num_nodes:
+            raise RuntimeError(
+                "pilot node inventory differs from its scheduler request: "
+                f"discovered {len(self.node_hostnames)}, "
+                f"expected {self.config.num_nodes}"
+            )
         resources = self.query_resources()
 
         self._inventory = resources.hosts
         if not any(host.gpus for host in self._inventory):
             raise RuntimeError("no GPUs discovered; cannot start ReplicaManager")
 
+        gpu_count = sum(len(host.gpus) for host in self._inventory)
         logger.info(
-            f"discovered {len(self._inventory)} GPU(s) across {len(resources.hosts)} hosts"
+            "discovered %d GPU(s) across %d hosts", gpu_count, len(resources.hosts)
         )
 
         # Private directory (0700 by default) that holds every replica's Unix
@@ -181,9 +325,17 @@ class ReplicaManager:
 
     @ttl_cache(ttl=60)
     def query_resources(self) -> PilotResources:
-        """Query nvidia-smi across all hosts in this pilot job"""
-        with ThreadPoolExecutor(max_workers=8) as pool:
-            host_gpus = list(pool.map(query_gpus, self.node_hostnames))
+        """Discover the exact scheduler-requested inventory without SSH."""
+        if len(self.node_hostnames) == 1:
+            host_gpus = [query_gpus(self.node_hostnames[0], self.config.gpus_per_node)]
+        else:
+            if self.config.pals_path is None:
+                raise RuntimeError("multi-node GPU inventory requires pals_path")
+            host_gpus = query_gpus_pals(
+                self.node_hostnames,
+                self.config.pals_path,
+                self.config.gpus_per_node,
+            )
 
         return PilotResources(hosts=host_gpus)
 
@@ -211,8 +363,11 @@ class ReplicaManager:
         requested: list[tuple[str, str]] = []
 
         for host_idx, gpu_idx in gpu_indices:
-            if host_idx >= len(self._inventory) or gpu_idx >= len(
-                self._inventory[host_idx].gpus
+            if (
+                host_idx < 0
+                or gpu_idx < 0
+                or host_idx >= len(self._inventory)
+                or gpu_idx >= len(self._inventory[host_idx].gpus)
             ):
                 raise BadPilotRequest(
                     f"requested {host_idx=} {gpu_idx=} outside GPUs pilot inventory"

--- a/packages/pilot/first_pilot/replica_manager.py
+++ b/packages/pilot/first_pilot/replica_manager.py
@@ -28,17 +28,13 @@ from first_common.schema.pilot import (
 )
 from first_common.schema.types import (
     GpuClaim,
+    PalsDiscovery,
+    SSHDiscovery,
 )
 
 from .replica import Replica
 
 logger = logging.getLogger(__name__)
-
-
-def safe_getfqdn(name: str = "", *, timeout: float = 2.0) -> str:
-    """Return a DNS-free address label; retained for the control API contract."""
-    del timeout
-    return name or socket.gethostname()
 
 
 class _ReservedSentinel(Enum):
@@ -106,30 +102,68 @@ def _validated_host_gpus(
     )
 
 
-def query_gpus(hostname: str, expected_gpus: int) -> HostGpus:
-    """Inventory a single-node pilot locally; never use a remote shell."""
-    nvidia_smi = "nvidia-smi"
+def _query_gpus_command(
+    hostname: str,
+    command: list[str],
+    expected_gpus: int,
+    timeout_sec: float,
+    *,
+    label: str,
+) -> HostGpus:
     try:
         result = subprocess.run(
-            [nvidia_smi, *_NVIDIA_SMI_ARGS],
+            command,
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=timeout_sec,
         )
     except subprocess.TimeoutExpired as exc:
-        raise RuntimeError("local GPU inventory timed out after 5s") from exc
+        raise RuntimeError(
+            f"{label} GPU inventory timed out after {timeout_sec:g}s"
+        ) from exc
 
     if result.returncode != 0:
+        diagnostics = result.stderr.strip() or result.stdout.strip()
         raise RuntimeError(
-            f"local GPU inventory exited {result.returncode}: "
-            f"{result.stderr.strip()[-2000:]}"
+            f"{label} GPU inventory exited {result.returncode}: {diagnostics[-2000:]}"
         )
 
     try:
         gpus = [_parse_gpu_row(line) for line in result.stdout.splitlines() if line]
     except ValueError as exc:
-        raise RuntimeError(f"local GPU inventory was malformed: {exc}") from exc
+        raise RuntimeError(f"{label} GPU inventory was malformed: {exc}") from exc
     return _validated_host_gpus(hostname, gpus, expected_gpus)
+
+
+def query_gpus_local(
+    hostname: str, expected_gpus: int, timeout_sec: float = 5.0
+) -> HostGpus:
+    """Inventory a single-node pilot locally; never use a remote shell."""
+    return _query_gpus_command(
+        hostname,
+        ["nvidia-smi", *_NVIDIA_SMI_ARGS],
+        expected_gpus,
+        timeout_sec,
+        label="local",
+    )
+
+
+def query_gpus_ssh(
+    hostnames: list[str], expected_gpus: int, timeout_sec: float = 5.0
+) -> list[HostGpus]:
+    """Query every scheduler host concurrently and retain scheduler order."""
+
+    def query_host(hostname: str) -> HostGpus:
+        return _query_gpus_command(
+            hostname,
+            ["ssh", hostname, "nvidia-smi", *_NVIDIA_SMI_ARGS],
+            expected_gpus,
+            timeout_sec,
+            label=f"SSH host {hostname!r}",
+        )
+
+    with ThreadPoolExecutor(max_workers=len(hostnames)) as pool:
+        return list(pool.map(query_host, hostnames))
 
 
 def _normalized_hostname(hostname: str) -> str:
@@ -160,11 +194,14 @@ def _deduplicate_hosts(hostnames: list[str]) -> list[str]:
 
 
 def query_gpus_pals(
-    hostnames: list[str], pals_path: Path, expected_gpus: int
+    hostnames: list[str],
+    launcher_path: Path,
+    expected_gpus: int,
+    timeout_sec: float = 35.0,
 ) -> list[HostGpus]:
     """Run one labeled inventory rank per host through the site PALS launcher."""
     nvidia_smi = "nvidia-smi"
-    pals = _require_executable(pals_path, label="PALS launcher")
+    pals = _require_executable(launcher_path, label="PALS launcher")
 
     command = [
         pals,
@@ -175,7 +212,9 @@ def query_gpus_pals(
         "--label",
         "--abort-on-failure",
         "--timeout",
-        "30",
+        # Leave time for the launcher to report and exit before our outer
+        # subprocess deadline expires.
+        str(max(1, int(timeout_sec) - 5)),
         "-n",
         str(len(hostnames)),
         "--ppn",
@@ -189,10 +228,12 @@ def query_gpus_pals(
             command,
             capture_output=True,
             text=True,
-            timeout=35,
+            timeout=timeout_sec,
         )
     except subprocess.TimeoutExpired as exc:
-        raise RuntimeError("PALS GPU inventory timed out after 35s") from exc
+        raise RuntimeError(
+            f"PALS GPU inventory timed out after {timeout_sec:g}s"
+        ) from exc
 
     if result.returncode != 0:
         diagnostics = result.stderr.strip() or result.stdout.strip()
@@ -325,17 +366,30 @@ class ReplicaManager:
 
     @ttl_cache(ttl=60)
     def query_resources(self) -> PilotResources:
-        """Discover the exact scheduler-requested inventory without SSH."""
+        """Discover and validate the exact scheduler-requested inventory."""
+        discovery = self.config.gpu_discovery
         if len(self.node_hostnames) == 1:
-            host_gpus = [query_gpus(self.node_hostnames[0], self.config.gpus_per_node)]
-        else:
-            if self.config.pals_path is None:
-                raise RuntimeError("multi-node GPU inventory requires pals_path")
+            host_gpus = [
+                query_gpus_local(
+                    self.node_hostnames[0],
+                    self.config.gpus_per_node,
+                )
+            ]
+        elif isinstance(discovery, SSHDiscovery):
+            host_gpus = query_gpus_ssh(
+                self.node_hostnames,
+                self.config.gpus_per_node,
+                discovery.timeout_sec,
+            )
+        elif isinstance(discovery, PalsDiscovery):
             host_gpus = query_gpus_pals(
                 self.node_hostnames,
-                self.config.pals_path,
+                discovery.launcher_path,
                 self.config.gpus_per_node,
+                discovery.timeout_sec,
             )
+        else:
+            raise AssertionError(f"unsupported GPU discovery method: {discovery!r}")
 
         return PilotResources(hosts=host_gpus)
 

--- a/tests/test_graphql_pbs_allocation.py
+++ b/tests/test_graphql_pbs_allocation.py
@@ -3,6 +3,7 @@ import json
 import re
 from datetime import datetime, timezone
 from pathlib import Path
+from shlex import quote
 
 import httpx
 
@@ -23,7 +24,7 @@ def _successful_graphql_transport(queries: list[str]) -> httpx.MockTransport:
             json={
                 "data": {
                     "createJob": {
-                        "node": {"jobId": "1234.tara"},
+                        "node": {"jobId": "1234.test"},
                         "error": None,
                     }
                 }
@@ -44,60 +45,64 @@ async def test_graphql_submit_maps_exact_two_node_four_gpu_request() -> None:
     async with httpx.AsyncClient(
         transport=_successful_graphql_transport(queries)
     ) as client:
-        adapter = GraphQLPBSAdapter(client, "openinference_svc", "https://bridge")
+        adapter = GraphQLPBSAdapter(
+            client, "test-service", "https://scheduler.example.test/graphql"
+        )
         result = await adapter.submit_job(
             JobSubmitPayload(
-                name="first-nemotron",
-                queue="workq",
-                account="inference_service",
+                name="test-pilot",
+                queue="test-queue",
+                account="test-account",
                 scheduler_flags="",
                 num_nodes=2,
                 gpus_per_node=4,
                 walltime_min=90,
-                log_path=Path("/service/logs/nemotron.log"),
-                script="#!/bin/bash\nexec /service/bin/first-pilot\n",
+                log_path=Path("/opt/test/logs/pilot.log"),
+                script="#!/bin/bash\nexec /opt/test/bin/first-pilot\n",
             )
         )
 
-    assert result.scheduler_id == "1234.tara"
+    assert result.scheduler_id == "1234.test"
     assert len(queries) == 1
     query = queries[0]
     assert "wallClockTime: 5400" in query
     assert re.search(r"taskCount:\s*\{\s*min: 2\s*max: 2", query)
     assert re.search(r'tasksResources:\s*\[\s*\{\s*index: "0-1"\s*gpus: 4', query)
-    assert _submitted_script(query) == ("#!/bin/bash\nexec /service/bin/first-pilot\n")
+    assert _submitted_script(query) == ("#!/bin/bash\nexec /opt/test/bin/first-pilot\n")
 
 
 async def test_graphql_submitter_propagates_exact_runtime_allocation() -> None:
-    config = PilotConfig.model_validate(
-        {
-            "scheduler_adapter": (
-                "first_gateway.platforms.schedulers.graphql_pbs.GraphQLPBSAdapter"
-            ),
-            "scheduler_config": {},
-            "job_walltime_min": 90,
-            "queue": "workq",
-            "account": "inference_service",
-            "max_num_nodes": 2,
-            "gpus_per_node": 4,
-            "workdir": "/service/first-v2/workdir",
-            "external_port": 18443,
-            "nginx_path": "/service/nginx/sbin/nginx",
-            "ip_allowlist": ["10.124.176.33/32"],
-            "node_file_env": "PBS_NODEFILE",
-            "pals_path": "/opt/cray/pals/1.8/bin/mpiexec",
-            "submit_script_preamble": "#!/bin/bash\nset -eu",
-            "pilot_path": "/service/first v2/bin/first-pilot",
-            "pilot_config_path": "/service/first v2/config.yaml",
-        }
-    )
+    config_input = {
+        "scheduler_adapter": (
+            "first_gateway.platforms.schedulers.graphql_pbs.GraphQLPBSAdapter"
+        ),
+        "scheduler_config": {},
+        "job_walltime_min": 90,
+        "queue": "test-queue",
+        "account": "test-account",
+        "max_num_nodes": 2,
+        "gpus_per_node": 4,
+        "workdir": "/opt/test/pilot-workdir",
+        "external_port": 18443,
+        "nginx_path": "/opt/test/nginx",
+        "ip_allowlist": ["192.0.2.10/32"],
+        "node_file_env": "TEST_NODEFILE",
+        "gpu_discovery": {
+            "method": "pals",
+            "launcher_path": "/opt/test/mpiexec",
+        },
+        "submit_script_preamble": "#!/bin/bash\nset -eu",
+        "pilot_path": "/opt/test/first pilot",
+        "pilot_config_path": "/opt/test/pilot config.yaml",
+    }
+    config = PilotConfig.model_validate(config_input)
     pilot_job = PilotJob(
         kind="PilotJob",
-        name="nemotron-canary",
+        name="test-pilot",
         uid=1,
         created_at=datetime.now(timezone.utc),
         scheduler_job_id="",
-        cluster_name="tara-production",
+        cluster_name="test-cluster",
         scheduler_state=SchedulerJobState.pending_submit,
         manager_url="",
         manager_health=HealthCheckResult.unknown,
@@ -113,20 +118,30 @@ async def test_graphql_submitter_propagates_exact_runtime_allocation() -> None:
     async with httpx.AsyncClient(
         transport=_successful_graphql_transport(queries)
     ) as client:
-        adapter = GraphQLPBSAdapter(client, "openinference_svc", "https://bridge")
+        adapter = GraphQLPBSAdapter(
+            client, "test-service", "https://scheduler.example.test/graphql"
+        )
         await PilotSubmitter(config, adapter, "unused-ca", "unused-key").submit(
             pilot_job
         )
 
     script = _submitted_script(queries[0])
-    assert "PILOT_CONFIG_FILE='/service/first v2/config.yaml'" in script
-    assert "PILOT_JOB_NAME=nemotron-canary" in script
-    assert "PILOT_NUM_NODES=2" in script
-    assert "PILOT_GPUS_PER_NODE=4" in script
-    assert "PILOT_PALS_PATH=/opt/cray/pals/1.8/bin/mpiexec" in script
-    assert "PILOT_EXTERNAL_PORT=18443" in script
-    assert "PILOT_NGINX_PATH=/service/nginx/sbin/nginx" in script
-    assert "PILOT_IP_ALLOWLIST_JSON='[\"10.124.176.33/32\"]'" in script
-    assert "PILOT_WORKDIR=/service/first-v2/workdir" in script
-    assert "PILOT_NODE_FILE_ENV=PBS_NODEFILE" in script
-    assert script.endswith("'/service/first v2/bin/first-pilot'\n")
+    expected_runtime_env = {
+        "PILOT_CONFIG_FILE": str(config.pilot_config_path),
+        "PILOT_JOB_NAME": pilot_job.name,
+        "PILOT_EXTERNAL_PORT": str(config.external_port),
+        "PILOT_NGINX_PATH": str(config.nginx_path),
+        "PILOT_IP_ALLOWLIST": json.dumps(config.ip_allowlist, separators=(",", ":")),
+        "PILOT_WORKDIR": str(config.workdir),
+        "PILOT_NODE_FILE_ENV": config.node_file_env,
+        "PILOT_GPU_DISCOVERY": json.dumps(
+            config.gpu_discovery.model_dump(mode="json"), separators=(",", ":")
+        ),
+        "PILOT_NUM_NODES": str(pilot_job.num_nodes),
+        "PILOT_GPUS_PER_NODE": str(pilot_job.gpus_per_node),
+    }
+    for key, value in expected_runtime_env.items():
+        assert f"{key}={quote(value)}" in script
+    assert "PILOT_PALS_PATH" not in script
+    assert "PILOT_IP_ALLOWLIST_JSON" not in script
+    assert script.endswith(f"{quote(str(config.pilot_path))}\n")

--- a/tests/test_graphql_pbs_allocation.py
+++ b/tests/test_graphql_pbs_allocation.py
@@ -1,0 +1,132 @@
+import base64
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+
+from first_common.schema.base_scheduler import JobSubmitPayload, SchedulerJobState
+from first_common.schema.pilot import PilotResources
+from first_common.schema.resources.read import PilotJob
+from first_common.schema.types import HealthCheckResult, PilotConfig
+from first_gateway.platforms.schedulers.graphql_pbs import GraphQLPBSAdapter
+from first_gateway.services.pilot_submitter import PilotSubmitter
+
+
+def _successful_graphql_transport(queries: list[str]) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        query = json.loads(request.content)["query"]
+        queries.append(query)
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "createJob": {
+                        "node": {"jobId": "1234.tara"},
+                        "error": None,
+                    }
+                }
+            },
+        )
+
+    return httpx.MockTransport(handler)
+
+
+def _submitted_script(query: str) -> str:
+    match = re.search(r'scriptContent:\s*"([A-Za-z0-9_=-]+)"', query)
+    assert match is not None
+    return base64.urlsafe_b64decode(match.group(1)).decode()
+
+
+async def test_graphql_submit_maps_exact_two_node_four_gpu_request() -> None:
+    queries: list[str] = []
+    async with httpx.AsyncClient(
+        transport=_successful_graphql_transport(queries)
+    ) as client:
+        adapter = GraphQLPBSAdapter(client, "openinference_svc", "https://bridge")
+        result = await adapter.submit_job(
+            JobSubmitPayload(
+                name="first-nemotron",
+                queue="workq",
+                account="inference_service",
+                scheduler_flags="",
+                num_nodes=2,
+                gpus_per_node=4,
+                walltime_min=90,
+                log_path=Path("/service/logs/nemotron.log"),
+                script="#!/bin/bash\nexec /service/bin/first-pilot\n",
+            )
+        )
+
+    assert result.scheduler_id == "1234.tara"
+    assert len(queries) == 1
+    query = queries[0]
+    assert "wallClockTime: 5400" in query
+    assert re.search(r"taskCount:\s*\{\s*min: 2\s*max: 2", query)
+    assert re.search(r'tasksResources:\s*\[\s*\{\s*index: "0-1"\s*gpus: 4', query)
+    assert _submitted_script(query) == ("#!/bin/bash\nexec /service/bin/first-pilot\n")
+
+
+async def test_graphql_submitter_propagates_exact_runtime_allocation() -> None:
+    config = PilotConfig.model_validate(
+        {
+            "scheduler_adapter": (
+                "first_gateway.platforms.schedulers.graphql_pbs.GraphQLPBSAdapter"
+            ),
+            "scheduler_config": {},
+            "job_walltime_min": 90,
+            "queue": "workq",
+            "account": "inference_service",
+            "max_num_nodes": 2,
+            "gpus_per_node": 4,
+            "workdir": "/service/first-v2/workdir",
+            "external_port": 18443,
+            "nginx_path": "/service/nginx/sbin/nginx",
+            "ip_allowlist": ["10.124.176.33/32"],
+            "node_file_env": "PBS_NODEFILE",
+            "pals_path": "/opt/cray/pals/1.8/bin/mpiexec",
+            "submit_script_preamble": "#!/bin/bash\nset -eu",
+            "pilot_path": "/service/first v2/bin/first-pilot",
+            "pilot_config_path": "/service/first v2/config.yaml",
+        }
+    )
+    pilot_job = PilotJob(
+        kind="PilotJob",
+        name="nemotron-canary",
+        uid=1,
+        created_at=datetime.now(timezone.utc),
+        scheduler_job_id="",
+        cluster_name="tara-production",
+        scheduler_state=SchedulerJobState.pending_submit,
+        manager_url="",
+        manager_health=HealthCheckResult.unknown,
+        resources=PilotResources(hosts=[]),
+        assigned_replicas=[],
+        claimed_gpu_ids=[],
+        walltime_min=90,
+        num_nodes=2,
+        gpus_per_node=4,
+    )
+
+    queries: list[str] = []
+    async with httpx.AsyncClient(
+        transport=_successful_graphql_transport(queries)
+    ) as client:
+        adapter = GraphQLPBSAdapter(client, "openinference_svc", "https://bridge")
+        await PilotSubmitter(config, adapter, "unused-ca", "unused-key").submit(
+            pilot_job
+        )
+
+    script = _submitted_script(queries[0])
+    assert "PILOT_CONFIG_FILE='/service/first v2/config.yaml'" in script
+    assert "PILOT_JOB_NAME=nemotron-canary" in script
+    assert "PILOT_NUM_NODES=2" in script
+    assert "PILOT_GPUS_PER_NODE=4" in script
+    assert "PILOT_PALS_PATH=/opt/cray/pals/1.8/bin/mpiexec" in script
+    assert "PILOT_EXTERNAL_PORT=18443" in script
+    assert "PILOT_NGINX_PATH=/service/nginx/sbin/nginx" in script
+    assert "PILOT_IP_ALLOWLIST_JSON='[\"10.124.176.33/32\"]'" in script
+    assert "PILOT_WORKDIR=/service/first-v2/workdir" in script
+    assert "PILOT_NODE_FILE_ENV=PBS_NODEFILE" in script
+    assert script.endswith("'/service/first v2/bin/first-pilot'\n")

--- a/tests/test_pilot_replica_manager.py
+++ b/tests/test_pilot_replica_manager.py
@@ -13,18 +13,19 @@ from first_common.schema.pilot import (
     PilotResources,
     PilotRuntimeConfig,
 )
+from first_common.schema.types import PalsDiscovery, SSHDiscovery
 from first_pilot.replica_manager import (
     ReplicaManager,
     discover_hosts,
-    query_gpus,
+    query_gpus_local,
     query_gpus_pals,
+    query_gpus_ssh,
 )
 
 
 def _gpu_rows(hostname: str, rank: int, indices: tuple[int, ...]) -> str:
     return "".join(
-        f"{hostname} {rank}: {index}, NVIDIA GH200, 97871, {index}\n"
-        for index in indices
+        f"{hostname} {rank}: {index}, Test GPU, 97871, {index}\n" for index in indices
     )
 
 
@@ -52,23 +53,48 @@ def test_single_host_inventory_runs_nvidia_smi_locally(
     run.return_value = CompletedProcess(
         [],
         0,
-        stdout="".join(
-            f"{index}, NVIDIA GH200, 97871, {index}\n" for index in range(4)
-        ),
+        stdout="".join(f"{index}, Test GPU, 97871, {index}\n" for index in range(4)),
         stderr="",
     )
 
-    resources = query_gpus("head.example.test", 4)
+    resources = query_gpus_local("head.example.test", 4)
 
     assert [gpu.index for gpu in resources.gpus] == ["0", "1", "2", "3"]
     command = run.call_args.args[0]
     assert command[0] == "nvidia-smi"
     assert "ssh" not in command
+    assert run.call_args.kwargs["timeout"] == 5.0
+
+
+@patch("first_pilot.replica_manager.subprocess.run")
+def test_ssh_inventory_queries_every_host_and_preserves_scheduler_order(
+    run: MagicMock,
+) -> None:
+    def response(command: list[str], **_kwargs: object) -> CompletedProcess[str]:
+        hostname = command[1]
+        rows = "".join(
+            f"{index}, GPU on {hostname}, 100, {index}\n" for index in range(2)
+        )
+        return CompletedProcess(command, 0, stdout=rows, stderr="")
+
+    run.side_effect = response
+    hostnames = ["worker-b.example.test", "worker-a.example.test"]
+
+    resources = query_gpus_ssh(hostnames, expected_gpus=2, timeout_sec=7.0)
+
+    assert [host.hostname for host in resources] == hostnames
+    assert [[gpu.index for gpu in host.gpus] for host in resources] == [
+        ["0", "1"],
+        ["0", "1"],
+    ]
+    assert {call.args[0][1] for call in run.call_args_list} == set(hostnames)
+    assert all(call.kwargs["timeout"] == 7.0 for call in run.call_args_list)
+    assert all(call.args[0][0] == "ssh" for call in run.call_args_list)
 
 
 @patch(
     "first_pilot.replica_manager._require_executable",
-    return_value="/opt/site/mpiexec",
+    return_value="/opt/test/mpiexec",
 )
 @patch("first_pilot.replica_manager.subprocess.run")
 def test_pals_inventory_validates_and_preserves_rank_order(
@@ -85,7 +111,7 @@ def test_pals_inventory_validates_and_preserves_rank_order(
 
     resources = query_gpus_pals(
         ["head.example.test", "worker.example.test"],
-        Path("/opt/cray/pals/1.8/bin/mpiexec"),
+        Path("/opt/test/mpiexec"),
         4,
     )
 
@@ -98,10 +124,12 @@ def test_pals_inventory_validates_and_preserves_rank_order(
         ["0", "1", "2", "3"],
     ]
     command = run.call_args.args[0]
-    assert command[0] == "/opt/site/mpiexec"
+    assert command[0] == "/opt/test/mpiexec"
     assert "ssh" not in command
+    assert command[command.index("--timeout") + 1] == "30"
     assert command[command.index("-n") + 1] == "2"
     assert command[command.index("--ppn") + 1] == "1"
+    assert run.call_args.kwargs["timeout"] == 35.0
 
 
 @pytest.mark.parametrize(
@@ -109,7 +137,7 @@ def test_pals_inventory_validates_and_preserves_rank_order(
     [
         ("not-labeled\n", "unlabeled row"),
         (
-            "head 0: 0, NVIDIA GH200, unknown, 0\n",
+            "head 0: 0, Test GPU, unknown, 0\n",
             "was malformed",
         ),
         (
@@ -124,7 +152,7 @@ def test_pals_inventory_validates_and_preserves_rank_order(
 )
 @patch(
     "first_pilot.replica_manager._require_executable",
-    return_value="/opt/site/mpiexec",
+    return_value="/opt/test/mpiexec",
 )
 @patch("first_pilot.replica_manager.subprocess.run")
 def test_pals_inventory_rejects_malformed_host_and_rank_rows(
@@ -136,12 +164,12 @@ def test_pals_inventory_rejects_malformed_host_and_rank_rows(
     run.return_value = CompletedProcess([], 0, stdout=output, stderr="")
 
     with pytest.raises(RuntimeError, match=message):
-        query_gpus_pals(["head", "worker"], Path("/opt/cray/pals/1.8/bin/mpiexec"), 4)
+        query_gpus_pals(["head", "worker"], Path("/opt/test/mpiexec"), 4)
 
 
 @patch(
     "first_pilot.replica_manager._require_executable",
-    return_value="/opt/site/mpiexec",
+    return_value="/opt/test/mpiexec",
 )
 @patch("first_pilot.replica_manager.subprocess.run")
 def test_pals_inventory_rejects_incomplete_rank(
@@ -152,12 +180,12 @@ def test_pals_inventory_rejects_incomplete_rank(
     )
 
     with pytest.raises(RuntimeError, match=r"incomplete; missing ranks \[1\]"):
-        query_gpus_pals(["head", "worker"], Path("/opt/cray/pals/1.8/bin/mpiexec"), 4)
+        query_gpus_pals(["head", "worker"], Path("/opt/test/mpiexec"), 4)
 
 
 @patch(
     "first_pilot.replica_manager._require_executable",
-    return_value="/opt/site/mpiexec",
+    return_value="/opt/test/mpiexec",
 )
 @patch("first_pilot.replica_manager.subprocess.run")
 def test_pals_inventory_rejects_duplicate_gpu(
@@ -173,28 +201,28 @@ def test_pals_inventory_rejects_duplicate_gpu(
     )
 
     with pytest.raises(RuntimeError, match="duplicated an index on host 'head'"):
-        query_gpus_pals(["head", "worker"], Path("/opt/cray/pals/1.8/bin/mpiexec"), 4)
+        query_gpus_pals(["head", "worker"], Path("/opt/test/mpiexec"), 4)
 
 
 @patch(
     "first_pilot.replica_manager._require_executable",
-    return_value="/opt/site/mpiexec",
+    return_value="/opt/test/mpiexec",
 )
 @patch("first_pilot.replica_manager.subprocess.run")
 def test_pals_inventory_reports_launcher_failure(
     run: MagicMock, _executable: MagicMock
 ) -> None:
     run.return_value = CompletedProcess(
-        [], 127, stdout="", stderr="CXI endpoint unavailable"
+        [], 127, stdout="", stderr="launcher unavailable"
     )
 
-    with pytest.raises(RuntimeError, match="exited 127: CXI endpoint unavailable"):
-        query_gpus_pals(["head", "worker"], Path("/opt/cray/pals/1.8/bin/mpiexec"), 4)
+    with pytest.raises(RuntimeError, match="exited 127: launcher unavailable"):
+        query_gpus_pals(["head", "worker"], Path("/opt/test/mpiexec"), 4)
 
 
 @patch(
     "first_pilot.replica_manager._require_executable",
-    return_value="/opt/site/mpiexec",
+    return_value="/opt/test/mpiexec",
 )
 @patch("first_pilot.replica_manager.subprocess.run")
 def test_pals_inventory_reports_launcher_timeout(
@@ -203,7 +231,7 @@ def test_pals_inventory_reports_launcher_timeout(
     run.side_effect = subprocess.TimeoutExpired("mpiexec", 35)
 
     with pytest.raises(RuntimeError, match="timed out after 35s"):
-        query_gpus_pals(["head", "worker"], Path("/opt/cray/pals/1.8/bin/mpiexec"), 4)
+        query_gpus_pals(["head", "worker"], Path("/opt/test/mpiexec"), 4)
 
 
 @patch("first_pilot.replica_manager.discover_hosts")
@@ -235,7 +263,7 @@ def test_replica_manager_deduplicates_hosts_in_scheduler_order(
     )
     config = SimpleNamespace(
         node_file_env="TEST_NODEFILE",
-        pals_path=Path("/opt/cray/pals/1.8/bin/mpiexec"),
+        gpu_discovery=PalsDiscovery(launcher_path=Path("/opt/test/mpiexec")),
         num_nodes=2,
         gpus_per_node=1,
     )
@@ -252,7 +280,7 @@ def test_replica_manager_rejects_incomplete_host_inventory(
 ) -> None:
     config = SimpleNamespace(
         node_file_env="TEST_NODEFILE",
-        pals_path=Path("/opt/cray/pals/1.8/bin/mpiexec"),
+        gpu_discovery=SSHDiscovery(),
         num_nodes=2,
         gpus_per_node=4,
     )
@@ -261,7 +289,68 @@ def test_replica_manager_rejects_incomplete_host_inventory(
         ReplicaManager(config)  # type: ignore[arg-type]
 
 
-def test_runtime_config_load_overrides_all_nonsecret_public_fields(
+def _host_resources(hostnames: list[str], gpu_count: int) -> list[HostGpus]:
+    return [
+        HostGpus(
+            hostname=hostname,
+            gpus=[
+                GpuInfo(
+                    index=str(index),
+                    name="Test GPU",
+                    memory_total_mib=100,
+                    memory_used_mib=0,
+                )
+                for index in range(gpu_count)
+            ],
+        )
+        for hostname in hostnames
+    ]
+
+
+def test_replica_manager_dispatches_multi_node_ssh_discovery() -> None:
+    hostnames = ["head", "worker"]
+    config = SimpleNamespace(
+        node_file_env="TEST_NODEFILE",
+        gpu_discovery=SSHDiscovery(timeout_sec=7.0),
+        num_nodes=2,
+        gpus_per_node=2,
+    )
+    with (
+        patch("first_pilot.replica_manager.discover_hosts", return_value=hostnames),
+        patch(
+            "first_pilot.replica_manager.query_gpus_ssh",
+            return_value=_host_resources(hostnames, 2),
+        ) as query_ssh,
+    ):
+        manager = ReplicaManager(config)  # type: ignore[arg-type]
+
+    query_ssh.assert_called_once_with(hostnames, 2, 7.0)
+    manager._socket_dir.cleanup()
+
+
+def test_replica_manager_dispatches_multi_node_pals_discovery() -> None:
+    hostnames = ["head", "worker"]
+    discovery = PalsDiscovery(launcher_path=Path("/opt/test/mpiexec"), timeout_sec=41.0)
+    config = SimpleNamespace(
+        node_file_env="TEST_NODEFILE",
+        gpu_discovery=discovery,
+        num_nodes=2,
+        gpus_per_node=2,
+    )
+    with (
+        patch("first_pilot.replica_manager.discover_hosts", return_value=hostnames),
+        patch(
+            "first_pilot.replica_manager.query_gpus_pals",
+            return_value=_host_resources(hostnames, 2),
+        ) as query_pals,
+    ):
+        manager = ReplicaManager(config)  # type: ignore[arg-type]
+
+    query_pals.assert_called_once_with(hostnames, discovery.launcher_path, 2, 41.0)
+    manager._socket_dir.cleanup()
+
+
+def test_runtime_config_loads_public_fields_from_environment(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     config_path = tmp_path / "pilot.yaml"
@@ -271,37 +360,33 @@ def test_runtime_config_load_overrides_all_nonsecret_public_fields(
                 "ca_crt": "ca",
                 "server_crt": "crt",
                 "server_key": "key",
-                "external_port": 18443,
-                "nginx_path": "/malicious/nginx",
-                "ip_allowlist": ["0.0.0.0/0"],
-                "workdir": "/personal/workdir",
-                "node_file_env": "ATTACKER_NODEFILE",
-                "pals_path": "/stale/mpiexec",
-                "num_nodes": 1,
-                "gpus_per_node": 1,
-                "job_name": "stale-job",
             }
         )
     )
     monkeypatch.setenv("PILOT_CONFIG_FILE", str(config_path))
-    monkeypatch.setenv("PILOT_JOB_NAME", "nemotron-canary")
+    monkeypatch.setenv("PILOT_JOB_NAME", "test-pilot")
     monkeypatch.setenv("PILOT_EXTERNAL_PORT", "19443")
-    monkeypatch.setenv("PILOT_NGINX_PATH", "/service/nginx")
-    monkeypatch.setenv("PILOT_IP_ALLOWLIST_JSON", '["10.124.176.33/32"]')
-    monkeypatch.setenv("PILOT_WORKDIR", "/service/workdir")
-    monkeypatch.setenv("PILOT_NODE_FILE_ENV", "PBS_NODEFILE")
-    monkeypatch.setenv("PILOT_PALS_PATH", "/opt/cray/pals/1.8/bin/mpiexec")
+    monkeypatch.setenv("PILOT_NGINX_PATH", "/opt/test/nginx")
+    monkeypatch.setenv("PILOT_IP_ALLOWLIST", '["192.0.2.10/32"]')
+    monkeypatch.setenv("PILOT_WORKDIR", "/opt/test/workdir")
+    monkeypatch.setenv("PILOT_NODE_FILE_ENV", "TEST_NODEFILE")
+    monkeypatch.setenv(
+        "PILOT_GPU_DISCOVERY",
+        '{"method":"pals","launcher_path":"/opt/test/mpiexec"}',
+    )
     monkeypatch.setenv("PILOT_NUM_NODES", "2")
     monkeypatch.setenv("PILOT_GPUS_PER_NODE", "4")
 
     config = PilotRuntimeConfig.load()
 
-    assert config.job_name == "nemotron-canary"
+    assert config.job_name == "test-pilot"
     assert config.external_port == 19443
-    assert config.nginx_path == Path("/service/nginx")
-    assert config.ip_allowlist == ["10.124.176.33/32"]
-    assert config.workdir == Path("/service/workdir")
-    assert config.node_file_env == "PBS_NODEFILE"
-    assert config.pals_path == Path("/opt/cray/pals/1.8/bin/mpiexec")
+    assert config.nginx_path == Path("/opt/test/nginx")
+    assert config.ip_allowlist == ["192.0.2.10/32"]
+    assert config.workdir == Path("/opt/test/workdir")
+    assert config.node_file_env == "TEST_NODEFILE"
+    assert config.gpu_discovery == PalsDiscovery(
+        launcher_path=Path("/opt/test/mpiexec")
+    )
     assert config.num_nodes == 2
     assert config.gpus_per_node == 4

--- a/tests/test_pilot_replica_manager.py
+++ b/tests/test_pilot_replica_manager.py
@@ -1,0 +1,307 @@
+import subprocess
+from pathlib import Path
+from subprocess import CompletedProcess
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from first_common.schema.pilot import (
+    GpuInfo,
+    HostGpus,
+    PilotResources,
+    PilotRuntimeConfig,
+)
+from first_pilot.replica_manager import (
+    ReplicaManager,
+    discover_hosts,
+    query_gpus,
+    query_gpus_pals,
+)
+
+
+def _gpu_rows(hostname: str, rank: int, indices: tuple[int, ...]) -> str:
+    return "".join(
+        f"{hostname} {rank}: {index}, NVIDIA GH200, 97871, {index}\n"
+        for index in indices
+    )
+
+
+def test_scheduler_nodefile_inventory_does_not_resolve_dns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    nodefile = tmp_path / "nodes"
+    nodefile.write_text("head.example.test\nworker.example.test\n")
+    monkeypatch.setenv("TEST_NODEFILE", str(nodefile))
+    with patch(
+        "first_pilot.replica_manager.socket.getfqdn",
+        side_effect=AssertionError("DNS must not be called"),
+    ) as getfqdn:
+        assert discover_hosts("TEST_NODEFILE") == [
+            "head.example.test",
+            "worker.example.test",
+        ]
+        getfqdn.assert_not_called()
+
+
+@patch("first_pilot.replica_manager.subprocess.run")
+def test_single_host_inventory_runs_nvidia_smi_locally(
+    run: MagicMock,
+) -> None:
+    run.return_value = CompletedProcess(
+        [],
+        0,
+        stdout="".join(
+            f"{index}, NVIDIA GH200, 97871, {index}\n" for index in range(4)
+        ),
+        stderr="",
+    )
+
+    resources = query_gpus("head.example.test", 4)
+
+    assert [gpu.index for gpu in resources.gpus] == ["0", "1", "2", "3"]
+    command = run.call_args.args[0]
+    assert command[0] == "nvidia-smi"
+    assert "ssh" not in command
+
+
+@patch(
+    "first_pilot.replica_manager._require_executable",
+    return_value="/opt/site/mpiexec",
+)
+@patch("first_pilot.replica_manager.subprocess.run")
+def test_pals_inventory_validates_and_preserves_rank_order(
+    run: MagicMock, _executable: MagicMock
+) -> None:
+    run.return_value = CompletedProcess(
+        [],
+        0,
+        stdout=(
+            _gpu_rows("worker", 1, (3, 2, 1, 0)) + _gpu_rows("head", 0, (2, 0, 3, 1))
+        ),
+        stderr="",
+    )
+
+    resources = query_gpus_pals(
+        ["head.example.test", "worker.example.test"],
+        Path("/opt/cray/pals/1.8/bin/mpiexec"),
+        4,
+    )
+
+    assert [host.hostname for host in resources] == [
+        "head.example.test",
+        "worker.example.test",
+    ]
+    assert [[gpu.index for gpu in host.gpus] for host in resources] == [
+        ["0", "1", "2", "3"],
+        ["0", "1", "2", "3"],
+    ]
+    command = run.call_args.args[0]
+    assert command[0] == "/opt/site/mpiexec"
+    assert "ssh" not in command
+    assert command[command.index("-n") + 1] == "2"
+    assert command[command.index("--ppn") + 1] == "1"
+
+
+@pytest.mark.parametrize(
+    ("output", "message"),
+    [
+        ("not-labeled\n", "unlabeled row"),
+        (
+            "head 0: 0, NVIDIA GH200, unknown, 0\n",
+            "was malformed",
+        ),
+        (
+            _gpu_rows("worker", 0, (0, 1, 2, 3)) + _gpu_rows("head", 1, (0, 1, 2, 3)),
+            "rank 0 reported host",
+        ),
+        (
+            _gpu_rows("head", 0, (0, 1, 2, 3)) + _gpu_rows("worker", 2, (0, 1, 2, 3)),
+            "unexpected rank 2",
+        ),
+    ],
+)
+@patch(
+    "first_pilot.replica_manager._require_executable",
+    return_value="/opt/site/mpiexec",
+)
+@patch("first_pilot.replica_manager.subprocess.run")
+def test_pals_inventory_rejects_malformed_host_and_rank_rows(
+    run: MagicMock,
+    _executable: MagicMock,
+    output: str,
+    message: str,
+) -> None:
+    run.return_value = CompletedProcess([], 0, stdout=output, stderr="")
+
+    with pytest.raises(RuntimeError, match=message):
+        query_gpus_pals(["head", "worker"], Path("/opt/cray/pals/1.8/bin/mpiexec"), 4)
+
+
+@patch(
+    "first_pilot.replica_manager._require_executable",
+    return_value="/opt/site/mpiexec",
+)
+@patch("first_pilot.replica_manager.subprocess.run")
+def test_pals_inventory_rejects_incomplete_rank(
+    run: MagicMock, _executable: MagicMock
+) -> None:
+    run.return_value = CompletedProcess(
+        [], 0, stdout=_gpu_rows("head", 0, (0, 1, 2, 3)), stderr=""
+    )
+
+    with pytest.raises(RuntimeError, match=r"incomplete; missing ranks \[1\]"):
+        query_gpus_pals(["head", "worker"], Path("/opt/cray/pals/1.8/bin/mpiexec"), 4)
+
+
+@patch(
+    "first_pilot.replica_manager._require_executable",
+    return_value="/opt/site/mpiexec",
+)
+@patch("first_pilot.replica_manager.subprocess.run")
+def test_pals_inventory_rejects_duplicate_gpu(
+    run: MagicMock, _executable: MagicMock
+) -> None:
+    run.return_value = CompletedProcess(
+        [],
+        0,
+        stdout=(
+            _gpu_rows("head", 0, (0, 1, 2, 2)) + _gpu_rows("worker", 1, (0, 1, 2, 3))
+        ),
+        stderr="",
+    )
+
+    with pytest.raises(RuntimeError, match="duplicated an index on host 'head'"):
+        query_gpus_pals(["head", "worker"], Path("/opt/cray/pals/1.8/bin/mpiexec"), 4)
+
+
+@patch(
+    "first_pilot.replica_manager._require_executable",
+    return_value="/opt/site/mpiexec",
+)
+@patch("first_pilot.replica_manager.subprocess.run")
+def test_pals_inventory_reports_launcher_failure(
+    run: MagicMock, _executable: MagicMock
+) -> None:
+    run.return_value = CompletedProcess(
+        [], 127, stdout="", stderr="CXI endpoint unavailable"
+    )
+
+    with pytest.raises(RuntimeError, match="exited 127: CXI endpoint unavailable"):
+        query_gpus_pals(["head", "worker"], Path("/opt/cray/pals/1.8/bin/mpiexec"), 4)
+
+
+@patch(
+    "first_pilot.replica_manager._require_executable",
+    return_value="/opt/site/mpiexec",
+)
+@patch("first_pilot.replica_manager.subprocess.run")
+def test_pals_inventory_reports_launcher_timeout(
+    run: MagicMock, _executable: MagicMock
+) -> None:
+    run.side_effect = subprocess.TimeoutExpired("mpiexec", 35)
+
+    with pytest.raises(RuntimeError, match="timed out after 35s"):
+        query_gpus_pals(["head", "worker"], Path("/opt/cray/pals/1.8/bin/mpiexec"), 4)
+
+
+@patch("first_pilot.replica_manager.discover_hosts")
+def test_replica_manager_deduplicates_hosts_in_scheduler_order(
+    discover: MagicMock,
+) -> None:
+    discover.return_value = [
+        "Head.Example.Test",
+        "head",
+        "HEAD.example.test.",
+        "worker",
+        "worker.example.test",
+    ]
+    resources = PilotResources(
+        hosts=[
+            HostGpus(
+                hostname=hostname,
+                gpus=[
+                    GpuInfo(
+                        index="0",
+                        name="GPU",
+                        memory_total_mib=1,
+                        memory_used_mib=0,
+                    )
+                ],
+            )
+            for hostname in ("head", "worker")
+        ]
+    )
+    config = SimpleNamespace(
+        node_file_env="TEST_NODEFILE",
+        pals_path=Path("/opt/cray/pals/1.8/bin/mpiexec"),
+        num_nodes=2,
+        gpus_per_node=1,
+    )
+
+    with patch.object(ReplicaManager, "query_resources", return_value=resources):
+        manager = ReplicaManager(config)  # type: ignore[arg-type]
+
+    assert manager.node_hostnames == ["Head.Example.Test", "worker"]
+
+
+@patch("first_pilot.replica_manager.discover_hosts", return_value=["head"])
+def test_replica_manager_rejects_incomplete_host_inventory(
+    _discover: MagicMock,
+) -> None:
+    config = SimpleNamespace(
+        node_file_env="TEST_NODEFILE",
+        pals_path=Path("/opt/cray/pals/1.8/bin/mpiexec"),
+        num_nodes=2,
+        gpus_per_node=4,
+    )
+
+    with pytest.raises(RuntimeError, match="discovered 1, expected 2"):
+        ReplicaManager(config)  # type: ignore[arg-type]
+
+
+def test_runtime_config_load_overrides_all_nonsecret_public_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "pilot.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "ca_crt": "ca",
+                "server_crt": "crt",
+                "server_key": "key",
+                "external_port": 18443,
+                "nginx_path": "/malicious/nginx",
+                "ip_allowlist": ["0.0.0.0/0"],
+                "workdir": "/personal/workdir",
+                "node_file_env": "ATTACKER_NODEFILE",
+                "pals_path": "/stale/mpiexec",
+                "num_nodes": 1,
+                "gpus_per_node": 1,
+                "job_name": "stale-job",
+            }
+        )
+    )
+    monkeypatch.setenv("PILOT_CONFIG_FILE", str(config_path))
+    monkeypatch.setenv("PILOT_JOB_NAME", "nemotron-canary")
+    monkeypatch.setenv("PILOT_EXTERNAL_PORT", "19443")
+    monkeypatch.setenv("PILOT_NGINX_PATH", "/service/nginx")
+    monkeypatch.setenv("PILOT_IP_ALLOWLIST_JSON", '["10.124.176.33/32"]')
+    monkeypatch.setenv("PILOT_WORKDIR", "/service/workdir")
+    monkeypatch.setenv("PILOT_NODE_FILE_ENV", "PBS_NODEFILE")
+    monkeypatch.setenv("PILOT_PALS_PATH", "/opt/cray/pals/1.8/bin/mpiexec")
+    monkeypatch.setenv("PILOT_NUM_NODES", "2")
+    monkeypatch.setenv("PILOT_GPUS_PER_NODE", "4")
+
+    config = PilotRuntimeConfig.load()
+
+    assert config.job_name == "nemotron-canary"
+    assert config.external_port == 19443
+    assert config.nginx_path == Path("/service/nginx")
+    assert config.ip_allowlist == ["10.124.176.33/32"]
+    assert config.workdir == Path("/service/workdir")
+    assert config.node_file_env == "PBS_NODEFILE"
+    assert config.pals_path == Path("/opt/cray/pals/1.8/bin/mpiexec")
+    assert config.num_nodes == 2
+    assert config.gpus_per_node == 4

--- a/tests/test_pilot_submitter.py
+++ b/tests/test_pilot_submitter.py
@@ -76,6 +76,7 @@ def pilot_config(tmp_path: Path) -> PilotConfig:
             "nginx_path": str(nginx_path),
             "ip_allowlist": ["10.0.0.0/8"],
             "node_file_env": "PBS_NODEFILE",
+            "pals_path": "/opt/site/mpiexec",
             "submit_script_preamble": "#!/bin/bash\nset -eu\nmodule load python",
             "pilot_path": "/test/first-pilot",
         }
@@ -125,6 +126,9 @@ async def test_submit_renders_config_and_script(
     assert parsed["job_name"] == "alpha-7"
     assert parsed["ca_crt"] == ca_crt
     assert parsed["external_port"] == 8443
+    assert parsed["pals_path"] == "/opt/site/mpiexec"
+    assert parsed["num_nodes"] == 2
+    assert parsed["gpus_per_node"] == 4
     assert "BEGIN CERTIFICATE" in parsed["server_crt"]
     assert "BEGIN" in parsed["server_key"]
 
@@ -145,6 +149,20 @@ async def test_submit_renders_config_and_script(
 
     assert result.job_name == f"{pilot_config.job_name_prefix}alpha-7"
     assert result.scheduler_id == "42.fake"
+
+
+async def test_submit_rejects_multi_node_without_pals(
+    pilot_config: PilotConfig, ca_pair: tuple[str, str]
+) -> None:
+    config_without_pals = pilot_config.model_copy(update={"pals_path": None})
+    adapter = FakeSchedulerAdapter()
+    submitter = PilotSubmitter(config_without_pals, adapter, *ca_pair)
+
+    with pytest.raises(ValueError, match="multi-node pilot submission requires"):
+        await submitter.submit(_make_pilot_job("no-pals"))
+
+    assert not adapter.submitted
+    assert not adapter.files
 
 
 async def test_get_statuses_filters_by_prefix(

--- a/tests/test_pilot_submitter.py
+++ b/tests/test_pilot_submitter.py
@@ -4,6 +4,7 @@ from typing import Any, Self
 
 import pytest
 import yaml
+from pydantic import ValidationError
 
 from first_common.schema.base_scheduler import (
     JobStatusInfo,
@@ -14,7 +15,13 @@ from first_common.schema.base_scheduler import (
 )
 from first_common.schema.pilot import AddressInfo, PilotResources
 from first_common.schema.resources.read import PilotJob
-from first_common.schema.types import HealthCheckResult, PilotConfig
+from first_common.schema.types import (
+    HealthCheckResult,
+    PalsDiscovery,
+    PilotConfig,
+    SSHDiscovery,
+)
+from first_gateway.platforms.schedulers.graphql_pbs import GraphQLPBSAdapter
 from first_gateway.services.certmanager import gen_ca_pem
 from first_gateway.services.pilot_submitter import PilotSubmitter
 
@@ -52,6 +59,17 @@ class FakeSchedulerAdapter(SchedulerAdapter):
         return self.files[str(path)][0]
 
 
+class FakeGraphQLSchedulerAdapter(GraphQLPBSAdapter):
+    """GraphQL marker adapter that only records the rendered submit payload."""
+
+    def __init__(self) -> None:
+        self.submitted: list[JobSubmitPayload] = []
+
+    async def submit_job(self, job_spec: JobSubmitPayload) -> JobSubmitResult:
+        self.submitted.append(job_spec)
+        return JobSubmitResult(job_name=job_spec.name, scheduler_id="42.fake")
+
+
 @pytest.fixture
 def ca_pair() -> tuple[str, str]:
     return gen_ca_pem(name="test-ca")
@@ -76,7 +94,10 @@ def pilot_config(tmp_path: Path) -> PilotConfig:
             "nginx_path": str(nginx_path),
             "ip_allowlist": ["10.0.0.0/8"],
             "node_file_env": "PBS_NODEFILE",
-            "pals_path": "/opt/site/mpiexec",
+            "gpu_discovery": {
+                "method": "pals",
+                "launcher_path": "/opt/test/mpiexec",
+            },
             "submit_script_preamble": "#!/bin/bash\nset -eu\nmodule load python",
             "pilot_path": "/test/first-pilot",
         }
@@ -126,7 +147,11 @@ async def test_submit_renders_config_and_script(
     assert parsed["job_name"] == "alpha-7"
     assert parsed["ca_crt"] == ca_crt
     assert parsed["external_port"] == 8443
-    assert parsed["pals_path"] == "/opt/site/mpiexec"
+    assert parsed["gpu_discovery"] == {
+        "method": "pals",
+        "launcher_path": "/opt/test/mpiexec",
+        "timeout_sec": 35.0,
+    }
     assert parsed["num_nodes"] == 2
     assert parsed["gpus_per_node"] == 4
     assert "BEGIN CERTIFICATE" in parsed["server_crt"]
@@ -151,18 +176,67 @@ async def test_submit_renders_config_and_script(
     assert result.scheduler_id == "42.fake"
 
 
-async def test_submit_rejects_multi_node_without_pals(
+async def test_submit_accepts_multi_node_ssh_discovery(
     pilot_config: PilotConfig, ca_pair: tuple[str, str]
 ) -> None:
-    config_without_pals = pilot_config.model_copy(update={"pals_path": None})
+    ssh_config = pilot_config.model_copy(update={"gpu_discovery": SSHDiscovery()})
     adapter = FakeSchedulerAdapter()
-    submitter = PilotSubmitter(config_without_pals, adapter, *ca_pair)
+    submitter = PilotSubmitter(ssh_config, adapter, *ca_pair)
 
-    with pytest.raises(ValueError, match="multi-node pilot submission requires"):
-        await submitter.submit(_make_pilot_job("no-pals"))
+    await submitter.submit(_make_pilot_job("portable-ssh"))
 
-    assert not adapter.submitted
-    assert not adapter.files
+    assert len(adapter.submitted) == 1
+    config_path = ssh_config.workdir / "submit_scripts" / "portable-ssh.config.yaml"
+    parsed = yaml.safe_load(adapter.files[str(config_path)][0])
+    assert parsed["gpu_discovery"] == {"method": "ssh", "timeout_sec": 5.0}
+
+
+def test_pals_discovery_requires_launcher_path(pilot_config: PilotConfig) -> None:
+    raw_config = pilot_config.model_dump()
+    raw_config["gpu_discovery"] = {"method": "pals"}
+
+    with pytest.raises(ValidationError, match="launcher_path"):
+        PilotConfig.model_validate(raw_config)
+
+
+def test_gpu_discovery_defaults_to_ssh(pilot_config: PilotConfig) -> None:
+    raw_config = pilot_config.model_dump(exclude={"gpu_discovery"})
+
+    config = PilotConfig.model_validate(raw_config)
+
+    assert config.gpu_discovery == SSHDiscovery()
+
+
+async def test_graphql_submit_serializes_and_quotes_discovery_environment(
+    pilot_config: PilotConfig, ca_pair: tuple[str, str]
+) -> None:
+    config = pilot_config.model_copy(
+        update={
+            "gpu_discovery": PalsDiscovery(launcher_path=Path("/opt/test/mpiexec")),
+            "ip_allowlist": ["192.0.2.10/32"],
+            "pilot_config_path": Path("/opt/test/pilot config.yaml"),
+            "pilot_path": Path("/opt/test/first pilot"),
+        }
+    )
+    adapter = FakeGraphQLSchedulerAdapter()
+
+    await PilotSubmitter(config, adapter, *ca_pair).submit(
+        _make_pilot_job("graphql-pilot")
+    )
+
+    assert len(adapter.submitted) == 1
+    script = adapter.submitted[0].script
+    assert script is not None
+    assert "PILOT_CONFIG_FILE='/opt/test/pilot config.yaml'" in script
+    assert "PILOT_IP_ALLOWLIST='[\"192.0.2.10/32\"]'" in script
+    assert (
+        "PILOT_GPU_DISCOVERY="
+        '\'{"method":"pals","launcher_path":"/opt/test/mpiexec",'
+        '"timeout_sec":35.0}\''
+    ) in script
+    assert "PILOT_PALS_PATH" not in script
+    assert "PILOT_IP_ALLOWLIST_JSON" not in script
+    assert script.endswith("'/opt/test/first pilot'\n")
 
 
 async def test_get_statuses_filters_by_prefix(


### PR DESCRIPTION
## Summary

- Propagate requested node/GPU topology into the pilot runtime.
- Discover GPUs locally for single-node pilots and through one labeled PALS rank per host for multi-node pilots.
- Preserve scheduler rank order and validate hosts, ranks, GPU indices, counts, timeouts, and launcher results.
- Reject multi-node submissions without a configured PALS launcher.

## Why this is needed

SSH-based node discovery is unreliable on production HPC systems. FIRST must verify that observed topology matches the scheduler request before creating GPU claims or launching replicas.

## Tests

- Allocation, submitter, and replica-manager suites: 21 passed
- Ruff, formatting, and MyPy passed