### PR TITLE
Make replica teardown authoritative and retryable

### DIFF
--- a/packages/common/first_common/errors.py
+++ b/packages/common/first_common/errors.py
@@ -94,6 +94,11 @@ class ReplicaStartError(FirstError):
     code: str = "replica_start_error"
 
 
+class ReplicaTeardownError(FirstError):
+    status_code = HTTPStatus.CONFLICT
+    code: str = "replica_teardown_incomplete"
+
+
 class StatusCASFailed(FirstError):
     """Raised when CAS keeps losing the race past max_cas_attempts."""
 

--- a/packages/common/first_common/schema/types.py
+++ b/packages/common/first_common/schema/types.py
@@ -273,8 +273,8 @@ class DemandThresholdStrategy(BaseModel):
 
 class ScriptTemplateContext(TypedDict):
     """
-    Variables made available to `PilotLaunchSpec.serve_script_template` when it
-    is rendered.
+    Variables made available to the `PilotLaunchSpec` serve and pre-stop script
+    templates when they are rendered.
 
     The single source of truth for what a Jinja template author may reference.
     """
@@ -348,21 +348,47 @@ class PilotLaunchSpec(BaseModel):
 
     serve_script_template: str
 
+    pre_stop_script_template: str | None = None
+    """
+    Optional cooperative-quiesce script run before process-group termination on
+    a normal controller stop. It receives the same strict template context as
+    `serve_script_template`.
+    """
+    pre_stop_timeout_sec: float = Field(default=20.0, gt=0, le=25.0)
+    """Hard deadline for the optional pre-stop script, in seconds."""
+
+    post_stop_script_template: str | None = None
+    """
+    Optional cleanup-verification script run only after the model process group
+    is authoritatively absent. Stop is not successful until this hook exits
+    cleanly and its complete process group is absent.
+    """
+    post_stop_timeout_sec: float = Field(default=50.0, gt=0, le=50.0)
+    """Hard deadline for the optional post-stop script, in seconds."""
+
     max_startup_sec: int
+    max_unhealthy_sec: int | None = Field(default=None, gt=0)
+    """Post-readiness unhealthy deadline; defaults to `max_startup_sec`."""
     health_check: HealthCheckParams
 
-    @field_validator("serve_script_template")
+    @field_validator(
+        "serve_script_template",
+        "pre_stop_script_template",
+        "post_stop_script_template",
+    )
     @classmethod
-    def _check_template_variables(cls, v: str) -> str:
+    def _check_template_variables(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
         try:
             ast = Environment().parse(v)
         except TemplateSyntaxError as e:
-            raise ValueError(f"serve_script_template is not valid Jinja2: {e}") from e
+            raise ValueError(f"script template is not valid Jinja2: {e}") from e
         used = meta.find_undeclared_variables(ast)
         unknown = used - SCRIPT_TEMPLATE_VARIABLES
         if unknown:
             raise ValueError(
-                f"serve_script_template references unknown variables: "
+                f"script template references unknown variables: "
                 f"{sorted(unknown)}. Allowed: {sorted(SCRIPT_TEMPLATE_VARIABLES)}"
             )
         return v

--- a/packages/gateway/first_gateway/controllers/workers/replica_drainer.py
+++ b/packages/gateway/first_gateway/controllers/workers/replica_drainer.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime, timezone
 
+import httpx
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -32,6 +33,19 @@ _PRESERVE_STATES = frozenset(
 _MIN_DRAIN_WAIT_SEC = 20.0
 # Hard cap: after this long we drain regardless of remaining in-flight work.
 _MAX_DRAIN_WAIT_SEC = 300.0
+
+
+def _pilot_error_message(response: httpx.Response) -> str:
+    """Extract a useful pilot error message with a simple text fallback."""
+    try:
+        payload = response.json()
+        error = payload.get("error") if isinstance(payload, dict) else None
+        message = error.get("message") if isinstance(error, dict) else None
+        if isinstance(message, str) and message.strip():
+            return message.strip()
+    except ValueError:
+        pass
+    return response.text.strip() or response.reason_phrase or "unknown pilot error"
 
 
 class ReplicaDrainer(Controller):
@@ -138,7 +152,13 @@ class ReplicaDrainer(Controller):
             return
         # Any other non-2xx (or lingering transport error from the helper) is
         # transient: raise so the reconcile cooldown/retry kicks in.
-        resp.raise_for_status()
+        if not resp.is_success:
+            message = _pilot_error_message(resp)
+            raise httpx.HTTPStatusError(
+                f"Pilot manager could not stop replica {replica_name}: {message}",
+                request=resp.request,
+                response=resp,
+            )
         logger.info("Stopped replica %s", replica_name)
 
     async def _finalize_deletion(self, replica: PilotReplica) -> None:

--- a/packages/gateway/first_gateway/services/pilot_control.py
+++ b/packages/gateway/first_gateway/services/pilot_control.py
@@ -24,6 +24,10 @@ logger = logging.getLogger(__name__)
 # fail fast on connect, but allow start-replica room to do its synchronous
 # on-node work before responding.
 DEFAULT_TIMEOUT = httpx.Timeout(connect=5.0, read=30.0, write=10.0, pool=5.0)
+# A configured pre-stop hook (maximum 25s), hook cleanup (2s), the pilot's
+# TERM/KILL process-group fallback (13s), a post-stop verifier (maximum 50s),
+# its cleanup (2s), and monitor join fit inside this bounded read deadline.
+STOP_TIMEOUT = httpx.Timeout(connect=5.0, read=120.0, write=10.0, pool=5.0)
 
 # Short retry to ride out ephemeral hiccups (a dropped connection, a manager
 # still binding its port, a momentary 503). A handful of quick attempts only;
@@ -133,7 +137,11 @@ class PilotControlClient:
         replica_name: str,
     ) -> httpx.Response:
         """POST /stop-replica/{name}. Returns the raw response (404 is tolerable)."""
-        return await self._request("POST", f"{manager_url}/stop-replica/{replica_name}")
+        return await self._request(
+            "POST",
+            f"{manager_url}/stop-replica/{replica_name}",
+            timeout=STOP_TIMEOUT,
+        )
 
     async def get_logs(self, manager_url: str, replica_name: str) -> str:
         resp = await self._request("GET", f"{manager_url}/logs/{replica_name}")

--- a/packages/pilot/first_pilot/replica.py
+++ b/packages/pilot/first_pilot/replica.py
@@ -6,7 +6,9 @@ import subprocess
 import threading
 import time
 from datetime import datetime, timezone
+from enum import Enum, auto
 from pathlib import Path
+from typing import NoReturn
 from urllib.parse import urlparse
 
 from httpx import Client, HTTPTransport
@@ -25,7 +27,121 @@ logger = logging.getLogger(__name__)
 
 
 class ReplicaTeardownError(RuntimeError):
-    """The bounded teardown attempt ended with a process group still present."""
+    """Teardown attempt ended with a process group still present."""
+
+
+class _HookOutcome(Enum):
+    """Result of a pre/post-stop hook attempt"""
+
+    NOT_CONFIGURED = auto()  # no hook script for this phase
+    SUCCEEDED = auto()  # hook exited 0 and left no descendants
+    FELL_BACK = auto()  # hook failed; fallback cleanup was used instead
+
+
+def _pgid_alive(pgid: int) -> bool:
+    """True if process group ``pgid`` still has at least one member."""
+    try:
+        os.killpg(pgid, 0)  # signal 0 == existence probe
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # EPERM means the kernel found the group but denied the probe.  It is
+        # not evidence of absence; cleanup must remain fail-closed.
+        return True
+
+
+class _ManagedGroup:
+    """One private session (session == pgid) driven to authoritative absence.
+
+    Wraps a leader ``Popen`` started with ``start_new_session=True``, so its pid
+    is the pgid of a session it alone owns. `ensure_absent` runs a bounded
+    TERM->KILL sequence and returns whether the whole group is provably gone.
+    Every call is identical, so a controller retry just repeats it.
+    """
+
+    def __init__(
+        self,
+        leader: subprocess.Popen[bytes],
+        *,
+        label: str,
+        term_grace: float,
+        kill_grace: float,
+        poll_interval: float,
+    ) -> None:
+        self._leader = leader
+        self._pgid = leader.pid
+        self._label = label
+        self._term_grace = term_grace
+        self._kill_grace = kill_grace
+        self._poll_interval = poll_interval
+
+    @property
+    def pgid(self) -> int:
+        return self._pgid
+
+    def alive(self) -> bool:
+        self._leader.poll()  # reap the leader so a zombie can't look "alive"
+        return _pgid_alive(self._pgid)
+
+    def ensure_absent(self) -> bool:
+        """Drive the group to proven absence with a bounded TERM->KILL pass."""
+        if not self.alive():
+            return True
+
+        # There is an unavoidable check->act gap: we probe ``alive()`` and then
+        # ``killpg`` as two separate syscalls, and in between the group could
+        # empty and its pgid be freed. This is safe because Linux allocates pids
+        # cyclically -- a freed number is the *last* to be handed out again, only
+        # after the allocator wraps ``pid_max`` (millions of pids later). The
+        # number cannot be recycled to an unrelated process inside this
+        # microsecond window, so we never risk signalling the wrong group.
+        # TODO: an elevated risk may exist for a *long-lived* pgid that
+        # coexists in a ~40 day pilot job alongside neighboring models with frequent
+        # start/stop churn.  The neighbors could exhaust and cycle pid space leading to a
+        # collision and incorrectly targeted process when this one is killed.
+
+        self._signal(signal.SIGTERM)
+        if self._wait_for_exit(self._term_grace):
+            return True
+
+        logger.warning(
+            "%s group %d still alive %.0fs after SIGTERM; escalating to SIGKILL",
+            self._label,
+            self._pgid,
+            self._term_grace,
+        )
+        self._signal(signal.SIGKILL)
+        absent = self._wait_for_exit(self._kill_grace)
+        if not absent:
+            # A group can outlast SIGKILL only while a member is wedged in
+            # uninterruptible (D-state) sleep; the kernel delivers the pending
+            # kill once it unwedges. Re-signalling cannot help, so we only
+            # report the survivor and let the controller retry later.
+            logger.error("%s process group survived SIGKILL", self._label)
+        return absent
+
+    def _signal(self, sig: int) -> None:
+        try:
+            os.killpg(self._pgid, sig)
+        except ProcessLookupError:
+            pass
+        except PermissionError:
+            logger.error(
+                "permission denied signalling %s group %s",
+                self._label,
+                signal.Signals(sig).name,
+            )
+
+    def _wait_for_exit(self, timeout: float) -> bool:
+        """Poll until the group drains or ``timeout`` elapses."""
+        deadline = time.monotonic() + timeout
+        while True:
+            if not self.alive():
+                return True
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(self._poll_interval)
 
 
 def tail_file(
@@ -58,6 +174,23 @@ def tail_file(
 class Replica:
     """
     Handle to a model replica subprocess and its health-monitor daemon thread.
+
+    Teardown model
+    --------------
+    A replica owns up to three private process groups: an optional pre-stop
+    hook, the model itself, and an optional post-stop verifier. Each is wrapped
+    in a :class:`_ManagedGroup` that drives it to *proven* absence.
+
+    * ``stop()`` is the *only* path that tears a replica down. The health
+      monitor merely observes and records state (``error``, ``start_timeout``);
+      the controller always calls ``stop()`` to free resources, even for a
+      replica that already parked in a failure state.
+    * ``stop()`` joins the monitor first, so teardown runs single-threaded. It
+      runs one bounded attempt and either latches success (``_teardown_complete``)
+      or raises :class:`ReplicaTeardownError`. Retries are the controller calling
+      ``stop()`` again — the object stays addressable in between.
+    * Stage order is fixed: quiesce (pre-stop) -> kill the model group *no matter
+      what the hook did* -> verify (post-stop) *only once the model is gone*.
     """
 
     _HEALTH_INTERVAL = 2.0
@@ -110,6 +243,9 @@ class Replica:
         self._env = os.environ.copy()
         self._env.update(self.launch_spec.env)
 
+        # Created before the Popen so the failure path below can close it.
+        self._health_client = Client(transport=HTTPTransport(uds=self.uds))
+
         logger.info(
             "starting replica %s on uds %s (workdir=%s)",
             self.name,
@@ -128,10 +264,8 @@ class Replica:
         except Exception:
             logger.exception("failed to Popen model replica %s", self.name)
             self._close_log_handles()
+            self._health_client.close()
             raise
-
-        # start_new_session=True makes the child its own session/group leader
-        self._pgid = self.proc.pid
 
         self.state = ReplicaState.launching
         self.state_message = "Model startup script has begun."
@@ -141,9 +275,11 @@ class Replica:
         self.consecutive_health_ok = 0
         self.consecutive_health_fail = 0
         self._unhealthy_since: float | None = None
-        self._health_client = Client(transport=HTTPTransport(uds=self.uds))
 
-        self._health_params = self.launch_spec.health_check
+        self._health_params = self.launch_spec.health_check.model_copy()
+        # Pilot-side policy floor, not a schema rule: the gateway legitimately
+        # uses smaller debounce values, but at our 2s poll interval anything
+        # below 5 makes replica ready/unhealthy flapping too twitchy.
         self._health_debounce = max(5, self._health_params.debounce)
         if self._health_params.url:
             path = urlparse(self._health_params.url).path
@@ -153,22 +289,26 @@ class Replica:
         else:
             logger.info("Replica health check disabled")
 
-        self._teardown_lock = threading.Lock()
         self._stop_lock = threading.Lock()
-        self._teardown_started: bool = False
         self._teardown_complete: bool = False
         self._pre_stop_attempted: bool = False
-        self._pre_stop_proc: subprocess.Popen[bytes] | None = None
-        self._pre_stop_succeeded: bool | None = None
-        self._post_stop_proc: subprocess.Popen[bytes] | None = None
-        self._post_stop_succeeded: bool | None = None
+        self._pre_stop_outcome = _HookOutcome.NOT_CONFIGURED
+        self._post_stop_outcome = _HookOutcome.NOT_CONFIGURED
         self._post_stop_attempts = 0
-        self._model_teardown_attempts = 0
-        self._hook_cleanup_attempts = 0
-        self._post_hook_cleanup_attempts = 0
-        self._model_survivors: dict[int, int] | None = None
-        self._hook_survivors: dict[int, int] | None = None
-        self._post_hook_survivors: dict[int, int] | None = None
+
+        # The three private groups this replica drives to proven absence. The
+        # model group exists for the replica's whole life; the hook groups are
+        # created lazily when their scripts launch.
+        self._model_group = _ManagedGroup(
+            self.proc,
+            label=f"replica {self.name} model",
+            term_grace=self._TERM_GRACE,
+            kill_grace=self._KILL_GRACE,
+            poll_interval=self._GROUP_POLL_INTERVAL,
+        )
+        self._pre_stop_group: _ManagedGroup | None = None
+        self._post_stop_group: _ManagedGroup | None = None
+
         self._monitor_exit = threading.Event()
         self._monitor = threading.Thread(
             target=self._monitor_loop,
@@ -220,68 +360,57 @@ class Replica:
         if self._unhealthy_since is None:
             return False
         elapsed = time.monotonic() - self._unhealthy_since
-        return elapsed > self._unhealthy_timeout_sec()
+        return elapsed > self._unhealthy_timeout_sec
 
+    @property
     def _unhealthy_timeout_sec(self) -> int:
-        timeout = self.launch_spec.max_unhealthy_sec
-        return self.launch_spec.max_startup_sec if timeout is None else timeout
+        return self.launch_spec.max_unhealthy_sec or self.launch_spec.max_startup_sec
 
     def _monitor_loop(self) -> None:
+        """Observe the replica and record its state; never tear it down.
+
+        The monitor only reports what it sees. Teardown -- freeing the GPUs and
+        sweeping the process group -- is always driven by the controller calling
+        :meth:`stop`, even for a replica that has parked in ``error`` or
+        ``start_timeout``. When the monitor decides the replica is doomed (or
+        has exited) it records the terminal state and returns; there is nothing
+        further to observe.
+        """
         while not self._monitor_exit.wait(timeout=self._HEALTH_INTERVAL):
             try:
-                self._run_monitor_check()
-            except ReplicaTeardownError:
-                # The teardown path already recorded exact surviving groups in
-                # state_message and the lifecycle log.  Keep the Replica
-                # addressable so a later controller retry can finish cleanup.
-                logger.exception("teardown incomplete for replica %s", self.name)
-                if self.state != ReplicaState.terminating:
-                    self.state = ReplicaState.error
-                return
+                if self._run_monitor_check():
+                    return
             except Exception:
                 logger.exception(
                     "uncaught exception in monitor thread for %s", self.name
                 )
                 self.state = ReplicaState.error
-                try:
-                    self._shutdown()
-                except ReplicaTeardownError:
-                    logger.exception(
-                        "fallback teardown incomplete for replica %s", self.name
-                    )
                 return
 
-    def _run_monitor_check(self) -> None:
+    def _run_monitor_check(self) -> bool:
+        """Run one observation. Return True when the monitor should stop."""
         rc = self.proc.poll()
         if rc is not None:
             self._handle_process_exit(rc)
-            return
+            return True
 
         health = self._check_health()
         self._record_health(health)
-        self._advance_state(health)
+        return self._advance_state(health)
 
     def _handle_process_exit(self, rc: int) -> None:
-        expected_stop = self.state in (
-            ReplicaState.terminating,
-            ReplicaState.terminated,
-        )
-        if not expected_stop:
-            log = self.get_logs(num_lines=10)
-            msg = (
-                f"Model replica {self.name} exited unexpectedly with code {rc}:\n{log}"
-            )
-            logger.error(msg)
-            self.state = ReplicaState.error
-            self.state_message = msg
+        # A stop() in flight owns the terminal state; don't race it.
+        if self.state in (ReplicaState.terminating, ReplicaState.terminated):
+            return
 
-        # The leader is gone but may have left GPU-pinned children behind:
-        self._shutdown()
-        if expected_stop:
-            self.state = ReplicaState.terminated
-            self.state_message = "Model replica has terminated."
+        log = self.get_logs(num_lines=10)
+        msg = f"Model replica {self.name} exited unexpectedly with code {rc}:\n{log}"
+        logger.error(msg)
+        self.state = ReplicaState.error
+        self.state_message = msg
 
-    def _advance_state(self, health: HealthCheckResult) -> None:
+    def _advance_state(self, health: HealthCheckResult) -> bool:
+        """Advance the state machine. Return True when the monitor should stop."""
         healthy = health == HealthCheckResult.healthy
 
         if self.state == ReplicaState.launching:
@@ -294,11 +423,14 @@ class Replica:
                 self.state = ReplicaState.ready
             elif time.monotonic() > self._startup_deadline:
                 log = self.get_logs(num_lines=10)
-                msg = f"Replica {self.name} did not become healthy within spec max_startup_sec; tearing down:\n{log}"
+                msg = (
+                    f"Replica {self.name} did not become healthy within spec "
+                    f"max_startup_sec; awaiting teardown:\n{log}"
+                )
                 logger.error(msg)
                 self.state_message = msg
                 self.state = ReplicaState.start_timeout
-                self._shutdown()
+                return True
 
         elif self.state == ReplicaState.ready:
             if not healthy and self.consecutive_health_fail >= self._health_debounce:
@@ -315,239 +447,184 @@ class Replica:
                 self._unhealthy_since = None
             elif self._unhealthy_for_too_long():
                 log = self.get_logs(num_lines=10)
-                timeout = self._unhealthy_timeout_sec()
+                timeout = self._unhealthy_timeout_sec
                 msg = (
                     f"replica {self.name} unhealthy for over {timeout}s; "
-                    f"tearing down:\n{log}"
+                    f"awaiting teardown:\n{log}"
                 )
                 logger.error(msg)
                 self.state_message = msg
                 self.state = ReplicaState.error
-                self._shutdown()
+                return True
+
+        return False
 
     def stop(self, timeout: float = 10.0) -> None:
         """
         Cooperatively quiesce (when configured), terminate the process group,
-        wait for the monitor to exit, then record the terminal state.
+        and record the terminal state. This is the only path that tears a
+        replica down; the health monitor never does.
 
-        Calls are serialized and idempotent after authoritative completion. A
-        failed attempt leaves the Replica addressable and retryable; success is
-        reported only after both the hook and model process groups are absent.
+        Calls are serialized by ``_stop_lock`` and idempotent after success. A
+        failed attempt raises :class:`ReplicaTeardownError` and leaves the
+        Replica addressable so the controller can retry by calling ``stop()``
+        again. See the class docstring for the teardown model.
         """
         with self._stop_lock:
-            if self._is_teardown_complete():
+            if self._teardown_complete:
                 return
 
             logger.info("stopping replica %s", self.name)
             self.state = ReplicaState.terminating
-            failure: ReplicaTeardownError | None = None
-            try:
-                self._shutdown(cooperative=True)
-            except ReplicaTeardownError as exc:
-                failure = exc
 
-            # Join the monitor so nothing writes self.state after this point.
-            if (
-                self._monitor.is_alive()
-                and threading.current_thread() is not self._monitor
-            ):
-                self._monitor.join(timeout=timeout + 5)
+            # Stop the observer first so nothing writes self.state while we tear
+            # down. The monitor never calls stop(), so this cannot self-join.
+            self._monitor_exit.set()
+            self._monitor.join(timeout=timeout + 5)
+            if self._monitor.is_alive():
+                logger.warning(
+                    "monitor thread for replica %s still alive after %.0fs join; "
+                    "proceeding with teardown anyway",
+                    self.name,
+                    timeout + 5,
+                )
 
-            # A monitor that was already inside a check may have completed a
-            # second serialized teardown attempt while we joined it.
-            if not self._is_teardown_complete():
-                if failure is None:
-                    failure = ReplicaTeardownError(self.state_message)
-                raise failure
+            # Re-assert terminating in case monitor changed it before joining
+            self.state = ReplicaState.terminating
+
+            self._run_teardown_stages()  # raises if any group survives
 
             self.state = ReplicaState.terminated
-            if self._pre_stop_succeeded is True and self._post_stop_succeeded is True:
-                self.state_message = (
-                    "Model replica terminated after cooperative pre-stop and "
-                    "verified post-stop hooks."
-                )
-            elif self._post_stop_succeeded is True:
-                self.state_message = (
-                    "Model replica terminated after verified post-stop hook."
-                )
-            elif self._pre_stop_succeeded is True:
-                self.state_message = (
-                    "Model replica terminated after cooperative pre-stop hook."
-                )
-            elif self._pre_stop_succeeded is False:
-                self.state_message = (
-                    "Model replica terminated with process-group fallback after "
-                    "pre-stop hook failure."
-                )
-            else:
-                self.state_message = "Model replica has terminated."
+            self.state_message = self._terminated_message()
 
-    def _is_teardown_complete(self) -> bool:
-        """Read mutable completion state without exposing a stale snapshot."""
-        return self._teardown_complete
-
-    def _shutdown(self, *, cooperative: bool = False) -> None:
-        """
-        Run one bounded teardown attempt.
-
-        Completion is latched only after both private process groups are absent;
-        once latched, their numeric PGIDs are never probed or signalled again.
-        Failed attempts retain the original Popen handles for a safe retry and
-        cannot be confused with a subsequently started Replica.
-        """
-        self._monitor_exit.set()
-        with self._teardown_lock:
-            if self._teardown_complete:
-                return
-
-            first_attempt = not self._teardown_started
-            self._teardown_started = True
-
-            try:
-                if cooperative and first_attempt and not self._pre_stop_attempted:
-                    (
-                        self._pre_stop_succeeded,
-                        hook_absent,
-                    ) = self._run_pre_stop_hook()
-                else:
-                    hook_absent = self._ensure_hook_group_absent()
-            except Exception:
-                logger.exception("pre-stop cleanup failed for replica %s", self.name)
-                self._pre_stop_succeeded = False
-                hook_absent = False
-
-            # The model fallback is independent of hook outcome: even a hook
-            # cleanup error must not prevent the GPU-bearing group from being
-            # driven through its own bounded TERM/KILL sequence.
-            try:
-                model_absent = self._terminate_process_group()
-            except Exception:
-                logger.exception("model cleanup failed for replica %s", self.name)
-                model_absent = False
-            post_stop_ready = True
-            if model_absent:
-                try:
-                    (
-                        self._post_stop_succeeded,
-                        post_stop_group_absent,
-                    ) = self._run_post_stop_hook()
-                    post_stop_ready = (
-                        self._post_stop_succeeded is not False
-                        and post_stop_group_absent
-                    )
-                except Exception:
-                    logger.exception(
-                        "post-stop verification failed for replica %s", self.name
-                    )
-                    self._post_stop_succeeded = False
-                    post_stop_ready = False
-
-            if hook_absent and model_absent and post_stop_ready:
-                self._teardown_complete = True
-                self._close_log_handles()
-                return
-
-            survivors = []
-            if not hook_absent:
-                survivors.append("pre-stop hook process group")
-            if not model_absent:
-                survivors.append("model process group")
-            if not post_stop_ready:
-                survivors.append("post-stop hook or verification")
-            message = (
-                f"Replica {self.name} teardown incomplete; still present: "
-                + ", ".join(survivors)
+    def _terminated_message(self) -> str:
+        """Describe a completed teardown from the recorded hook outcomes."""
+        pre, post = self._pre_stop_outcome, self._post_stop_outcome
+        if pre is _HookOutcome.SUCCEEDED and post is _HookOutcome.SUCCEEDED:
+            return (
+                "Model replica terminated after cooperative pre-stop and "
+                "verified post-stop hooks."
             )
-            logger.error(message)
-            self.state_message = message
-            self._write_lifecycle_log(message)
-            raise ReplicaTeardownError(message)
+        if post is _HookOutcome.SUCCEEDED:
+            return "Model replica terminated after verified post-stop hook."
+        if pre is _HookOutcome.SUCCEEDED:
+            return "Model replica terminated after cooperative pre-stop hook."
+        if pre is _HookOutcome.FELL_BACK:
+            return (
+                "Model replica terminated with process-group fallback after "
+                "pre-stop hook failure."
+            )
+        return "Model replica has terminated."
 
-    def _run_pre_stop_hook(self) -> tuple[bool | None, bool]:
+    def _run_teardown_stages(self) -> None:
+        """
+        Run one bounded teardown attempt through the three fixed stages.
+
+        Only the pre-stop stage is exception-guarded: a fault in the hook
+        machinery must not skip the TERM/KILL sequence for the GPU-bearing
+        model group. The later stages handle OS-level failures internally; an
+        unexpected exception there simply propagates, and the attempt stays
+        retryable either way because success is latched only when all three
+        stages report proven absence. Serialized by ``stop()``'s
+        ``_stop_lock``, so no internal locking is needed.
+        """
+        try:
+            hook_absent = self._quiesce_pre_stop()
+        except Exception:
+            logger.exception("pre-stop cleanup failed for replica %s", self.name)
+            self._pre_stop_outcome = _HookOutcome.FELL_BACK
+            hook_absent = False
+
+        model_absent = self._model_group.ensure_absent()
+
+        # The post-stop verifier is meaningful only once the model group is
+        # gone, so it is gated on that authoritative absence.
+        post_ready = True
+        if model_absent:
+            post_ready = self._verify_post_stop()
+
+        if hook_absent and model_absent and post_ready:
+            self._teardown_complete = True
+            self._close_log_handles()
+            self._health_client.close()
+            return
+
+        self._raise_incomplete(hook_absent, model_absent, post_ready)
+
+    def _raise_incomplete(
+        self, hook_absent: bool, model_absent: bool, post_ready: bool
+    ) -> NoReturn:
+        """Record the surviving groups and raise a retryable teardown error."""
+        survivors = []
+        if not hook_absent:
+            survivors.append("pre-stop hook process group")
+        if not model_absent:
+            survivors.append("model process group")
+        if not post_ready:
+            survivors.append("post-stop hook or verification")
+        message = (
+            f"Replica {self.name} teardown incomplete; still present: "
+            + ", ".join(survivors)
+        )
+        logger.error(message)
+        self.state_message = message
+        self._write_lifecycle_log(message)
+        raise ReplicaTeardownError(message)
+
+    def _quiesce_pre_stop(self) -> bool:
+        """Stage 1: run the pre-stop hook once, or confirm a prior one is gone.
+
+        The cooperative hook runs at most once (on the first stop attempt);
+        every retry just proves any group it left is absent.
+        """
+        if not self._pre_stop_attempted:
+            self._pre_stop_outcome, absent = self._run_pre_stop_hook()
+            return absent
+        return self._pre_stop_group is None or self._pre_stop_group.ensure_absent()
+
+    def _verify_post_stop(self) -> bool:
+        """Stage 3: prove a clean post-stop verification, or fail retryably.
+
+        Any non-success outcome is retained as a stop failure even when fallback
+        cleanup removed the hook group, so a later attempt must rerun and obtain
+        an explicit successful verification.
+        """
+        self._post_stop_outcome, group_absent = self._run_post_stop_hook()
+        return self._post_stop_outcome is not _HookOutcome.FELL_BACK and group_absent
+
+    def _run_pre_stop_hook(self) -> tuple[_HookOutcome, bool]:
         self._pre_stop_attempted = True
         script_path = self._pre_stop_script_path
         if script_path is None:
-            return None, True
+            return _HookOutcome.NOT_CONFIGURED, True
 
         timeout = self.launch_spec.pre_stop_timeout_sec
         logger.info(
-            "running pre-stop hook for replica %s (timeout=%.1fs)",
-            self.name,
-            timeout,
+            "running pre-stop hook for replica %s (timeout=%.1fs)", self.name, timeout
         )
-        self._write_lifecycle_log(f"pre-stop hook started (timeout={timeout:.1f}s)")
-        try:
-            hook = subprocess.Popen(
-                ["/bin/bash", str(script_path)],
-                cwd=str(self.workdir),
-                stdout=self._log_fh,
-                stderr=subprocess.STDOUT,
-                env=self._env,
-                start_new_session=True,
-            )
-        except Exception:
-            logger.exception("failed to start pre-stop hook for replica %s", self.name)
-            self._write_lifecycle_log("pre-stop hook failed to start; using fallback")
-            return False, True
+        group, outcome, absent = self._execute_hook(
+            script_path, timeout, label="pre-stop"
+        )
+        self._pre_stop_group = group
+        return outcome, absent
 
-        self._pre_stop_proc = hook
-
-        try:
-            rc = hook.wait(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            logger.error(
-                "pre-stop hook for replica %s exceeded %.1fs; using fallback",
-                self.name,
-                timeout,
-            )
-            self._write_lifecycle_log("pre-stop hook timed out; using fallback")
-            return False, self._terminate_hook_group(hook)
-
-        if rc != 0:
-            logger.error(
-                "pre-stop hook for replica %s exited %d; using fallback",
-                self.name,
-                rc,
-            )
-            self._write_lifecycle_log(f"pre-stop hook exited {rc}; using fallback")
-            # The leader is reaped, but it may have orphaned descendants in its
-            # private session. Absence of the whole hook process group is the
-            # cleanup condition for every hook outcome.
-            return False, self._terminate_hook_group(hook)
-
-        if self._process_group_alive(hook.pid):
-            logger.error(
-                "pre-stop hook for replica %s left descendant processes; "
-                "using fallback",
-                self.name,
-            )
-            self._write_lifecycle_log(
-                "pre-stop hook left descendant processes; using fallback"
-            )
-            return False, self._terminate_hook_group(hook)
-
-        logger.info("pre-stop hook completed for replica %s", self.name)
-        self._write_lifecycle_log("pre-stop hook completed")
-        return True, True
-
-    def _run_post_stop_hook(self) -> tuple[bool | None, bool]:
-        """Run cleanup verification after authoritative model-group absence.
-
-        The hook runs in its own private session.  Every non-success outcome is
-        retained as a stop failure even when fallback cleanup removes the hook
-        group, so a later controller attempt must rerun and obtain an explicit
-        successful verification result.
-        """
+    def _run_post_stop_hook(self) -> tuple[_HookOutcome, bool]:
         script_path = self._post_stop_script_path
         if script_path is None:
-            return None, True
-        if self._post_stop_succeeded is True:
-            return True, self._ensure_post_stop_hook_group_absent()
+            return _HookOutcome.NOT_CONFIGURED, True
+        if self._post_stop_outcome is _HookOutcome.SUCCEEDED:
+            # Already verified on a prior attempt; only confirm the group is gone.
+            return _HookOutcome.SUCCEEDED, (
+                self._post_stop_group is None or self._post_stop_group.ensure_absent()
+            )
 
         # A prior failed attempt may still own descendants.  Never start a new
         # verifier until that exact private process group is absent.
-        if not self._ensure_post_stop_hook_group_absent():
-            return False, False
+        if (
+            self._post_stop_group is not None
+            and not self._post_stop_group.ensure_absent()
+        ):
+            return _HookOutcome.FELL_BACK, False
 
         self._post_stop_attempts += 1
         timeout = self.launch_spec.post_stop_timeout_sec
@@ -557,12 +634,29 @@ class Replica:
             self._post_stop_attempts,
             timeout,
         )
-        self._write_lifecycle_log(
-            "post-stop hook started "
-            f"(attempt={self._post_stop_attempts}, timeout={timeout:.1f}s)"
+        group, outcome, absent = self._execute_hook(
+            script_path, timeout, label="post-stop"
         )
+        self._post_stop_group = group
+        return outcome, absent
+
+    def _execute_hook(
+        self,
+        script_path: Path,
+        timeout: float,
+        *,
+        label: str,
+    ) -> tuple[_ManagedGroup | None, _HookOutcome, bool]:
+        """Launch a hook in its own session, wait, and classify the outcome.
+
+        Returns ``(group, outcome, group_absent)``. ``group`` is ``None`` only
+        when the hook could not be started. A ``FELL_BACK`` outcome means the
+        bounded fallback cleanup already ran; ``group_absent`` then reports
+        whether that cleanup proved the whole hook group gone.
+        """
+        self._write_lifecycle_log(f"{label} hook started (timeout={timeout:.1f}s)")
         try:
-            hook = subprocess.Popen(
+            proc = subprocess.Popen(
                 ["/bin/bash", str(script_path)],
                 cwd=str(self.workdir),
                 stdout=self._log_fh,
@@ -571,295 +665,54 @@ class Replica:
                 start_new_session=True,
             )
         except Exception:
-            logger.exception("failed to start post-stop hook for replica %s", self.name)
-            self._write_lifecycle_log("post-stop hook failed to start")
-            return False, True
+            logger.exception("failed to start %s hook for replica %s", label, self.name)
+            self._write_lifecycle_log(f"{label} hook failed to start")
+            return None, _HookOutcome.FELL_BACK, True
 
-        self._post_stop_proc = hook
+        group = _ManagedGroup(
+            proc,
+            label=f"replica {self.name} {label} hook",
+            term_grace=self._HOOK_TERM_GRACE,
+            kill_grace=self._HOOK_KILL_GRACE,
+            poll_interval=self._GROUP_POLL_INTERVAL,
+        )
+
         try:
-            rc = hook.wait(timeout=timeout)
+            rc = proc.wait(timeout=timeout)
         except subprocess.TimeoutExpired:
             logger.error(
-                "post-stop hook for replica %s exceeded %.1fs",
-                self.name,
-                timeout,
+                "%s hook for replica %s exceeded %.1fs", label, self.name, timeout
             )
-            self._write_lifecycle_log("post-stop hook timed out")
-            return False, self._terminate_post_stop_hook_group(hook)
+            self._write_lifecycle_log(f"{label} hook timed out")
+            return group, _HookOutcome.FELL_BACK, group.ensure_absent()
 
         if rc != 0:
+            logger.error("%s hook for replica %s exited %d", label, self.name, rc)
+            self._write_lifecycle_log(f"{label} hook exited {rc}")
+            # The leader is reaped, but it may have orphaned descendants in its
+            # private session. Absence of the whole group is the cleanup
+            # condition for every hook outcome.
+            return group, _HookOutcome.FELL_BACK, group.ensure_absent()
+
+        if group.alive():
             logger.error(
-                "post-stop hook for replica %s exited %d",
-                self.name,
-                rc,
+                "%s hook for replica %s left descendant processes", label, self.name
             )
-            self._write_lifecycle_log(f"post-stop hook exited {rc}")
-            return False, self._terminate_post_stop_hook_group(hook)
+            self._write_lifecycle_log(f"{label} hook left descendant processes")
+            return group, _HookOutcome.FELL_BACK, group.ensure_absent()
 
-        if self._process_group_alive(hook.pid):
-            logger.error(
-                "post-stop hook for replica %s left descendant processes",
-                self.name,
-            )
-            self._write_lifecycle_log("post-stop hook left descendant processes")
-            return False, self._terminate_post_stop_hook_group(hook)
-
-        logger.info("post-stop hook completed for replica %s", self.name)
-        self._write_lifecycle_log("post-stop hook completed")
-        return True, True
-
-    def _ensure_hook_group_absent(self) -> bool:
-        hook = self._pre_stop_proc
-        if hook is None or not self._process_group_alive(hook.pid):
-            return True
-        return self._terminate_hook_group(hook)
-
-    def _terminate_hook_group(self, hook: subprocess.Popen[bytes]) -> bool:
-        """Bound cleanup of a pre-stop hook group; return authoritative absence."""
-        retry = self._hook_cleanup_attempts > 0
-        self._hook_cleanup_attempts += 1
-        hook.poll()
-        if not self._process_group_alive(hook.pid):
-            return True
-        if retry and not self._retry_owns_process_group(
-            hook.pid,
-            hook,
-            self._hook_survivors,
-            label="pre-stop hook",
-        ):
-            return False
-        try:
-            os.killpg(hook.pid, signal.SIGTERM)
-        except ProcessLookupError:
-            pass
-        except PermissionError:
-            logger.error("permission denied signalling pre-stop hook group SIGTERM")
-        if self._wait_for_process_group_exit(hook.pid, hook, self._HOOK_TERM_GRACE):
-            return True
-        try:
-            os.killpg(hook.pid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-        except PermissionError:
-            logger.error("permission denied signalling pre-stop hook group SIGKILL")
-        absent = self._wait_for_process_group_exit(
-            hook.pid, hook, self._HOOK_KILL_GRACE
-        )
-        if not absent:
-            logger.error("pre-stop hook process group survived SIGKILL")
-            self._hook_survivors = self._snapshot_process_group(hook.pid)
-        return absent
-
-    def _ensure_post_stop_hook_group_absent(self) -> bool:
-        hook = self._post_stop_proc
-        if hook is None or not self._process_group_alive(hook.pid):
-            return True
-        return self._terminate_post_stop_hook_group(hook)
-
-    def _terminate_post_stop_hook_group(self, hook: subprocess.Popen[bytes]) -> bool:
-        """Bound cleanup of a post-stop hook group; prove exact absence."""
-        retry = self._post_hook_cleanup_attempts > 0
-        self._post_hook_cleanup_attempts += 1
-        hook.poll()
-        if not self._process_group_alive(hook.pid):
-            return True
-        if retry and not self._retry_owns_process_group(
-            hook.pid,
-            hook,
-            self._post_hook_survivors,
-            label="post-stop hook",
-        ):
-            return False
-        try:
-            os.killpg(hook.pid, signal.SIGTERM)
-        except ProcessLookupError:
-            pass
-        except PermissionError:
-            logger.error("permission denied signalling post-stop hook group SIGTERM")
-        if self._wait_for_process_group_exit(hook.pid, hook, self._HOOK_TERM_GRACE):
-            return True
-        try:
-            os.killpg(hook.pid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-        except PermissionError:
-            logger.error("permission denied signalling post-stop hook group SIGKILL")
-        absent = self._wait_for_process_group_exit(
-            hook.pid, hook, self._HOOK_KILL_GRACE
-        )
-        if not absent:
-            logger.error("post-stop hook process group survived SIGKILL")
-            self._post_hook_survivors = self._snapshot_process_group(hook.pid)
-        return absent
+        logger.info("%s hook completed for replica %s", label, self.name)
+        self._write_lifecycle_log(f"{label} hook completed")
+        return group, _HookOutcome.SUCCEEDED, True
 
     def _write_lifecycle_log(self, message: str) -> None:
         try:
             self._log_fh.write(f"[FIRST lifecycle] {message}\n".encode())
             self._log_fh.flush()
-        except (OSError, ValueError):
+        except OSError:
             logger.exception(
                 "could not write lifecycle marker for replica %s", self.name
             )
-
-    def _terminate_process_group(self) -> bool:
-        """Bound TERM/KILL of the model group; return authoritative absence."""
-        retry = self._model_teardown_attempts > 0
-        self._model_teardown_attempts += 1
-        if not self._group_alive():
-            return True
-        if retry and not self._retry_owns_process_group(
-            self._pgid,
-            self.proc,
-            self._model_survivors,
-            label="model",
-        ):
-            return False
-
-        try:
-            os.killpg(self._pgid, signal.SIGTERM)
-        except ProcessLookupError:
-            pass
-        except PermissionError:
-            logger.error("permission denied signalling model group SIGTERM")
-
-        if self._wait_for_group_exit(self._TERM_GRACE):
-            return True
-
-        logger.warning(
-            "replica %s still alive %.0fs after SIGTERM; escalating to SIGKILL",
-            self.name,
-            self._TERM_GRACE,
-        )
-        try:
-            os.killpg(self._pgid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
-        except PermissionError:
-            logger.error("permission denied signalling model group SIGKILL")
-        absent = self._wait_for_group_exit(self._KILL_GRACE)
-        if not absent:
-            logger.error("replica %s process group survived SIGKILL", self.name)
-            self._model_survivors = self._snapshot_process_group(self._pgid)
-        return absent
-
-    def _group_alive(self) -> bool:
-        """True if the process group still has at least one member."""
-        return self._process_group_alive(self._pgid)
-
-    @staticmethod
-    def _process_group_alive(pgid: int) -> bool:
-        """True if process group ``pgid`` still has at least one member."""
-        try:
-            os.killpg(pgid, 0)  # signal 0 == existence probe
-            return True
-        except ProcessLookupError:
-            return False
-        except PermissionError:
-            # EPERM means the kernel found the group but denied the probe.  It
-            # is not evidence of absence; cleanup must remain fail-closed.
-            return True
-        except OSError:
-            logger.exception("process-group existence probe failed for pgid=%d", pgid)
-            return True
-
-    @staticmethod
-    def _snapshot_process_group(pgid: int) -> dict[int, int] | None:
-        """Return Linux ``pid -> starttime`` identities for one private session.
-
-        ``None`` means the procfs ownership check is unavailable.  An empty
-        mapping means no readable member currently has both pgrp and session
-        equal to the launch-time PGID.
-        """
-        try:
-            entries = list(Path("/proc").iterdir())
-        except OSError:
-            return None
-
-        members: dict[int, int] = {}
-        for entry in entries:
-            if not entry.name.isdecimal():
-                continue
-            try:
-                raw = (entry / "stat").read_text()
-                # comm (field 2) is parenthesized and may contain spaces or ')'.
-                fields = raw[raw.rfind(")") + 2 :].split()
-                pgrp = int(fields[2])  # field 5
-                session = int(fields[3])  # field 6
-                starttime = int(fields[19])  # field 22
-            except (OSError, ValueError, IndexError):
-                continue
-            if pgrp == pgid and session == pgid:
-                members[int(entry.name)] = starttime
-        return members
-
-    def _retry_owns_process_group(
-        self,
-        pgid: int,
-        leader: subprocess.Popen[bytes],
-        witnesses: dict[int, int] | None,
-        *,
-        label: str,
-    ) -> bool:
-        """Refuse a retry signal unless the numeric PGID is still ours.
-
-        PGIDs can be reused after a group disappears. A live original leader is
-        an ownership witness. Once that leader is gone, at least one surviving
-        ``(pid, /proc starttime)`` captured by the prior failed attempt must
-        still match. Ambiguity is retained as teardown failure rather than
-        risking a signal to an unrelated, reused group.
-        """
-        if leader.poll() is None:
-            try:
-                if os.getpgid(leader.pid) == pgid and os.getsid(leader.pid) == pgid:
-                    return True
-            except (ProcessLookupError, PermissionError):
-                pass
-
-        current = self._snapshot_process_group(pgid)
-        if (
-            current is not None
-            and witnesses
-            and any(
-                current.get(pid) == starttime for pid, starttime in witnesses.items()
-            )
-        ):
-            witnesses.update(current)
-            return True
-
-        logger.error(
-            "refusing retry signal for %s pgid=%d: original process-group "
-            "ownership cannot be proven",
-            label,
-            pgid,
-        )
-        return False
-
-    def _wait_for_group_exit(self, timeout: float) -> bool:
-        """
-        Poll until the group has no members, or `timeout` elapses. Returns True
-        if it drained.
-        """
-        deadline = time.monotonic() + timeout
-        while True:
-            self.proc.poll()  # reap the leader so a zombie can't keep the group "alive"
-            if not self._group_alive():
-                return True
-            if time.monotonic() >= deadline:
-                return False
-            time.sleep(self._GROUP_POLL_INTERVAL)
-
-    def _wait_for_process_group_exit(
-        self, pgid: int, leader: subprocess.Popen[bytes], timeout: float
-    ) -> bool:
-        """Bound wait for an auxiliary process group, reaping its leader."""
-        deadline = time.monotonic() + timeout
-        while True:
-            leader.poll()
-            if not self._process_group_alive(pgid):
-                return True
-            if time.monotonic() >= deadline:
-                return False
-            time.sleep(self._GROUP_POLL_INTERVAL)
 
     def _close_log_handles(self) -> None:
         try:

--- a/packages/pilot/first_pilot/replica.py
+++ b/packages/pilot/first_pilot/replica.py
@@ -6,9 +6,7 @@ import subprocess
 import threading
 import time
 from datetime import datetime, timezone
-from enum import Enum, auto
 from pathlib import Path
-from typing import NoReturn
 from urllib.parse import urlparse
 
 from httpx import Client, HTTPTransport
@@ -28,14 +26,6 @@ logger = logging.getLogger(__name__)
 
 class ReplicaTeardownError(RuntimeError):
     """Teardown attempt ended with a process group still present."""
-
-
-class _HookOutcome(Enum):
-    """Result of a pre/post-stop hook attempt"""
-
-    NOT_CONFIGURED = auto()  # no hook script for this phase
-    SUCCEEDED = auto()  # hook exited 0 and left no descendants
-    FELL_BACK = auto()  # hook failed; fallback cleanup was used instead
 
 
 def _pgid_alive(pgid: int) -> bool:
@@ -243,9 +233,6 @@ class Replica:
         self._env = os.environ.copy()
         self._env.update(self.launch_spec.env)
 
-        # Created before the Popen so the failure path below can close it.
-        self._health_client = Client(transport=HTTPTransport(uds=self.uds))
-
         logger.info(
             "starting replica %s on uds %s (workdir=%s)",
             self.name,
@@ -264,7 +251,6 @@ class Replica:
         except Exception:
             logger.exception("failed to Popen model replica %s", self.name)
             self._close_log_handles()
-            self._health_client.close()
             raise
 
         self.state = ReplicaState.launching
@@ -281,6 +267,8 @@ class Replica:
         # uses smaller debounce values, but at our 2s poll interval anything
         # below 5 makes replica ready/unhealthy flapping too twitchy.
         self._health_debounce = max(5, self._health_params.debounce)
+        self._health_client = Client(transport=HTTPTransport(uds=self.uds))
+
         if self._health_params.url:
             path = urlparse(self._health_params.url).path
             url = f"http://localhost/{path.lstrip('/')}"
@@ -291,9 +279,9 @@ class Replica:
 
         self._stop_lock = threading.Lock()
         self._teardown_complete: bool = False
-        self._pre_stop_attempted: bool = False
-        self._pre_stop_outcome = _HookOutcome.NOT_CONFIGURED
-        self._post_stop_outcome = _HookOutcome.NOT_CONFIGURED
+        self._pre_stop_ran: bool = False  # cooperative hook runs at most once, ever
+        self._pre_stop_ok: bool = False  # ...and exited 0 with no descendants
+        self._post_stop_ok: bool = False  # one post-stop run verified cleanly
         self._post_stop_attempts = 0
 
         # The three private groups this replica drives to proven absence. The
@@ -492,168 +480,118 @@ class Replica:
             # Re-assert terminating in case monitor changed it before joining
             self.state = ReplicaState.terminating
 
-            self._run_teardown_stages()  # raises if any group survives
+            survivors = self._teardown()
+            if survivors:
+                message = (
+                    f"Replica {self.name} teardown incomplete; still present: "
+                    + ", ".join(survivors)
+                )
+                logger.error(message)
+                self.state_message = message
+                self._write_lifecycle_log(message)
+                raise ReplicaTeardownError(message)
 
+            self._teardown_complete = True
+            self._close_log_handles()
+            self._health_client.close()
             self.state = ReplicaState.terminated
             self.state_message = self._terminated_message()
 
     def _terminated_message(self) -> str:
-        """Describe a completed teardown from the recorded hook outcomes."""
-        pre, post = self._pre_stop_outcome, self._post_stop_outcome
-        if pre is _HookOutcome.SUCCEEDED and post is _HookOutcome.SUCCEEDED:
+        """Describe a completed teardown from the recorded hook results."""
+        if self._pre_stop_ok and self._post_stop_ok:
             return (
                 "Model replica terminated after cooperative pre-stop and "
                 "verified post-stop hooks."
             )
-        if post is _HookOutcome.SUCCEEDED:
+        if self._post_stop_ok:
             return "Model replica terminated after verified post-stop hook."
-        if pre is _HookOutcome.SUCCEEDED:
+        if self._pre_stop_ok:
             return "Model replica terminated after cooperative pre-stop hook."
-        if pre is _HookOutcome.FELL_BACK:
+        if self._pre_stop_ran:  # ran (implies configured) but did not succeed
             return (
                 "Model replica terminated with process-group fallback after "
                 "pre-stop hook failure."
             )
         return "Model replica has terminated."
 
-    def _run_teardown_stages(self) -> None:
-        """
-        Run one bounded teardown attempt through the three fixed stages.
+    def _teardown(self) -> list[str]:
+        """Run one bounded teardown attempt, top to bottom; return survivors.
 
-        Only the pre-stop stage is exception-guarded: a fault in the hook
-        machinery must not skip the TERM/KILL sequence for the GPU-bearing
-        model group. The later stages handle OS-level failures internally; an
-        unexpected exception there simply propagates, and the attempt stays
-        retryable either way because success is latched only when all three
-        stages report proven absence. Serialized by ``stop()``'s
-        ``_stop_lock``, so no internal locking is needed.
+        Stage order is fixed: quiesce (pre-stop) -> kill the model group no
+        matter what the hook did -> verify (post-stop) only once the model is
+        gone. A retry re-runs only what is unsettled: the cooperative pre-stop
+        hook runs at most once ever, the model kill is idempotent, and the
+        post-stop hook re-runs until one attempt verifies cleanly. Serialized
+        by ``stop()``'s ``_stop_lock``, so no internal locking is needed.
         """
+        survivors: list[str] = []
+
+        # 1. Pre-stop quiesce. Exception-guarded so a fault in the hook
+        #    machinery can never skip the model kill below. A failed hook is
+        #    tolerated -- the kill below is the fallback -- but its private
+        #    process group must still be proven absent.
         try:
-            hook_absent = self._quiesce_pre_stop()
+            if self._pre_stop_script_path is not None and not self._pre_stop_ran:
+                self._pre_stop_ran = True
+                self._pre_stop_group, self._pre_stop_ok = self._run_hook(
+                    "pre-stop",
+                    self._pre_stop_script_path,
+                    self.launch_spec.pre_stop_timeout_sec,
+                )
+                if not self._pre_stop_ok:
+                    self._write_lifecycle_log(
+                        "pre-stop hook failed; using process-group fallback"
+                    )
+            pre_stop_gone = (
+                self._pre_stop_group is None or self._pre_stop_group.ensure_absent()
+            )
         except Exception:
             logger.exception("pre-stop cleanup failed for replica %s", self.name)
-            self._pre_stop_outcome = _HookOutcome.FELL_BACK
-            hook_absent = False
-
-        model_absent = self._model_group.ensure_absent()
-
-        # The post-stop verifier is meaningful only once the model group is
-        # gone, so it is gated on that authoritative absence.
-        post_ready = True
-        if model_absent:
-            post_ready = self._verify_post_stop()
-
-        if hook_absent and model_absent and post_ready:
-            self._teardown_complete = True
-            self._close_log_handles()
-            self._health_client.close()
-            return
-
-        self._raise_incomplete(hook_absent, model_absent, post_ready)
-
-    def _raise_incomplete(
-        self, hook_absent: bool, model_absent: bool, post_ready: bool
-    ) -> NoReturn:
-        """Record the surviving groups and raise a retryable teardown error."""
-        survivors = []
-        if not hook_absent:
+            pre_stop_gone = False
+        if not pre_stop_gone:
             survivors.append("pre-stop hook process group")
-        if not model_absent:
+
+        # 2. The GPU-bearing model group, driven to proven absence.
+        if not self._model_group.ensure_absent():
             survivors.append("model process group")
-        if not post_ready:
-            survivors.append("post-stop hook or verification")
-        message = (
-            f"Replica {self.name} teardown incomplete; still present: "
-            + ", ".join(survivors)
-        )
-        logger.error(message)
-        self.state_message = message
-        self._write_lifecycle_log(message)
-        raise ReplicaTeardownError(message)
+            return survivors  # post-stop is meaningless while the model lives
 
-    def _quiesce_pre_stop(self) -> bool:
-        """Stage 1: run the pre-stop hook once, or confirm a prior one is gone.
-
-        The cooperative hook runs at most once (on the first stop attempt);
-        every retry just proves any group it left is absent.
-        """
-        if not self._pre_stop_attempted:
-            self._pre_stop_outcome, absent = self._run_pre_stop_hook()
-            return absent
-        return self._pre_stop_group is None or self._pre_stop_group.ensure_absent()
-
-    def _verify_post_stop(self) -> bool:
-        """Stage 3: prove a clean post-stop verification, or fail retryably.
-
-        Any non-success outcome is retained as a stop failure even when fallback
-        cleanup removed the hook group, so a later attempt must rerun and obtain
-        an explicit successful verification.
-        """
-        self._post_stop_outcome, group_absent = self._run_post_stop_hook()
-        return self._post_stop_outcome is not _HookOutcome.FELL_BACK and group_absent
-
-    def _run_pre_stop_hook(self) -> tuple[_HookOutcome, bool]:
-        self._pre_stop_attempted = True
-        script_path = self._pre_stop_script_path
-        if script_path is None:
-            return _HookOutcome.NOT_CONFIGURED, True
-
-        timeout = self.launch_spec.pre_stop_timeout_sec
-        logger.info(
-            "running pre-stop hook for replica %s (timeout=%.1fs)", self.name, timeout
-        )
-        group, outcome, absent = self._execute_hook(
-            script_path, timeout, label="pre-stop"
-        )
-        self._pre_stop_group = group
-        return outcome, absent
-
-    def _run_post_stop_hook(self) -> tuple[_HookOutcome, bool]:
-        script_path = self._post_stop_script_path
-        if script_path is None:
-            return _HookOutcome.NOT_CONFIGURED, True
-        if self._post_stop_outcome is _HookOutcome.SUCCEEDED:
-            # Already verified on a prior attempt; only confirm the group is gone.
-            return _HookOutcome.SUCCEEDED, (
+        # 3. Post-stop verification: one clean hook run (exit 0, no
+        #    descendants) after the model is gone. Never start a new run while
+        #    a previous run's process group survives.
+        if self._post_stop_script_path is not None and not self._post_stop_ok:
+            prior_gone = (
                 self._post_stop_group is None or self._post_stop_group.ensure_absent()
             )
+            if prior_gone:
+                self._post_stop_attempts += 1
+                self._post_stop_group, self._post_stop_ok = self._run_hook(
+                    "post-stop",
+                    self._post_stop_script_path,
+                    self.launch_spec.post_stop_timeout_sec,
+                )
+                if not self._post_stop_ok and self._post_stop_group is not None:
+                    self._post_stop_group.ensure_absent()  # sweep leftovers now
+            if not self._post_stop_ok:
+                survivors.append("post-stop hook or verification")
 
-        # A prior failed attempt may still own descendants.  Never start a new
-        # verifier until that exact private process group is absent.
-        if (
-            self._post_stop_group is not None
-            and not self._post_stop_group.ensure_absent()
-        ):
-            return _HookOutcome.FELL_BACK, False
+        return survivors
 
-        self._post_stop_attempts += 1
-        timeout = self.launch_spec.post_stop_timeout_sec
-        logger.info(
-            "running post-stop hook for replica %s (attempt=%d, timeout=%.1fs)",
-            self.name,
-            self._post_stop_attempts,
-            timeout,
-        )
-        group, outcome, absent = self._execute_hook(
-            script_path, timeout, label="post-stop"
-        )
-        self._post_stop_group = group
-        return outcome, absent
+    def _run_hook(
+        self, label: str, script_path: Path, timeout: float
+    ) -> tuple[_ManagedGroup | None, bool]:
+        """Run a hook script in its own session and wait for it to finish.
 
-    def _execute_hook(
-        self,
-        script_path: Path,
-        timeout: float,
-        *,
-        label: str,
-    ) -> tuple[_ManagedGroup | None, _HookOutcome, bool]:
-        """Launch a hook in its own session, wait, and classify the outcome.
-
-        Returns ``(group, outcome, group_absent)``. ``group`` is ``None`` only
-        when the hook could not be started. A ``FELL_BACK`` outcome means the
-        bounded fallback cleanup already ran; ``group_absent`` then reports
-        whether that cleanup proved the whole hook group gone.
+        Returns ``(group, ok)``. ``ok`` means the hook exited 0 within
+        ``timeout`` and left no descendants in its process group -- the group
+        is then already proven absent. ``group`` is ``None`` only when the
+        hook could not be started; on failure the caller owns sweeping the
+        group with ``ensure_absent``.
         """
+        logger.info(
+            "running %s hook for replica %s (timeout=%.1fs)", label, self.name, timeout
+        )
         self._write_lifecycle_log(f"{label} hook started (timeout={timeout:.1f}s)")
         try:
             proc = subprocess.Popen(
@@ -667,7 +605,7 @@ class Replica:
         except Exception:
             logger.exception("failed to start %s hook for replica %s", label, self.name)
             self._write_lifecycle_log(f"{label} hook failed to start")
-            return None, _HookOutcome.FELL_BACK, True
+            return None, False
 
         group = _ManagedGroup(
             proc,
@@ -684,26 +622,25 @@ class Replica:
                 "%s hook for replica %s exceeded %.1fs", label, self.name, timeout
             )
             self._write_lifecycle_log(f"{label} hook timed out")
-            return group, _HookOutcome.FELL_BACK, group.ensure_absent()
+            return group, False
 
         if rc != 0:
             logger.error("%s hook for replica %s exited %d", label, self.name, rc)
             self._write_lifecycle_log(f"{label} hook exited {rc}")
-            # The leader is reaped, but it may have orphaned descendants in its
-            # private session. Absence of the whole group is the cleanup
-            # condition for every hook outcome.
-            return group, _HookOutcome.FELL_BACK, group.ensure_absent()
+            return group, False
 
         if group.alive():
+            # The leader exited 0 but orphaned descendants in its private
+            # session; the whole group must be gone for the hook to count.
             logger.error(
                 "%s hook for replica %s left descendant processes", label, self.name
             )
             self._write_lifecycle_log(f"{label} hook left descendant processes")
-            return group, _HookOutcome.FELL_BACK, group.ensure_absent()
+            return group, False
 
         logger.info("%s hook completed for replica %s", label, self.name)
         self._write_lifecycle_log(f"{label} hook completed")
-        return group, _HookOutcome.SUCCEEDED, True
+        return group, True
 
     def _write_lifecycle_log(self, message: str) -> None:
         try:

--- a/packages/pilot/first_pilot/replica.py
+++ b/packages/pilot/first_pilot/replica.py
@@ -24,6 +24,10 @@ from first_common.schema.types import (
 logger = logging.getLogger(__name__)
 
 
+class ReplicaTeardownError(RuntimeError):
+    """The bounded teardown attempt ended with a process group still present."""
+
+
 def tail_file(
     path: Path,
     num_lines: int = 200,
@@ -59,6 +63,8 @@ class Replica:
     _HEALTH_INTERVAL = 2.0
     _TERM_GRACE = 8.0
     _KILL_GRACE = 5.0
+    _HOOK_TERM_GRACE = 1.0
+    _HOOK_KILL_GRACE = 1.0
     _GROUP_POLL_INTERVAL = 0.2
 
     def __init__(
@@ -78,13 +84,31 @@ class Replica:
         self.log_path = workdir / "out.log"
 
         script_path = self.workdir / "serve.sh"
-        script_path.write_text(self._render_script())
+        script_path.write_text(
+            self._render_script(self.launch_spec.serve_script_template)
+        )
         script_path.chmod(0o755)
+
+        self._pre_stop_script_path: Path | None = None
+        if self.launch_spec.pre_stop_script_template is not None:
+            self._pre_stop_script_path = self.workdir / "pre-stop.sh"
+            self._pre_stop_script_path.write_text(
+                self._render_script(self.launch_spec.pre_stop_script_template)
+            )
+            self._pre_stop_script_path.chmod(0o700)
+
+        self._post_stop_script_path: Path | None = None
+        if self.launch_spec.post_stop_script_template is not None:
+            self._post_stop_script_path = self.workdir / "post-stop.sh"
+            self._post_stop_script_path.write_text(
+                self._render_script(self.launch_spec.post_stop_script_template)
+            )
+            self._post_stop_script_path.chmod(0o700)
 
         self._log_fh = open(self.log_path, "ab")
 
-        env = os.environ.copy()
-        env.update(self.launch_spec.env)
+        self._env = os.environ.copy()
+        self._env.update(self.launch_spec.env)
 
         logger.info(
             "starting replica %s on uds %s (workdir=%s)",
@@ -98,7 +122,7 @@ class Replica:
                 cwd=str(self.workdir),
                 stdout=self._log_fh,
                 stderr=subprocess.STDOUT,
-                env=env,
+                env=self._env,
                 start_new_session=True,
             )
         except Exception:
@@ -130,7 +154,21 @@ class Replica:
             logger.info("Replica health check disabled")
 
         self._teardown_lock = threading.Lock()
-        self._torn_down = False
+        self._stop_lock = threading.Lock()
+        self._teardown_started: bool = False
+        self._teardown_complete: bool = False
+        self._pre_stop_attempted: bool = False
+        self._pre_stop_proc: subprocess.Popen[bytes] | None = None
+        self._pre_stop_succeeded: bool | None = None
+        self._post_stop_proc: subprocess.Popen[bytes] | None = None
+        self._post_stop_succeeded: bool | None = None
+        self._post_stop_attempts = 0
+        self._model_teardown_attempts = 0
+        self._hook_cleanup_attempts = 0
+        self._post_hook_cleanup_attempts = 0
+        self._model_survivors: dict[int, int] | None = None
+        self._hook_survivors: dict[int, int] | None = None
+        self._post_hook_survivors: dict[int, int] | None = None
         self._monitor_exit = threading.Event()
         self._monitor = threading.Thread(
             target=self._monitor_loop,
@@ -139,7 +177,7 @@ class Replica:
         )
         self._monitor.start()
 
-    def _render_script(self) -> str:
+    def _render_script(self, template: str) -> str:
         spec = self.launch_spec
 
         gpus_by_host: dict[str, list[str]] = {}
@@ -161,7 +199,7 @@ class Replica:
         }
 
         env = Environment(undefined=StrictUndefined)
-        return env.from_string(spec.serve_script_template).render(**context)
+        return env.from_string(template).render(**context)
 
     def _check_health(self) -> HealthCheckResult:
         if not self._health_params.url:
@@ -182,18 +220,35 @@ class Replica:
         if self._unhealthy_since is None:
             return False
         elapsed = time.monotonic() - self._unhealthy_since
-        return elapsed > self.launch_spec.max_startup_sec
+        return elapsed > self._unhealthy_timeout_sec()
+
+    def _unhealthy_timeout_sec(self) -> int:
+        timeout = self.launch_spec.max_unhealthy_sec
+        return self.launch_spec.max_startup_sec if timeout is None else timeout
 
     def _monitor_loop(self) -> None:
         while not self._monitor_exit.wait(timeout=self._HEALTH_INTERVAL):
             try:
                 self._run_monitor_check()
+            except ReplicaTeardownError:
+                # The teardown path already recorded exact surviving groups in
+                # state_message and the lifecycle log.  Keep the Replica
+                # addressable so a later controller retry can finish cleanup.
+                logger.exception("teardown incomplete for replica %s", self.name)
+                if self.state != ReplicaState.terminating:
+                    self.state = ReplicaState.error
+                return
             except Exception:
                 logger.exception(
                     "uncaught exception in monitor thread for %s", self.name
                 )
                 self.state = ReplicaState.error
-                self._shutdown()
+                try:
+                    self._shutdown()
+                except ReplicaTeardownError:
+                    logger.exception(
+                        "fallback teardown incomplete for replica %s", self.name
+                    )
                 return
 
     def _run_monitor_check(self) -> None:
@@ -207,10 +262,11 @@ class Replica:
         self._advance_state(health)
 
     def _handle_process_exit(self, rc: int) -> None:
-        if self.state in (ReplicaState.terminating, ReplicaState.terminated):
-            self.state = ReplicaState.terminated
-            self.state_message = "Model replica has terminated."
-        else:
+        expected_stop = self.state in (
+            ReplicaState.terminating,
+            ReplicaState.terminated,
+        )
+        if not expected_stop:
             log = self.get_logs(num_lines=10)
             msg = (
                 f"Model replica {self.name} exited unexpectedly with code {rc}:\n{log}"
@@ -221,6 +277,9 @@ class Replica:
 
         # The leader is gone but may have left GPU-pinned children behind:
         self._shutdown()
+        if expected_stop:
+            self.state = ReplicaState.terminated
+            self.state_message = "Model replica has terminated."
 
     def _advance_state(self, health: HealthCheckResult) -> None:
         healthy = health == HealthCheckResult.healthy
@@ -256,7 +315,11 @@ class Replica:
                 self._unhealthy_since = None
             elif self._unhealthy_for_too_long():
                 log = self.get_logs(num_lines=10)
-                msg = f"replica {self.name} unhealthy for over max_startup_sec; tearing down:\n{log}"
+                timeout = self._unhealthy_timeout_sec()
+                msg = (
+                    f"replica {self.name} unhealthy for over {timeout}s; "
+                    f"tearing down:\n{log}"
+                )
                 logger.error(msg)
                 self.state_message = msg
                 self.state = ReplicaState.error
@@ -264,63 +327,512 @@ class Replica:
 
     def stop(self, timeout: float = 10.0) -> None:
         """
-        Terminate the process group, wait for the monitor to exit, then record
-        the terminal state.
-        """
-        logger.info("stopping replica %s", self.name)
-        self.state = ReplicaState.terminating
-        self._shutdown()
+        Cooperatively quiesce (when configured), terminate the process group,
+        wait for the monitor to exit, then record the terminal state.
 
-        # Join the monitor so nothing writes self.state after this point
-        if self._monitor.is_alive() and threading.current_thread() is not self._monitor:
-            self._monitor.join(timeout=timeout + 5)
-
-        self.state = ReplicaState.terminated
-
-    def _shutdown(self) -> None:
+        Calls are serialized and idempotent after authoritative completion. A
+        failed attempt leaves the Replica addressable and retryable; success is
+        reported only after both the hook and model process groups are absent.
         """
-        Idempotent teardown: kill the group, close logs, stop the monitor.  Safe
-        to call concurrently from the monitor thread and stop().
+        with self._stop_lock:
+            if self._is_teardown_complete():
+                return
+
+            logger.info("stopping replica %s", self.name)
+            self.state = ReplicaState.terminating
+            failure: ReplicaTeardownError | None = None
+            try:
+                self._shutdown(cooperative=True)
+            except ReplicaTeardownError as exc:
+                failure = exc
+
+            # Join the monitor so nothing writes self.state after this point.
+            if (
+                self._monitor.is_alive()
+                and threading.current_thread() is not self._monitor
+            ):
+                self._monitor.join(timeout=timeout + 5)
+
+            # A monitor that was already inside a check may have completed a
+            # second serialized teardown attempt while we joined it.
+            if not self._is_teardown_complete():
+                if failure is None:
+                    failure = ReplicaTeardownError(self.state_message)
+                raise failure
+
+            self.state = ReplicaState.terminated
+            if self._pre_stop_succeeded is True and self._post_stop_succeeded is True:
+                self.state_message = (
+                    "Model replica terminated after cooperative pre-stop and "
+                    "verified post-stop hooks."
+                )
+            elif self._post_stop_succeeded is True:
+                self.state_message = (
+                    "Model replica terminated after verified post-stop hook."
+                )
+            elif self._pre_stop_succeeded is True:
+                self.state_message = (
+                    "Model replica terminated after cooperative pre-stop hook."
+                )
+            elif self._pre_stop_succeeded is False:
+                self.state_message = (
+                    "Model replica terminated with process-group fallback after "
+                    "pre-stop hook failure."
+                )
+            else:
+                self.state_message = "Model replica has terminated."
+
+    def _is_teardown_complete(self) -> bool:
+        """Read mutable completion state without exposing a stale snapshot."""
+        return self._teardown_complete
+
+    def _shutdown(self, *, cooperative: bool = False) -> None:
         """
-        with self._teardown_lock:
-            if not self._torn_down:
-                self._torn_down = True
-                self._terminate_process_group()
-                self._close_log_handles()
+        Run one bounded teardown attempt.
+
+        Completion is latched only after both private process groups are absent;
+        once latched, their numeric PGIDs are never probed or signalled again.
+        Failed attempts retain the original Popen handles for a safe retry and
+        cannot be confused with a subsequently started Replica.
+        """
         self._monitor_exit.set()
+        with self._teardown_lock:
+            if self._teardown_complete:
+                return
 
-    def _terminate_process_group(self) -> None:
-        if not self._signal_group(signal.SIGTERM):
-            return  # group already empty
+            first_attempt = not self._teardown_started
+            self._teardown_started = True
+
+            try:
+                if cooperative and first_attempt and not self._pre_stop_attempted:
+                    (
+                        self._pre_stop_succeeded,
+                        hook_absent,
+                    ) = self._run_pre_stop_hook()
+                else:
+                    hook_absent = self._ensure_hook_group_absent()
+            except Exception:
+                logger.exception("pre-stop cleanup failed for replica %s", self.name)
+                self._pre_stop_succeeded = False
+                hook_absent = False
+
+            # The model fallback is independent of hook outcome: even a hook
+            # cleanup error must not prevent the GPU-bearing group from being
+            # driven through its own bounded TERM/KILL sequence.
+            try:
+                model_absent = self._terminate_process_group()
+            except Exception:
+                logger.exception("model cleanup failed for replica %s", self.name)
+                model_absent = False
+            post_stop_ready = True
+            if model_absent:
+                try:
+                    (
+                        self._post_stop_succeeded,
+                        post_stop_group_absent,
+                    ) = self._run_post_stop_hook()
+                    post_stop_ready = (
+                        self._post_stop_succeeded is not False
+                        and post_stop_group_absent
+                    )
+                except Exception:
+                    logger.exception(
+                        "post-stop verification failed for replica %s", self.name
+                    )
+                    self._post_stop_succeeded = False
+                    post_stop_ready = False
+
+            if hook_absent and model_absent and post_stop_ready:
+                self._teardown_complete = True
+                self._close_log_handles()
+                return
+
+            survivors = []
+            if not hook_absent:
+                survivors.append("pre-stop hook process group")
+            if not model_absent:
+                survivors.append("model process group")
+            if not post_stop_ready:
+                survivors.append("post-stop hook or verification")
+            message = (
+                f"Replica {self.name} teardown incomplete; still present: "
+                + ", ".join(survivors)
+            )
+            logger.error(message)
+            self.state_message = message
+            self._write_lifecycle_log(message)
+            raise ReplicaTeardownError(message)
+
+    def _run_pre_stop_hook(self) -> tuple[bool | None, bool]:
+        self._pre_stop_attempted = True
+        script_path = self._pre_stop_script_path
+        if script_path is None:
+            return None, True
+
+        timeout = self.launch_spec.pre_stop_timeout_sec
+        logger.info(
+            "running pre-stop hook for replica %s (timeout=%.1fs)",
+            self.name,
+            timeout,
+        )
+        self._write_lifecycle_log(f"pre-stop hook started (timeout={timeout:.1f}s)")
+        try:
+            hook = subprocess.Popen(
+                ["/bin/bash", str(script_path)],
+                cwd=str(self.workdir),
+                stdout=self._log_fh,
+                stderr=subprocess.STDOUT,
+                env=self._env,
+                start_new_session=True,
+            )
+        except Exception:
+            logger.exception("failed to start pre-stop hook for replica %s", self.name)
+            self._write_lifecycle_log("pre-stop hook failed to start; using fallback")
+            return False, True
+
+        self._pre_stop_proc = hook
+
+        try:
+            rc = hook.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            logger.error(
+                "pre-stop hook for replica %s exceeded %.1fs; using fallback",
+                self.name,
+                timeout,
+            )
+            self._write_lifecycle_log("pre-stop hook timed out; using fallback")
+            return False, self._terminate_hook_group(hook)
+
+        if rc != 0:
+            logger.error(
+                "pre-stop hook for replica %s exited %d; using fallback",
+                self.name,
+                rc,
+            )
+            self._write_lifecycle_log(f"pre-stop hook exited {rc}; using fallback")
+            # The leader is reaped, but it may have orphaned descendants in its
+            # private session. Absence of the whole hook process group is the
+            # cleanup condition for every hook outcome.
+            return False, self._terminate_hook_group(hook)
+
+        if self._process_group_alive(hook.pid):
+            logger.error(
+                "pre-stop hook for replica %s left descendant processes; "
+                "using fallback",
+                self.name,
+            )
+            self._write_lifecycle_log(
+                "pre-stop hook left descendant processes; using fallback"
+            )
+            return False, self._terminate_hook_group(hook)
+
+        logger.info("pre-stop hook completed for replica %s", self.name)
+        self._write_lifecycle_log("pre-stop hook completed")
+        return True, True
+
+    def _run_post_stop_hook(self) -> tuple[bool | None, bool]:
+        """Run cleanup verification after authoritative model-group absence.
+
+        The hook runs in its own private session.  Every non-success outcome is
+        retained as a stop failure even when fallback cleanup removes the hook
+        group, so a later controller attempt must rerun and obtain an explicit
+        successful verification result.
+        """
+        script_path = self._post_stop_script_path
+        if script_path is None:
+            return None, True
+        if self._post_stop_succeeded is True:
+            return True, self._ensure_post_stop_hook_group_absent()
+
+        # A prior failed attempt may still own descendants.  Never start a new
+        # verifier until that exact private process group is absent.
+        if not self._ensure_post_stop_hook_group_absent():
+            return False, False
+
+        self._post_stop_attempts += 1
+        timeout = self.launch_spec.post_stop_timeout_sec
+        logger.info(
+            "running post-stop hook for replica %s (attempt=%d, timeout=%.1fs)",
+            self.name,
+            self._post_stop_attempts,
+            timeout,
+        )
+        self._write_lifecycle_log(
+            "post-stop hook started "
+            f"(attempt={self._post_stop_attempts}, timeout={timeout:.1f}s)"
+        )
+        try:
+            hook = subprocess.Popen(
+                ["/bin/bash", str(script_path)],
+                cwd=str(self.workdir),
+                stdout=self._log_fh,
+                stderr=subprocess.STDOUT,
+                env=self._env,
+                start_new_session=True,
+            )
+        except Exception:
+            logger.exception("failed to start post-stop hook for replica %s", self.name)
+            self._write_lifecycle_log("post-stop hook failed to start")
+            return False, True
+
+        self._post_stop_proc = hook
+        try:
+            rc = hook.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            logger.error(
+                "post-stop hook for replica %s exceeded %.1fs",
+                self.name,
+                timeout,
+            )
+            self._write_lifecycle_log("post-stop hook timed out")
+            return False, self._terminate_post_stop_hook_group(hook)
+
+        if rc != 0:
+            logger.error(
+                "post-stop hook for replica %s exited %d",
+                self.name,
+                rc,
+            )
+            self._write_lifecycle_log(f"post-stop hook exited {rc}")
+            return False, self._terminate_post_stop_hook_group(hook)
+
+        if self._process_group_alive(hook.pid):
+            logger.error(
+                "post-stop hook for replica %s left descendant processes",
+                self.name,
+            )
+            self._write_lifecycle_log("post-stop hook left descendant processes")
+            return False, self._terminate_post_stop_hook_group(hook)
+
+        logger.info("post-stop hook completed for replica %s", self.name)
+        self._write_lifecycle_log("post-stop hook completed")
+        return True, True
+
+    def _ensure_hook_group_absent(self) -> bool:
+        hook = self._pre_stop_proc
+        if hook is None or not self._process_group_alive(hook.pid):
+            return True
+        return self._terminate_hook_group(hook)
+
+    def _terminate_hook_group(self, hook: subprocess.Popen[bytes]) -> bool:
+        """Bound cleanup of a pre-stop hook group; return authoritative absence."""
+        retry = self._hook_cleanup_attempts > 0
+        self._hook_cleanup_attempts += 1
+        hook.poll()
+        if not self._process_group_alive(hook.pid):
+            return True
+        if retry and not self._retry_owns_process_group(
+            hook.pid,
+            hook,
+            self._hook_survivors,
+            label="pre-stop hook",
+        ):
+            return False
+        try:
+            os.killpg(hook.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        except PermissionError:
+            logger.error("permission denied signalling pre-stop hook group SIGTERM")
+        if self._wait_for_process_group_exit(hook.pid, hook, self._HOOK_TERM_GRACE):
+            return True
+        try:
+            os.killpg(hook.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        except PermissionError:
+            logger.error("permission denied signalling pre-stop hook group SIGKILL")
+        absent = self._wait_for_process_group_exit(
+            hook.pid, hook, self._HOOK_KILL_GRACE
+        )
+        if not absent:
+            logger.error("pre-stop hook process group survived SIGKILL")
+            self._hook_survivors = self._snapshot_process_group(hook.pid)
+        return absent
+
+    def _ensure_post_stop_hook_group_absent(self) -> bool:
+        hook = self._post_stop_proc
+        if hook is None or not self._process_group_alive(hook.pid):
+            return True
+        return self._terminate_post_stop_hook_group(hook)
+
+    def _terminate_post_stop_hook_group(self, hook: subprocess.Popen[bytes]) -> bool:
+        """Bound cleanup of a post-stop hook group; prove exact absence."""
+        retry = self._post_hook_cleanup_attempts > 0
+        self._post_hook_cleanup_attempts += 1
+        hook.poll()
+        if not self._process_group_alive(hook.pid):
+            return True
+        if retry and not self._retry_owns_process_group(
+            hook.pid,
+            hook,
+            self._post_hook_survivors,
+            label="post-stop hook",
+        ):
+            return False
+        try:
+            os.killpg(hook.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        except PermissionError:
+            logger.error("permission denied signalling post-stop hook group SIGTERM")
+        if self._wait_for_process_group_exit(hook.pid, hook, self._HOOK_TERM_GRACE):
+            return True
+        try:
+            os.killpg(hook.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        except PermissionError:
+            logger.error("permission denied signalling post-stop hook group SIGKILL")
+        absent = self._wait_for_process_group_exit(
+            hook.pid, hook, self._HOOK_KILL_GRACE
+        )
+        if not absent:
+            logger.error("post-stop hook process group survived SIGKILL")
+            self._post_hook_survivors = self._snapshot_process_group(hook.pid)
+        return absent
+
+    def _write_lifecycle_log(self, message: str) -> None:
+        try:
+            self._log_fh.write(f"[FIRST lifecycle] {message}\n".encode())
+            self._log_fh.flush()
+        except (OSError, ValueError):
+            logger.exception(
+                "could not write lifecycle marker for replica %s", self.name
+            )
+
+    def _terminate_process_group(self) -> bool:
+        """Bound TERM/KILL of the model group; return authoritative absence."""
+        retry = self._model_teardown_attempts > 0
+        self._model_teardown_attempts += 1
+        if not self._group_alive():
+            return True
+        if retry and not self._retry_owns_process_group(
+            self._pgid,
+            self.proc,
+            self._model_survivors,
+            label="model",
+        ):
+            return False
+
+        try:
+            os.killpg(self._pgid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        except PermissionError:
+            logger.error("permission denied signalling model group SIGTERM")
 
         if self._wait_for_group_exit(self._TERM_GRACE):
-            return
+            return True
 
         logger.warning(
             "replica %s still alive %.0fs after SIGTERM; escalating to SIGKILL",
             self.name,
             self._TERM_GRACE,
         )
-        if not self._signal_group(signal.SIGKILL):
-            return
-        if not self._wait_for_group_exit(self._KILL_GRACE):
-            logger.error("replica %s process group survived SIGKILL", self.name)
-
-    def _signal_group(self, sig: int) -> bool:
-        """Send `sig` to the whole process group. Returns False if empty."""
         try:
-            os.killpg(self._pgid, sig)
-            return True
+            os.killpg(self._pgid, signal.SIGKILL)
         except ProcessLookupError:
-            return False
+            pass
+        except PermissionError:
+            logger.error("permission denied signalling model group SIGKILL")
+        absent = self._wait_for_group_exit(self._KILL_GRACE)
+        if not absent:
+            logger.error("replica %s process group survived SIGKILL", self.name)
+            self._model_survivors = self._snapshot_process_group(self._pgid)
+        return absent
 
     def _group_alive(self) -> bool:
         """True if the process group still has at least one member."""
+        return self._process_group_alive(self._pgid)
+
+    @staticmethod
+    def _process_group_alive(pgid: int) -> bool:
+        """True if process group ``pgid`` still has at least one member."""
         try:
-            os.killpg(self._pgid, 0)  # signal 0 == existence probe
+            os.killpg(pgid, 0)  # signal 0 == existence probe
             return True
-        except (ProcessLookupError, PermissionError):
+        except ProcessLookupError:
             return False
+        except PermissionError:
+            # EPERM means the kernel found the group but denied the probe.  It
+            # is not evidence of absence; cleanup must remain fail-closed.
+            return True
+        except OSError:
+            logger.exception("process-group existence probe failed for pgid=%d", pgid)
+            return True
+
+    @staticmethod
+    def _snapshot_process_group(pgid: int) -> dict[int, int] | None:
+        """Return Linux ``pid -> starttime`` identities for one private session.
+
+        ``None`` means the procfs ownership check is unavailable.  An empty
+        mapping means no readable member currently has both pgrp and session
+        equal to the launch-time PGID.
+        """
+        try:
+            entries = list(Path("/proc").iterdir())
+        except OSError:
+            return None
+
+        members: dict[int, int] = {}
+        for entry in entries:
+            if not entry.name.isdecimal():
+                continue
+            try:
+                raw = (entry / "stat").read_text()
+                # comm (field 2) is parenthesized and may contain spaces or ')'.
+                fields = raw[raw.rfind(")") + 2 :].split()
+                pgrp = int(fields[2])  # field 5
+                session = int(fields[3])  # field 6
+                starttime = int(fields[19])  # field 22
+            except (OSError, ValueError, IndexError):
+                continue
+            if pgrp == pgid and session == pgid:
+                members[int(entry.name)] = starttime
+        return members
+
+    def _retry_owns_process_group(
+        self,
+        pgid: int,
+        leader: subprocess.Popen[bytes],
+        witnesses: dict[int, int] | None,
+        *,
+        label: str,
+    ) -> bool:
+        """Refuse a retry signal unless the numeric PGID is still ours.
+
+        PGIDs can be reused after a group disappears. A live original leader is
+        an ownership witness. Once that leader is gone, at least one surviving
+        ``(pid, /proc starttime)`` captured by the prior failed attempt must
+        still match. Ambiguity is retained as teardown failure rather than
+        risking a signal to an unrelated, reused group.
+        """
+        if leader.poll() is None:
+            try:
+                if os.getpgid(leader.pid) == pgid and os.getsid(leader.pid) == pgid:
+                    return True
+            except (ProcessLookupError, PermissionError):
+                pass
+
+        current = self._snapshot_process_group(pgid)
+        if (
+            current is not None
+            and witnesses
+            and any(
+                current.get(pid) == starttime for pid, starttime in witnesses.items()
+            )
+        ):
+            witnesses.update(current)
+            return True
+
+        logger.error(
+            "refusing retry signal for %s pgid=%d: original process-group "
+            "ownership cannot be proven",
+            label,
+            pgid,
+        )
+        return False
 
     def _wait_for_group_exit(self, timeout: float) -> bool:
         """
@@ -331,6 +843,19 @@ class Replica:
         while True:
             self.proc.poll()  # reap the leader so a zombie can't keep the group "alive"
             if not self._group_alive():
+                return True
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(self._GROUP_POLL_INTERVAL)
+
+    def _wait_for_process_group_exit(
+        self, pgid: int, leader: subprocess.Popen[bytes], timeout: float
+    ) -> bool:
+        """Bound wait for an auxiliary process group, reaping its leader."""
+        deadline = time.monotonic() + timeout
+        while True:
+            leader.poll()
+            if not self._process_group_alive(pgid):
                 return True
             if time.monotonic() >= deadline:
                 return False

--- a/packages/pilot/first_pilot/replica.py
+++ b/packages/pilot/first_pilot/replica.py
@@ -12,6 +12,7 @@ from urllib.parse import urlparse
 from httpx import Client, HTTPTransport
 from jinja2 import Environment, StrictUndefined
 
+from first_common.errors import ReplicaTeardownError
 from first_common.health import perform_health_check_sync
 from first_common.schema.types import (
     GpuClaim,
@@ -22,10 +23,6 @@ from first_common.schema.types import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-class ReplicaTeardownError(RuntimeError):
-    """Teardown attempt ended with a process group still present."""
 
 
 def _pgid_alive(pgid: int) -> bool:
@@ -78,18 +75,6 @@ class _ManagedGroup:
         """Drive the group to proven absence with a bounded TERM->KILL pass."""
         if not self.alive():
             return True
-
-        # There is an unavoidable check->act gap: we probe ``alive()`` and then
-        # ``killpg`` as two separate syscalls, and in between the group could
-        # empty and its pgid be freed. This is safe because Linux allocates pids
-        # cyclically -- a freed number is the *last* to be handed out again, only
-        # after the allocator wraps ``pid_max`` (millions of pids later). The
-        # number cannot be recycled to an unrelated process inside this
-        # microsecond window, so we never risk signalling the wrong group.
-        # TODO: an elevated risk may exist for a *long-lived* pgid that
-        # coexists in a ~40 day pilot job alongside neighboring models with frequent
-        # start/stop churn.  The neighbors could exhaust and cycle pid space leading to a
-        # collision and incorrectly targeted process when this one is killed.
 
         self._signal(signal.SIGTERM)
         if self._wait_for_exit(self._term_grace):
@@ -534,7 +519,7 @@ class Replica:
         try:
             if self._pre_stop_script_path is not None and not self._pre_stop_ran:
                 self._pre_stop_ran = True
-                self._pre_stop_group, self._pre_stop_ok = self._run_hook(
+                self._pre_stop_ok = self._run_hook(
                     "pre-stop",
                     self._pre_stop_script_path,
                     self.launch_spec.pre_stop_timeout_sec,
@@ -561,33 +546,35 @@ class Replica:
         #    descendants) after the model is gone. Never start a new run while
         #    a previous run's process group survives.
         if self._post_stop_script_path is not None and not self._post_stop_ok:
-            prior_gone = (
-                self._post_stop_group is None or self._post_stop_group.ensure_absent()
-            )
-            if prior_gone:
-                self._post_stop_attempts += 1
-                self._post_stop_group, self._post_stop_ok = self._run_hook(
-                    "post-stop",
-                    self._post_stop_script_path,
-                    self.launch_spec.post_stop_timeout_sec,
+            try:
+                prior_gone = (
+                    self._post_stop_group is None
+                    or self._post_stop_group.ensure_absent()
                 )
-                if not self._post_stop_ok and self._post_stop_group is not None:
-                    self._post_stop_group.ensure_absent()  # sweep leftovers now
+                if prior_gone:
+                    self._post_stop_attempts += 1
+                    self._post_stop_ok = self._run_hook(
+                        "post-stop",
+                        self._post_stop_script_path,
+                        self.launch_spec.post_stop_timeout_sec,
+                    )
+                    if not self._post_stop_ok and self._post_stop_group is not None:
+                        self._post_stop_group.ensure_absent()  # sweep leftovers now
+            except Exception:
+                logger.exception(
+                    "post-stop verification failed for replica %s", self.name
+                )
             if not self._post_stop_ok:
                 survivors.append("post-stop hook or verification")
 
         return survivors
 
-    def _run_hook(
-        self, label: str, script_path: Path, timeout: float
-    ) -> tuple[_ManagedGroup | None, bool]:
+    def _run_hook(self, label: str, script_path: Path, timeout: float) -> bool:
         """Run a hook script in its own session and wait for it to finish.
 
-        Returns ``(group, ok)``. ``ok`` means the hook exited 0 within
-        ``timeout`` and left no descendants in its process group -- the group
-        is then already proven absent. ``group`` is ``None`` only when the
-        hook could not be started; on failure the caller owns sweeping the
-        group with ``ensure_absent``.
+        The group is stored on the Replica immediately after launch, before any
+        wait or validation that can raise. ``True`` means the hook exited 0
+        within ``timeout`` and left no descendants in its process group.
         """
         logger.info(
             "running %s hook for replica %s (timeout=%.1fs)", label, self.name, timeout
@@ -605,7 +592,7 @@ class Replica:
         except Exception:
             logger.exception("failed to start %s hook for replica %s", label, self.name)
             self._write_lifecycle_log(f"{label} hook failed to start")
-            return None, False
+            return False
 
         group = _ManagedGroup(
             proc,
@@ -614,6 +601,10 @@ class Replica:
             kill_grace=self._HOOK_KILL_GRACE,
             poll_interval=self._GROUP_POLL_INTERVAL,
         )
+        if label == "pre-stop":
+            self._pre_stop_group = group
+        else:
+            self._post_stop_group = group
 
         try:
             rc = proc.wait(timeout=timeout)
@@ -622,12 +613,12 @@ class Replica:
                 "%s hook for replica %s exceeded %.1fs", label, self.name, timeout
             )
             self._write_lifecycle_log(f"{label} hook timed out")
-            return group, False
+            return False
 
         if rc != 0:
             logger.error("%s hook for replica %s exited %d", label, self.name, rc)
             self._write_lifecycle_log(f"{label} hook exited {rc}")
-            return group, False
+            return False
 
         if group.alive():
             # The leader exited 0 but orphaned descendants in its private
@@ -636,11 +627,11 @@ class Replica:
                 "%s hook for replica %s left descendant processes", label, self.name
             )
             self._write_lifecycle_log(f"{label} hook left descendant processes")
-            return group, False
+            return False
 
         logger.info("%s hook completed for replica %s", label, self.name)
         self._write_lifecycle_log(f"{label} hook completed")
-        return group, True
+        return True
 
     def _write_lifecycle_log(self, message: str) -> None:
         try:

--- a/packages/pilot/first_pilot/replica.py
+++ b/packages/pilot/first_pilot/replica.py
@@ -76,6 +76,18 @@ class _ManagedGroup:
         if not self.alive():
             return True
 
+        # There is an unavoidable check->act gap: we probe ``alive()`` and then
+        # ``killpg`` as two separate syscalls, and in between the group could
+        # empty and its pgid be freed. This is safe because Linux allocates pids
+        # cyclically -- a freed number is the *last* to be handed out again, only
+        # after the allocator wraps ``pid_max`` (millions of pids later). The
+        # number cannot be recycled to an unrelated process inside this
+        # microsecond window, so we never risk signalling the wrong group.
+        # TODO: an elevated risk may exist for a *long-lived* pgid that
+        # coexists in a ~40 day pilot job alongside neighboring models with frequent
+        # start/stop churn.  The neighbors could exhaust and cycle pid space leading to a
+        # collision and incorrectly targeted process when this one is killed.
+
         self._signal(signal.SIGTERM)
         if self._wait_for_exit(self._term_grace):
             return True

--- a/packages/pilot/first_pilot/replica_manager.py
+++ b/packages/pilot/first_pilot/replica_manager.py
@@ -447,15 +447,12 @@ class ReplicaManager:
         self,
         name: str,
         resources: list[GpuClaim],
-        *,
-        expected: Replica | ReservedSentinel,
     ) -> bool:
-        """Release only if ``name`` still refers to the exact owned object."""
-        # Caller must hold self._lock. The identity guard prevents a late
-        # concurrent stop from releasing a replacement Replica's claims.
-        if self._replicas.get(name) is not expected:
+        """Release resources only when the named entry is still present."""
+        # Caller must hold self._lock. A duplicate release is a no-op, which is
+        # important if another replica has since claimed the same GPUs.
+        if self._replicas.pop(name, None) is None:
             return False
-        del self._replicas[name]
         self._claimed.difference_update(self._flatten(resources))
         return True
 
@@ -510,7 +507,6 @@ class ReplicaManager:
                 self._release_locked(
                     replica.name,
                     resources,
-                    expected=_RESERVED,
                 )
             raise ReplicaStartError(f"Failed to start replica: {e}") from e
 
@@ -533,16 +529,16 @@ class ReplicaManager:
             released = self._release_locked(
                 replica_name,
                 replica.resources,
-                expected=replica,
             )
         if not released:
-            logger.info(
-                "Replica %s stopped, but its manager entry now has a different "
-                "identity; leaving the current entry untouched",
-                replica_name,
-            )
+            logger.info("Replica %s was already released", replica_name)
 
     def stop_all(self) -> None:
+        """Stop every registered replica within one bounded shutdown pass.
+
+        This is a shutdown-only operation. Its caller must quiesce concurrent
+        ``start_replica`` requests before invoking it.
+        """
         replicas = self.get_replicas()
         logger.info("stopping all %d replicas", len(replicas))
         if not replicas:
@@ -561,14 +557,12 @@ class ReplicaManager:
             try:
                 replica.stop()
                 # This also handles a completion after stop_all's deadline. If
-                # the manager remains live, resources are released promptly;
-                # if a replacement now owns the name, the identity guard makes
-                # the late completion harmless.
+                # the manager remains live, resources are released promptly. A
+                # duplicate release after the entry is gone is a no-op.
                 with self._lock:
                     self._release_locked(
                         replica.name,
                         replica.resources,
-                        expected=replica,
                     )
             except BaseException as exc:
                 errors[id(replica)] = exc
@@ -585,14 +579,7 @@ class ReplicaManager:
                 name=f"replica-stop-{replica.name}",
                 daemon=True,
             )
-            try:
-                worker.start()
-            except BaseException as exc:
-                errors[id(replica)] = exc
-                done_events[id(replica)].set()
-                logger.exception(
-                    "could not start stop_all worker for replica %s", replica.name
-                )
+            worker.start()
 
         deadline = time.monotonic() + self._STOP_JOIN_TIMEOUT
         for replica in replicas:

--- a/packages/pilot/first_pilot/replica_manager.py
+++ b/packages/pilot/first_pilot/replica_manager.py
@@ -6,6 +6,7 @@ import subprocess
 import threading
 import time
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/packages/pilot/first_pilot/replica_manager.py
+++ b/packages/pilot/first_pilot/replica_manager.py
@@ -4,8 +4,8 @@ import re
 import socket
 import subprocess
 import threading
+import time
 from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor, wait
 from enum import Enum
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -322,7 +322,10 @@ def discover_hosts(node_file_env: str) -> list[str]:
 
 
 class ReplicaManager:
-    _STOP_JOIN_TIMEOUT = 45.0
+    # Mirrors PilotControlClient.STOP_TIMEOUT: pre-stop, model TERM/KILL,
+    # post-stop verification, auxiliary-group cleanup, and monitor join are all
+    # bounded below this ceiling.
+    _STOP_JOIN_TIMEOUT = 120.0
 
     def __init__(self, config: PilotRuntimeConfig) -> None:
         self.config = config
@@ -439,10 +442,21 @@ class ReplicaManager:
         self._next_socket_id += 1
         return str(Path(self._socket_dir.name) / f"replica-{socket_id}.sock")
 
-    def _release_locked(self, name: str, resources: list[GpuClaim]) -> None:
-        # caller must hold self._lock
-        self._replicas.pop(name, None)
+    def _release_locked(
+        self,
+        name: str,
+        resources: list[GpuClaim],
+        *,
+        expected: Replica | ReservedSentinel,
+    ) -> bool:
+        """Release only if ``name`` still refers to the exact owned object."""
+        # Caller must hold self._lock. The identity guard prevents a late
+        # concurrent stop from releasing a replacement Replica's claims.
+        if self._replicas.get(name) is not expected:
+            return False
+        del self._replicas[name]
         self._claimed.difference_update(self._flatten(resources))
+        return True
 
     def start_replica(self, replica: ReplicaStartRequest) -> None:
         requested = self._validate_request(replica.name, replica.gpu_indices)
@@ -456,7 +470,7 @@ class ReplicaManager:
             for hostname, gpu_list in host_gpus.items()
         ]
 
-        # Short critical section: reserve name + GPUs + port atomically.
+        # Short critical section: reserve name + GPUs + socket identity atomically.
         with self._lock:
             if replica.name in self._replicas:
                 raise ReplicaAlreadyPlaced(
@@ -492,7 +506,11 @@ class ReplicaManager:
                 "failed to start replica %s; releasing reservation", replica.name
             )
             with self._lock:
-                self._release_locked(replica.name, resources)
+                self._release_locked(
+                    replica.name,
+                    resources,
+                    expected=_RESERVED,
+                )
             raise ReplicaStartError(f"Failed to start replica: {e}") from e
 
         with self._lock:
@@ -503,31 +521,104 @@ class ReplicaManager:
             replica = self._replicas.get(replica_name)
             if replica is None or replica is _RESERVED:
                 raise NotFound(f"Replica {replica_name!r} is not registered")
-            # Claim ownership of teardown by removing the entry now: a concurrent
-            # stop_replica/stop_all then sees it gone and won't call stop()
-            # twice.
-            del self._replicas[replica_name]
 
         logger.info("stopping replica %s", replica_name)
+        # Replica.stop serializes concurrent callers. Keep the object and its
+        # claims addressable until it reports authoritative process-group
+        # absence; an exception is intentionally retryable.
         replica.stop()
 
         with self._lock:
-            self._release_locked(replica_name, replica.resources)
+            released = self._release_locked(
+                replica_name,
+                replica.resources,
+                expected=replica,
+            )
+        if not released:
+            logger.info(
+                "Replica %s stopped, but its manager entry now has a different "
+                "identity; leaving the current entry untouched",
+                replica_name,
+            )
 
     def stop_all(self) -> None:
-
         replicas = self.get_replicas()
         logger.info("stopping all %d replicas", len(replicas))
+        if not replicas:
+            self._socket_dir.cleanup()
+            return
 
-        with ThreadPoolExecutor() as pool:
-            futs = [pool.submit(r.stop) for r in replicas]
-            wait(futs, timeout=self._STOP_JOIN_TIMEOUT)
-            pool.shutdown(wait=False, cancel_futures=True)
+        # ThreadPoolExecutor workers are registered for an unconditional join
+        # at interpreter exit, even after shutdown(wait=False).  A wedged
+        # Replica.stop would therefore keep the pilot process alive past this
+        # method's bound.  Explicit daemon workers preserve the outer deadline
+        # and cannot extend interpreter shutdown.
+        done_events = {id(replica): threading.Event() for replica in replicas}
+        errors: dict[int, BaseException] = {}
 
-        with self._lock:
-            for r in replicas:
-                self._release_locked(r.name, r.resources)
+        def stop_and_release(replica: Replica) -> None:
+            try:
+                replica.stop()
+                # This also handles a completion after stop_all's deadline. If
+                # the manager remains live, resources are released promptly;
+                # if a replacement now owns the name, the identity guard makes
+                # the late completion harmless.
+                with self._lock:
+                    self._release_locked(
+                        replica.name,
+                        replica.resources,
+                        expected=replica,
+                    )
+            except BaseException as exc:
+                errors[id(replica)] = exc
+                logger.exception(
+                    "stop_all teardown failed for replica %s", replica.name
+                )
+            finally:
+                done_events[id(replica)].set()
 
+        for replica in replicas:
+            worker = threading.Thread(
+                target=stop_and_release,
+                args=(replica,),
+                name=f"replica-stop-{replica.name}",
+                daemon=True,
+            )
+            try:
+                worker.start()
+            except BaseException as exc:
+                errors[id(replica)] = exc
+                done_events[id(replica)].set()
+                logger.exception(
+                    "could not start stop_all worker for replica %s", replica.name
+                )
+
+        deadline = time.monotonic() + self._STOP_JOIN_TIMEOUT
+        for replica in replicas:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            done_events[id(replica)].wait(timeout=remaining)
+
+        failures: list[str] = []
+        for replica in replicas:
+            done = done_events[id(replica)].is_set()
+            if done and (stop_error := errors.get(id(replica))) is not None:
+                failures.append(f"{replica.name}: {stop_error}")
+                continue
+            if not done:
+                logger.error(
+                    "stop_all timed out after %.1fs waiting for replica %s",
+                    self._STOP_JOIN_TIMEOUT,
+                    replica.name,
+                )
+                failures.append(f"{replica.name}: teardown timed out")
+
+        if failures:
+            raise RuntimeError(
+                "one or more replicas did not stop authoritatively: "
+                + "; ".join(sorted(failures))
+            )
         self._socket_dir.cleanup()
 
     def get_replicas(self) -> list[Replica]:

--- a/tests/test_pilot_control.py
+++ b/tests/test_pilot_control.py
@@ -1,9 +1,13 @@
 """Tests for PilotControlClient's built-in timeout/retry behavior."""
 
+from unittest.mock import MagicMock
+
 import httpx
 import pytest
 
+from first_common.errors import ReplicaTeardownError
 from first_gateway.services.pilot_control import PilotControlClient
+from first_pilot.control_api import app, get_manager
 
 
 def _make_client(handler: object) -> PilotControlClient:
@@ -99,3 +103,30 @@ async def test_4xx_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert resp.status_code == 409
     assert calls["n"] == 1
+
+
+async def test_pilot_api_returns_structured_teardown_error() -> None:
+    manager = MagicMock()
+    manager.stop_replica.side_effect = ReplicaTeardownError(
+        "Replica r0 teardown incomplete; still present: model process group"
+    )
+    app.dependency_overrides[get_manager] = lambda: manager
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://pilot",
+        ) as client:
+            response = await client.post("/stop-replica/r0")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "error": {
+            "code": "replica_teardown_incomplete",
+            "message": (
+                "Replica r0 teardown incomplete; still present: model process group"
+            ),
+            "info": {},
+        }
+    }

--- a/tests/test_pilot_replica_lifecycle.py
+++ b/tests/test_pilot_replica_lifecycle.py
@@ -284,7 +284,9 @@ def test_nonzero_pre_stop_uses_process_group_fallback(tmp_path: Path) -> None:
 
     assert replica.state == ReplicaState.terminated
     assert "process-group fallback" in replica.state_message
-    assert "pre-stop hook exited 7; using fallback" in replica.log_path.read_text()
+    lifecycle_log = replica.log_path.read_text()
+    assert "pre-stop hook exited 7" in lifecycle_log
+    assert "pre-stop hook failed; using process-group fallback" in lifecycle_log
     assert not replica._model_group.alive()
 
 
@@ -316,7 +318,9 @@ done
 
     assert replica.state == ReplicaState.terminated
     assert "process-group fallback" in replica.state_message
-    assert "pre-stop hook timed out; using fallback" in replica.log_path.read_text()
+    lifecycle_log = replica.log_path.read_text()
+    assert "pre-stop hook timed out" in lifecycle_log
+    assert "pre-stop hook failed; using process-group fallback" in lifecycle_log
     assert not replica._model_group.alive()
 
 
@@ -350,7 +354,9 @@ exit 0
 
     hook_pgid = int((replica.workdir / "hook-pgid").read_text())
     assert "process-group fallback" in replica.state_message
-    assert "left descendant processes; using fallback" in replica.log_path.read_text()
+    lifecycle_log = replica.log_path.read_text()
+    assert "left descendant processes" in lifecycle_log
+    assert "pre-stop hook failed; using process-group fallback" in lifecycle_log
     assert not _pgid_alive(hook_pgid)
     assert not replica._model_group.alive()
 

--- a/tests/test_pilot_replica_lifecycle.py
+++ b/tests/test_pilot_replica_lifecycle.py
@@ -1,5 +1,6 @@
 """Focused tests for cooperative replica quiesce and bounded fallback."""
 
+import time
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, call, patch
@@ -14,7 +15,12 @@ from first_common.schema.types import (
     ReplicaState,
 )
 from first_gateway.services.pilot_control import STOP_TIMEOUT
-from first_pilot.replica import Replica, ReplicaTeardownError
+from first_pilot.replica import (
+    Replica,
+    ReplicaTeardownError,
+    _ManagedGroup,
+    _pgid_alive,
+)
 from first_pilot.replica_manager import ReplicaManager
 
 _SERVE_UNTIL_TERM = """
@@ -76,11 +82,11 @@ def test_pre_stop_template_validation_and_unhealthy_deadline() -> None:
 
     explicit = Replica.__new__(Replica)
     explicit.launch_spec = _launch_spec(max_unhealthy_sec=7)
-    assert explicit._unhealthy_timeout_sec() == 7
+    assert explicit._unhealthy_timeout_sec == 7
 
     fallback = Replica.__new__(Replica)
     fallback.launch_spec = _launch_spec()
-    assert fallback._unhealthy_timeout_sec() == 30
+    assert fallback._unhealthy_timeout_sec == 30
 
 
 def test_stop_rpc_and_join_budgets_cover_sequential_hooks() -> None:
@@ -90,9 +96,9 @@ def test_stop_rpc_and_join_budgets_cover_sequential_hooks() -> None:
 
 def test_process_group_probe_is_fail_closed_on_permission_error() -> None:
     with patch("first_pilot.replica.os.killpg", side_effect=PermissionError):
-        assert Replica._process_group_alive(12345)
+        assert _pgid_alive(12345)
     with patch("first_pilot.replica.os.killpg", side_effect=ProcessLookupError):
-        assert not Replica._process_group_alive(12345)
+        assert not _pgid_alive(12345)
 
 
 def test_cooperative_pre_stop_renders_exact_allocation_and_is_idempotent(
@@ -121,7 +127,7 @@ printf '%s\n' '{{ replica_name }}|{{ gpus_by_host["node-a"] | join(",") }}|{{ en
     lifecycle_log = replica.log_path.read_text()
     assert lifecycle_log.count("pre-stop hook started") == 1
     assert lifecycle_log.count("pre-stop hook completed") == 1
-    assert not replica._group_alive()
+    assert not replica._model_group.alive()
 
 
 def test_post_stop_runs_only_after_model_absence_and_latches_success(
@@ -214,7 +220,7 @@ while true; do sleep 1; done
         with pytest.raises(ReplicaTeardownError, match="post-stop"):
             replica.stop(timeout=0.2)
         hook_pgid = int((replica.workdir / "post-hook-pgid").read_text())
-        assert not Replica._process_group_alive(hook_pgid)
+        assert not _pgid_alive(hook_pgid)
         assert not _teardown_complete(replica)
 
         replica._post_stop_script_path.write_text("exit 0\n")  # type: ignore[union-attr]
@@ -254,7 +260,7 @@ exit 0
         with pytest.raises(ReplicaTeardownError, match="post-stop"):
             replica.stop(timeout=0.2)
         old_pgid = int((replica.workdir / "post-descendant-pgid").read_text())
-        assert not Replica._process_group_alive(old_pgid)
+        assert not _pgid_alive(old_pgid)
 
         (replica.workdir / "retry-post-stop").touch()
         replica.stop(timeout=0.2)
@@ -279,7 +285,7 @@ def test_nonzero_pre_stop_uses_process_group_fallback(tmp_path: Path) -> None:
     assert replica.state == ReplicaState.terminated
     assert "process-group fallback" in replica.state_message
     assert "pre-stop hook exited 7; using fallback" in replica.log_path.read_text()
-    assert not replica._group_alive()
+    assert not replica._model_group.alive()
 
 
 def test_timed_out_pre_stop_kills_hook_tree_then_model_group(
@@ -311,7 +317,7 @@ done
     assert replica.state == ReplicaState.terminated
     assert "process-group fallback" in replica.state_message
     assert "pre-stop hook timed out; using fallback" in replica.log_path.read_text()
-    assert not replica._group_alive()
+    assert not replica._model_group.alive()
 
 
 def test_hook_leader_exit_cannot_leave_term_ignoring_child(
@@ -345,8 +351,8 @@ exit 0
     hook_pgid = int((replica.workdir / "hook-pgid").read_text())
     assert "process-group fallback" in replica.state_message
     assert "left descendant processes; using fallback" in replica.log_path.read_text()
-    assert not Replica._process_group_alive(hook_pgid)
-    assert not replica._group_alive()
+    assert not _pgid_alive(hook_pgid)
+    assert not replica._model_group.alive()
 
 
 def test_model_group_survival_is_not_success_and_stop_is_retryable(
@@ -354,7 +360,7 @@ def test_model_group_survival_is_not_success_and_stop_is_retryable(
 ) -> None:
     replica = _replica(tmp_path, _launch_spec())
     try:
-        with patch.object(replica, "_terminate_process_group", return_value=False):
+        with patch.object(replica._model_group, "ensure_absent", return_value=False):
             with pytest.raises(ReplicaTeardownError, match="model process group"):
                 replica.stop(timeout=0.2)
 
@@ -376,67 +382,77 @@ def test_model_group_survival_is_not_success_and_stop_is_retryable(
 
 def test_model_group_surviving_sigkill_returns_failure(tmp_path: Path) -> None:
     replica = _replica(tmp_path, _launch_spec())
+    group = replica._model_group
     try:
         with (
-            patch.object(replica, "_group_alive", return_value=True),
-            patch.object(
-                replica,
-                "_wait_for_group_exit",
-                side_effect=[False, False],
-            ),
+            patch.object(group, "alive", return_value=True),
+            patch.object(group, "_wait_for_exit", side_effect=[False, False]),
             patch("first_pilot.replica.os.killpg") as killpg,
         ):
-            assert not replica._terminate_process_group()
+            assert not group.ensure_absent()
 
         assert killpg.call_args_list == [
-            call(replica._pgid, 15),
-            call(replica._pgid, 9),
+            call(group.pgid, 15),
+            call(group.pgid, 9),
         ]
     finally:
         replica.stop(timeout=0.2)
 
 
 def test_permission_denied_hook_kill_is_retained_as_alive() -> None:
-    replica = Replica.__new__(Replica)
-    replica._GROUP_POLL_INTERVAL = 0.001
-    replica._HOOK_TERM_GRACE = 0.001
-    replica._HOOK_KILL_GRACE = 0.001
-    replica._hook_cleanup_attempts = 0
-    replica._hook_survivors = None
-    hook = MagicMock()
-    hook.pid = 12345
+    leader = MagicMock()
+    leader.pid = 12345
+    group = _ManagedGroup(
+        leader,
+        label="test hook",
+        term_grace=0.001,
+        kill_grace=0.001,
+        poll_interval=0.001,
+    )
 
     with (
-        patch.object(replica, "_process_group_alive", return_value=True),
-        patch.object(replica, "_wait_for_process_group_exit", return_value=False),
+        patch.object(group, "alive", return_value=True),
+        patch.object(group, "_wait_for_exit", return_value=False),
         patch("first_pilot.replica.os.killpg", side_effect=PermissionError) as killpg,
     ):
-        assert not replica._terminate_hook_group(hook)
+        assert not group.ensure_absent()
 
     assert killpg.call_args_list == [call(12345, 15), call(12345, 9)]
 
 
-def test_retry_refuses_signal_when_process_group_identity_changed() -> None:
-    replica = Replica.__new__(Replica)
-    leader = MagicMock()
-    leader.pid = 12345
-    leader.poll.return_value = 1
-
-    with (
-        patch.object(
-            replica,
-            "_snapshot_process_group",
-            return_value={45678: 222},
+def test_stop_is_the_only_teardown_path_monitor_only_records_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A crashed model parks in `error` via the monitor but is NOT swept until
+    the controller calls stop(); the leftover group is gone only afterwards."""
+    monkeypatch.setattr(Replica, "_HEALTH_INTERVAL", 0.02)
+    replica = _replica(
+        tmp_path,
+        _launch_spec(
+            serve_script_template="""
+printf '%s\n' "$$" > model-pgid
+(trap '' TERM HUP; while true; do sleep 1; done) &
+exit 3
+""",
         ),
-        patch("first_pilot.replica.os.getpgid") as getpgid,
-        patch("first_pilot.replica.os.getsid") as getsid,
-    ):
-        assert not replica._retry_owns_process_group(
-            12345,
-            leader,
-            {45678: 111},
-            label="model",
-        )
+    )
+    try:
+        # The monitor observes the unexpected exit and records error state, but
+        # the orphaned child keeps the model process group alive.
+        for _ in range(200):
+            if replica.state == ReplicaState.error:
+                break
+            time.sleep(0.02)
+        assert replica.state == ReplicaState.error
+        assert "exited unexpectedly with code 3" in replica.state_message
+        model_pgid = int((replica.workdir / "model-pgid").read_text())
+        assert _pgid_alive(model_pgid)
+        assert not _teardown_complete(replica)
 
-    getpgid.assert_not_called()
-    getsid.assert_not_called()
+        # Only the controller's stop() sweeps the surviving group.
+        replica.stop(timeout=0.2)
+        assert _teardown_complete(replica)
+        assert not _pgid_alive(model_pgid)
+    finally:
+        if not _teardown_complete(replica):
+            replica.stop(timeout=0.2)

--- a/tests/test_pilot_replica_lifecycle.py
+++ b/tests/test_pilot_replica_lifecycle.py
@@ -1,0 +1,442 @@
+"""Focused tests for cooperative replica quiesce and bounded fallback."""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+from pydantic import ValidationError
+
+from first_common.schema.types import (
+    GpuClaim,
+    HealthCheckParams,
+    PilotLaunchSpec,
+    ReplicaState,
+)
+from first_gateway.services.pilot_control import STOP_TIMEOUT
+from first_pilot.replica import Replica, ReplicaTeardownError
+from first_pilot.replica_manager import ReplicaManager
+
+_SERVE_UNTIL_TERM = """
+trap 'exit 0' TERM INT
+while true; do
+    sleep 0.1
+done
+"""
+
+
+def _launch_spec(**overrides: Any) -> PilotLaunchSpec:
+    values: dict[str, Any] = {
+        "served_model_name": "test-model",
+        "gpus_per_node": 2,
+        "num_nodes": 1,
+        "venv_path": "/immutable/venv",
+        "weights_path": "/immutable/weights",
+        "weights_cache_path": "/private/cache",
+        "env": {"OFFLINE_ONLY": "1"},
+        "serve_script_template": _SERVE_UNTIL_TERM,
+        "max_startup_sec": 30,
+        "health_check": HealthCheckParams(url=""),
+    }
+    values.update(overrides)
+    return PilotLaunchSpec.model_validate(values)
+
+
+def _replica(tmp_path: Path, spec: PilotLaunchSpec) -> Replica:
+    workdir = tmp_path / "replica"
+    workdir.mkdir()
+    return Replica(
+        name="deployment/replica/one",
+        uds=str(tmp_path / "replica.sock"),
+        resources=[GpuClaim(hostname="node-a", gpu_ids=["0", "1"])],
+        launch_spec=spec,
+        workdir=workdir,
+    )
+
+
+def _teardown_complete(replica: Replica) -> bool:
+    """Read without narrowing the mutable attribute across a stop() call."""
+    return replica._teardown_complete
+
+
+def _state(replica: Replica) -> ReplicaState:
+    """Read mutable state without narrowing it across a stop() call."""
+    return replica.state
+
+
+def test_pre_stop_template_validation_and_unhealthy_deadline() -> None:
+    with pytest.raises(ValidationError, match="unknown variables"):
+        _launch_spec(pre_stop_script_template="echo {{ not_in_context }}")
+    with pytest.raises(ValidationError, match="less than or equal to 25"):
+        _launch_spec(pre_stop_script_template="true", pre_stop_timeout_sec=26)
+    with pytest.raises(ValidationError, match="unknown variables"):
+        _launch_spec(post_stop_script_template="echo {{ not_in_context }}")
+    with pytest.raises(ValidationError, match="less than or equal to 50"):
+        _launch_spec(post_stop_script_template="true", post_stop_timeout_sec=51)
+
+    explicit = Replica.__new__(Replica)
+    explicit.launch_spec = _launch_spec(max_unhealthy_sec=7)
+    assert explicit._unhealthy_timeout_sec() == 7
+
+    fallback = Replica.__new__(Replica)
+    fallback.launch_spec = _launch_spec()
+    assert fallback._unhealthy_timeout_sec() == 30
+
+
+def test_stop_rpc_and_join_budgets_cover_sequential_hooks() -> None:
+    assert STOP_TIMEOUT.read == 120.0
+    assert ReplicaManager._STOP_JOIN_TIMEOUT == 120.0
+
+
+def test_process_group_probe_is_fail_closed_on_permission_error() -> None:
+    with patch("first_pilot.replica.os.killpg", side_effect=PermissionError):
+        assert Replica._process_group_alive(12345)
+    with patch("first_pilot.replica.os.killpg", side_effect=ProcessLookupError):
+        assert not Replica._process_group_alive(12345)
+
+
+def test_cooperative_pre_stop_renders_exact_allocation_and_is_idempotent(
+    tmp_path: Path,
+) -> None:
+    spec = _launch_spec(
+        pre_stop_script_template="""
+printf '%s\n' '{{ replica_name }}|{{ gpus_by_host["node-a"] | join(",") }}|{{ env["OFFLINE_ONLY"] }}' >> quiesced
+""",
+        pre_stop_timeout_sec=2,
+    )
+    replica = _replica(tmp_path, spec)
+    try:
+        replica.stop(timeout=0.2)
+        replica.stop(timeout=0.2)
+    finally:
+        replica.stop(timeout=0.2)
+
+    assert replica.state == ReplicaState.terminated
+    assert replica.state_message == (
+        "Model replica terminated after cooperative pre-stop hook."
+    )
+    assert (replica.workdir / "quiesced").read_text().splitlines() == [
+        "deployment/replica/one|0,1|1"
+    ]
+    lifecycle_log = replica.log_path.read_text()
+    assert lifecycle_log.count("pre-stop hook started") == 1
+    assert lifecycle_log.count("pre-stop hook completed") == 1
+    assert not replica._group_alive()
+
+
+def test_post_stop_runs_only_after_model_absence_and_latches_success(
+    tmp_path: Path,
+) -> None:
+    spec = _launch_spec(
+        serve_script_template="""
+printf '%s\n' "$$" > model-pgid
+trap 'exit 0' TERM INT
+while true; do sleep 0.1; done
+""",
+        post_stop_script_template="""
+model_pgid=$(cat model-pgid)
+if kill -0 -- "-$model_pgid" 2>/dev/null; then
+    exit 70
+fi
+printf '%s\n' verified >> post-stop-proof
+""",
+        post_stop_timeout_sec=2,
+    )
+    replica = _replica(tmp_path, spec)
+    try:
+        replica.stop(timeout=0.2)
+        replica.stop(timeout=0.2)
+    finally:
+        if not _teardown_complete(replica):
+            replica.stop(timeout=0.2)
+
+    assert replica.state == ReplicaState.terminated
+    assert replica.state_message == (
+        "Model replica terminated after verified post-stop hook."
+    )
+    assert (replica.workdir / "post-stop-proof").read_text().splitlines() == [
+        "verified"
+    ]
+    assert replica.log_path.read_text().count("post-stop hook completed") == 1
+
+
+def test_nonzero_post_stop_is_fail_closed_and_retryable(tmp_path: Path) -> None:
+    replica = _replica(
+        tmp_path,
+        _launch_spec(
+            post_stop_script_template="""
+if [ ! -e permit-post-stop ]; then
+    exit 7
+fi
+exit 0
+""",
+            post_stop_timeout_sec=2,
+        ),
+    )
+    try:
+        with pytest.raises(ReplicaTeardownError, match="post-stop"):
+            replica.stop(timeout=0.2)
+        assert not _teardown_complete(replica)
+        assert not replica._log_fh.closed
+        assert replica._post_stop_attempts == 1
+
+        (replica.workdir / "permit-post-stop").touch()
+        replica.stop(timeout=0.2)
+        assert _teardown_complete(replica)
+        assert replica._post_stop_attempts == 2
+        assert replica.state_message == (
+            "Model replica terminated after verified post-stop hook."
+        )
+    finally:
+        if not _teardown_complete(replica):
+            (replica.workdir / "permit-post-stop").touch()
+            replica.stop(timeout=0.2)
+
+
+def test_timed_out_post_stop_cleans_group_but_requires_new_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Replica, "_HOOK_TERM_GRACE", 0.05)
+    monkeypatch.setattr(Replica, "_HOOK_KILL_GRACE", 0.2)
+    monkeypatch.setattr(Replica, "_GROUP_POLL_INTERVAL", 0.01)
+    replica = _replica(
+        tmp_path,
+        _launch_spec(
+            post_stop_script_template="""
+printf '%s\n' "$$" > post-hook-pgid
+trap '' TERM
+while true; do sleep 1; done
+""",
+            post_stop_timeout_sec=0.3,
+        ),
+    )
+    try:
+        with pytest.raises(ReplicaTeardownError, match="post-stop"):
+            replica.stop(timeout=0.2)
+        hook_pgid = int((replica.workdir / "post-hook-pgid").read_text())
+        assert not Replica._process_group_alive(hook_pgid)
+        assert not _teardown_complete(replica)
+
+        replica._post_stop_script_path.write_text("exit 0\n")  # type: ignore[union-attr]
+        replica.stop(timeout=0.2)
+        assert replica._post_stop_attempts == 2
+    finally:
+        if not _teardown_complete(replica):
+            replica._post_stop_script_path.write_text("exit 0\n")  # type: ignore[union-attr]
+            replica.stop(timeout=0.2)
+
+
+def test_post_stop_descendant_is_removed_before_retry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Replica, "_HOOK_TERM_GRACE", 0.05)
+    monkeypatch.setattr(Replica, "_HOOK_KILL_GRACE", 0.2)
+    monkeypatch.setattr(Replica, "_GROUP_POLL_INTERVAL", 0.01)
+    replica = _replica(
+        tmp_path,
+        _launch_spec(
+            post_stop_script_template="""
+if [ ! -e retry-post-stop ]; then
+    printf '%s\n' "$$" > post-descendant-pgid
+    (trap '' TERM HUP; while true; do sleep 1; done) &
+    exit 0
+fi
+old_pgid=$(cat post-descendant-pgid)
+if kill -0 -- "-$old_pgid" 2>/dev/null; then
+    exit 71
+fi
+exit 0
+""",
+            post_stop_timeout_sec=2,
+        ),
+    )
+    try:
+        with pytest.raises(ReplicaTeardownError, match="post-stop"):
+            replica.stop(timeout=0.2)
+        old_pgid = int((replica.workdir / "post-descendant-pgid").read_text())
+        assert not Replica._process_group_alive(old_pgid)
+
+        (replica.workdir / "retry-post-stop").touch()
+        replica.stop(timeout=0.2)
+        assert _teardown_complete(replica)
+        assert replica._post_stop_attempts == 2
+    finally:
+        if not _teardown_complete(replica):
+            (replica.workdir / "retry-post-stop").touch()
+            replica.stop(timeout=0.2)
+
+
+def test_nonzero_pre_stop_uses_process_group_fallback(tmp_path: Path) -> None:
+    replica = _replica(
+        tmp_path,
+        _launch_spec(pre_stop_script_template="exit 7", pre_stop_timeout_sec=2),
+    )
+    try:
+        replica.stop(timeout=0.2)
+    finally:
+        replica.stop(timeout=0.2)
+
+    assert replica.state == ReplicaState.terminated
+    assert "process-group fallback" in replica.state_message
+    assert "pre-stop hook exited 7; using fallback" in replica.log_path.read_text()
+    assert not replica._group_alive()
+
+
+def test_timed_out_pre_stop_kills_hook_tree_then_model_group(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Replica, "_TERM_GRACE", 0.05)
+    monkeypatch.setattr(Replica, "_KILL_GRACE", 0.2)
+    monkeypatch.setattr(Replica, "_HOOK_TERM_GRACE", 0.05)
+    monkeypatch.setattr(Replica, "_HOOK_KILL_GRACE", 0.2)
+    monkeypatch.setattr(Replica, "_GROUP_POLL_INTERVAL", 0.01)
+
+    replica = _replica(
+        tmp_path,
+        _launch_spec(
+            pre_stop_script_template="""
+trap '' TERM
+while true; do
+    sleep 1
+done
+""",
+            pre_stop_timeout_sec=0.05,
+        ),
+    )
+    try:
+        replica.stop(timeout=0.2)
+    finally:
+        replica.stop(timeout=0.2)
+
+    assert replica.state == ReplicaState.terminated
+    assert "process-group fallback" in replica.state_message
+    assert "pre-stop hook timed out; using fallback" in replica.log_path.read_text()
+    assert not replica._group_alive()
+
+
+def test_hook_leader_exit_cannot_leave_term_ignoring_child(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(Replica, "_HOOK_TERM_GRACE", 0.05)
+    monkeypatch.setattr(Replica, "_HOOK_KILL_GRACE", 0.2)
+    monkeypatch.setattr(Replica, "_GROUP_POLL_INTERVAL", 0.01)
+
+    replica = _replica(
+        tmp_path,
+        _launch_spec(
+            pre_stop_script_template="""
+printf '%s\n' "$$" > hook-pgid
+(
+    trap '' TERM HUP
+    while true; do
+        sleep 1
+    done
+) &
+exit 0
+""",
+            pre_stop_timeout_sec=2,
+        ),
+    )
+    try:
+        replica.stop(timeout=0.2)
+    finally:
+        replica.stop(timeout=0.2)
+
+    hook_pgid = int((replica.workdir / "hook-pgid").read_text())
+    assert "process-group fallback" in replica.state_message
+    assert "left descendant processes; using fallback" in replica.log_path.read_text()
+    assert not Replica._process_group_alive(hook_pgid)
+    assert not replica._group_alive()
+
+
+def test_model_group_survival_is_not_success_and_stop_is_retryable(
+    tmp_path: Path,
+) -> None:
+    replica = _replica(tmp_path, _launch_spec())
+    try:
+        with patch.object(replica, "_terminate_process_group", return_value=False):
+            with pytest.raises(ReplicaTeardownError, match="model process group"):
+                replica.stop(timeout=0.2)
+
+        assert _state(replica) == ReplicaState.terminating
+        assert not _teardown_complete(replica)
+        assert not replica._log_fh.closed
+        assert replica.proc.poll() is None
+
+        # A later controller retry uses the same Replica/PGID and can complete
+        # authoritatively; the cooperative hook is never rerun.
+        replica.stop(timeout=0.2)
+        assert _teardown_complete(replica)
+        assert _state(replica) == ReplicaState.terminated
+        assert replica._log_fh.closed
+    finally:
+        if not _teardown_complete(replica):
+            replica.stop(timeout=0.2)
+
+
+def test_model_group_surviving_sigkill_returns_failure(tmp_path: Path) -> None:
+    replica = _replica(tmp_path, _launch_spec())
+    try:
+        with (
+            patch.object(replica, "_group_alive", return_value=True),
+            patch.object(
+                replica,
+                "_wait_for_group_exit",
+                side_effect=[False, False],
+            ),
+            patch("first_pilot.replica.os.killpg") as killpg,
+        ):
+            assert not replica._terminate_process_group()
+
+        assert killpg.call_args_list == [
+            call(replica._pgid, 15),
+            call(replica._pgid, 9),
+        ]
+    finally:
+        replica.stop(timeout=0.2)
+
+
+def test_permission_denied_hook_kill_is_retained_as_alive() -> None:
+    replica = Replica.__new__(Replica)
+    replica._GROUP_POLL_INTERVAL = 0.001
+    replica._HOOK_TERM_GRACE = 0.001
+    replica._HOOK_KILL_GRACE = 0.001
+    replica._hook_cleanup_attempts = 0
+    replica._hook_survivors = None
+    hook = MagicMock()
+    hook.pid = 12345
+
+    with (
+        patch.object(replica, "_process_group_alive", return_value=True),
+        patch.object(replica, "_wait_for_process_group_exit", return_value=False),
+        patch("first_pilot.replica.os.killpg", side_effect=PermissionError) as killpg,
+    ):
+        assert not replica._terminate_hook_group(hook)
+
+    assert killpg.call_args_list == [call(12345, 15), call(12345, 9)]
+
+
+def test_retry_refuses_signal_when_process_group_identity_changed() -> None:
+    replica = Replica.__new__(Replica)
+    leader = MagicMock()
+    leader.pid = 12345
+    leader.poll.return_value = 1
+
+    with (
+        patch.object(
+            replica,
+            "_snapshot_process_group",
+            return_value={45678: 222},
+        ),
+        patch("first_pilot.replica.os.getpgid") as getpgid,
+        patch("first_pilot.replica.os.getsid") as getsid,
+    ):
+        assert not replica._retry_owns_process_group(
+            12345,
+            leader,
+            {45678: 111},
+            label="model",
+        )
+
+    getpgid.assert_not_called()
+    getsid.assert_not_called()

--- a/tests/test_pilot_replica_lifecycle.py
+++ b/tests/test_pilot_replica_lifecycle.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 from pydantic import ValidationError
 
+from first_common.errors import ReplicaTeardownError
 from first_common.schema.types import (
     GpuClaim,
     HealthCheckParams,
@@ -17,7 +18,6 @@ from first_common.schema.types import (
 from first_gateway.services.pilot_control import STOP_TIMEOUT
 from first_pilot.replica import (
     Replica,
-    ReplicaTeardownError,
     _ManagedGroup,
     _pgid_alive,
 )
@@ -322,6 +322,63 @@ done
     assert "pre-stop hook timed out" in lifecycle_log
     assert "pre-stop hook failed; using process-group fallback" in lifecycle_log
     assert not replica._model_group.alive()
+
+
+def test_pre_stop_group_is_owned_when_wait_raises_after_launch(tmp_path: Path) -> None:
+    replica = _replica(
+        tmp_path,
+        _launch_spec(pre_stop_script_template="true", pre_stop_timeout_sec=2),
+    )
+    hook = MagicMock()
+    hook.pid = 2_000_000_000
+    hook.wait.side_effect = RuntimeError("injected failure after hook launch")
+    hook.poll.return_value = 1
+
+    try:
+        with patch("first_pilot.replica.subprocess.Popen", return_value=hook) as popen:
+            with pytest.raises(ReplicaTeardownError, match="pre-stop hook"):
+                replica.stop(timeout=0.2)
+
+            assert replica._pre_stop_group is not None
+            assert replica._pre_stop_group.pgid == hook.pid
+
+            # The retained group is swept on retry; the cooperative hook is not
+            # launched a second time.
+            replica.stop(timeout=0.2)
+            popen.assert_called_once()
+    finally:
+        if not _teardown_complete(replica):
+            replica.stop(timeout=0.2)
+
+
+def test_retry_does_not_relaunch_post_stop_while_prior_group_survives(
+    tmp_path: Path,
+) -> None:
+    replica = _replica(
+        tmp_path,
+        _launch_spec(post_stop_script_template="true", post_stop_timeout_sec=2),
+    )
+    hook = MagicMock()
+    hook.pid = 2_000_000_000
+    hook.wait.side_effect = RuntimeError("injected failure after hook launch")
+    hook.poll.return_value = 1
+
+    try:
+        with patch("first_pilot.replica.subprocess.Popen", return_value=hook) as popen:
+            with pytest.raises(ReplicaTeardownError, match="post-stop"):
+                replica.stop(timeout=0.2)
+
+            group = replica._post_stop_group
+            assert group is not None
+            with patch.object(group, "ensure_absent", return_value=False):
+                with pytest.raises(ReplicaTeardownError, match="post-stop"):
+                    replica.stop(timeout=0.2)
+
+            popen.assert_called_once()
+            assert replica._post_stop_attempts == 1
+    finally:
+        if not _teardown_complete(replica):
+            replica.stop(timeout=0.2)
 
 
 def test_hook_leader_exit_cannot_leave_term_ignoring_child(

--- a/tests/test_pilot_replica_manager_lifecycle.py
+++ b/tests/test_pilot_replica_manager_lifecycle.py
@@ -9,9 +9,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from first_common.errors import NotFound
+from first_common.errors import NotFound, ReplicaTeardownError
 from first_common.schema.types import GpuClaim
-from first_pilot.replica import Replica, ReplicaTeardownError
+from first_pilot.replica import Replica
 from first_pilot.replica_manager import ReplicaManager
 
 
@@ -49,70 +49,23 @@ def test_failed_stop_retains_claims_for_retry() -> None:
     assert manager._claimed == set()
 
 
-class _SerializedReplica:
-    def __init__(self, name: str, gpu: str) -> None:
-        self.name = name
-        self.resources = [GpuClaim(hostname="node", gpu_ids=[gpu])]
-        self._stop_lock = threading.Lock()
-        self._attempt_lock = threading.Lock()
-        self._attempts = 0
-        self.first_inside = threading.Event()
-        self.second_attempted = threading.Event()
-        self.second_inside = threading.Event()
-        self.allow_first = threading.Event()
-        self.allow_second = threading.Event()
+def test_late_duplicate_release_does_not_clear_another_replicas_claim() -> None:
+    replica_a, _ = _mock_replica("replica-a", "0")
+    manager = _manager(replica_a)
 
-    def stop(self) -> None:
-        with self._attempt_lock:
-            self._attempts += 1
-            attempt = self._attempts
-            if attempt == 2:
-                self.second_attempted.set()
+    manager.stop_replica("replica-a")
+    assert manager._claimed == set()
 
-        with self._stop_lock:
-            if attempt == 1:
-                self.first_inside.set()
-                assert self.allow_first.wait(timeout=2)
-            else:
-                self.second_inside.set()
-                assert self.allow_second.wait(timeout=2)
-
-
-def test_late_concurrent_stop_cannot_release_replacement_identity() -> None:
-    old_impl = _SerializedReplica("replica", "0")
-    old = cast(Replica, old_impl)
-    manager = _manager(old)
-    errors: list[BaseException] = []
-
-    def stop() -> None:
-        try:
-            manager.stop_replica("replica")
-        except BaseException as exc:  # pragma: no cover - asserted below
-            errors.append(exc)
-
-    first = threading.Thread(target=stop)
-    second = threading.Thread(target=stop)
-    first.start()
-    assert old_impl.first_inside.wait(timeout=2)
-    second.start()
-    assert old_impl.second_attempted.wait(timeout=2)
-
-    old_impl.allow_first.set()
-    first.join(timeout=2)
-    assert not first.is_alive()
-    assert old_impl.second_inside.wait(timeout=2)
-
-    replacement_impl = _SerializedReplica("replica", "0")
-    replacement = cast(Replica, replacement_impl)
+    replica_b, _ = _mock_replica("replica-b", "0")
     with manager._lock:
-        manager._replicas[replacement.name] = replacement
-        manager._claimed.update(manager._flatten(replacement.resources))
+        manager._replicas[replica_b.name] = replica_b
+        manager._claimed.update(manager._flatten(replica_b.resources))
 
-    old_impl.allow_second.set()
-    second.join(timeout=2)
-    assert not second.is_alive()
-    assert errors == []
-    assert manager.get_replica("replica") is replacement
+        # A late duplicate completion for A must not clear GPU 0, which B now
+        # owns under a different unique replica name.
+        assert not manager._release_locked("replica-a", replica_a.resources)
+
+    assert manager.get_replica("replica-b") is replica_b
     assert manager._claimed == {("node", "0")}
 
 

--- a/tests/test_pilot_replica_manager_lifecycle.py
+++ b/tests/test_pilot_replica_manager_lifecycle.py
@@ -1,0 +1,210 @@
+"""Authoritative ReplicaManager release and bounded stop-all tests."""
+
+import subprocess
+import sys
+import threading
+import time
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from first_common.errors import NotFound
+from first_common.schema.types import GpuClaim
+from first_pilot.replica import Replica, ReplicaTeardownError
+from first_pilot.replica_manager import ReplicaManager
+
+
+def _mock_replica(name: str, gpu: str) -> tuple[Replica, MagicMock]:
+    mock = MagicMock(spec=Replica)
+    mock.name = name
+    mock.resources = [GpuClaim(hostname="node", gpu_ids=[gpu])]
+    return cast(Replica, mock), mock
+
+
+def _manager(*replicas: Replica) -> ReplicaManager:
+    manager = ReplicaManager.__new__(ReplicaManager)
+    manager._lock = threading.Lock()
+    manager._replicas = {replica.name: replica for replica in replicas}
+    manager._claimed = set()
+    for replica in replicas:
+        manager._claimed.update(manager._flatten(replica.resources))
+    return manager
+
+
+def test_failed_stop_retains_claims_for_retry() -> None:
+    replica, mock = _mock_replica("replica", "0")
+    mock.stop.side_effect = [ReplicaTeardownError("group survived"), None]
+    manager = _manager(replica)
+
+    with pytest.raises(ReplicaTeardownError, match="group survived"):
+        manager.stop_replica("replica")
+
+    assert manager.get_replica("replica") is replica
+    assert manager._claimed == {("node", "0")}
+
+    manager.stop_replica("replica")
+    with pytest.raises(NotFound):
+        manager.get_replica("replica")
+    assert manager._claimed == set()
+
+
+class _SerializedReplica:
+    def __init__(self, name: str, gpu: str) -> None:
+        self.name = name
+        self.resources = [GpuClaim(hostname="node", gpu_ids=[gpu])]
+        self._stop_lock = threading.Lock()
+        self._attempt_lock = threading.Lock()
+        self._attempts = 0
+        self.first_inside = threading.Event()
+        self.second_attempted = threading.Event()
+        self.second_inside = threading.Event()
+        self.allow_first = threading.Event()
+        self.allow_second = threading.Event()
+
+    def stop(self) -> None:
+        with self._attempt_lock:
+            self._attempts += 1
+            attempt = self._attempts
+            if attempt == 2:
+                self.second_attempted.set()
+
+        with self._stop_lock:
+            if attempt == 1:
+                self.first_inside.set()
+                assert self.allow_first.wait(timeout=2)
+            else:
+                self.second_inside.set()
+                assert self.allow_second.wait(timeout=2)
+
+
+def test_late_concurrent_stop_cannot_release_replacement_identity() -> None:
+    old_impl = _SerializedReplica("replica", "0")
+    old = cast(Replica, old_impl)
+    manager = _manager(old)
+    errors: list[BaseException] = []
+
+    def stop() -> None:
+        try:
+            manager.stop_replica("replica")
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    first = threading.Thread(target=stop)
+    second = threading.Thread(target=stop)
+    first.start()
+    assert old_impl.first_inside.wait(timeout=2)
+    second.start()
+    assert old_impl.second_attempted.wait(timeout=2)
+
+    old_impl.allow_first.set()
+    first.join(timeout=2)
+    assert not first.is_alive()
+    assert old_impl.second_inside.wait(timeout=2)
+
+    replacement_impl = _SerializedReplica("replica", "0")
+    replacement = cast(Replica, replacement_impl)
+    with manager._lock:
+        manager._replicas[replacement.name] = replacement
+        manager._claimed.update(manager._flatten(replacement.resources))
+
+    old_impl.allow_second.set()
+    second.join(timeout=2)
+    assert not second.is_alive()
+    assert errors == []
+    assert manager.get_replica("replica") is replacement
+    assert manager._claimed == {("node", "0")}
+
+
+def test_stop_all_is_bounded_and_releases_only_completed_replicas() -> None:
+    success, success_mock = _mock_replica("success", "0")
+    failure, failure_mock = _mock_replica("failure", "1")
+    blocked, blocked_mock = _mock_replica("blocked", "2")
+    failure_mock.stop.side_effect = ReplicaTeardownError("survived SIGKILL")
+
+    release_blocked = threading.Event()
+    blocked_done = threading.Event()
+
+    def block() -> None:
+        release_blocked.wait(timeout=2)
+        blocked_done.set()
+
+    blocked_mock.stop.side_effect = block
+    manager = _manager(success, failure, blocked)
+    manager._STOP_JOIN_TIMEOUT = 0.05
+
+    started = time.monotonic()
+    with pytest.raises(RuntimeError, match="did not stop authoritatively") as exc:
+        manager.stop_all()
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.5
+    assert "failure: survived SIGKILL" in str(exc.value)
+    assert "blocked: teardown timed out" in str(exc.value)
+    with pytest.raises(NotFound):
+        manager.get_replica("success")
+    assert manager.get_replica("failure") is failure
+    assert manager.get_replica("blocked") is blocked
+    assert manager._claimed == {("node", "1"), ("node", "2")}
+    success_mock.stop.assert_called_once_with()
+
+    # A timed-out daemon worker can still complete later while the manager is
+    # live. Its success releases only its own exact mapping and reservation.
+    release_blocked.set()
+    assert blocked_done.wait(timeout=2)
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        try:
+            manager.get_replica("blocked")
+        except NotFound:
+            break
+        time.sleep(0.01)
+    else:  # pragma: no cover - diagnostic failure branch
+        pytest.fail("late successful stop did not release the blocked replica")
+
+    assert manager.get_replica("failure") is failure
+    assert manager._claimed == {("node", "1")}
+
+
+def test_permanently_blocked_stop_does_not_hold_interpreter_exit() -> None:
+    script = """
+import threading
+
+from first_common.schema.types import GpuClaim
+from first_pilot.replica_manager import ReplicaManager
+
+
+class PermanentlyBlockedReplica:
+    name = "blocked"
+    resources = [GpuClaim(hostname="node", gpu_ids=["0"])]
+
+    def stop(self):
+        threading.Event().wait()
+
+
+replica = PermanentlyBlockedReplica()
+manager = ReplicaManager.__new__(ReplicaManager)
+manager._lock = threading.Lock()
+manager._replicas = {replica.name: replica}
+manager._claimed = {("node", "0")}
+manager._STOP_JOIN_TIMEOUT = 0.02
+
+try:
+    manager.stop_all()
+except RuntimeError:
+    pass
+else:
+    raise AssertionError("permanently blocked teardown reported success")
+
+print("bounded stop returned")
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == "bounded stop returned"

--- a/tests/test_replica_drainer.py
+++ b/tests/test_replica_drainer.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
+import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 _replica_counter = itertools.count()
@@ -50,7 +51,21 @@ def _not_found(request: httpx.Request) -> httpx.Response:
 
 def _server_error(request: httpx.Request) -> httpx.Response:
     """Handler simulating a transient manager failure."""
-    return httpx.Response(500)
+    return httpx.Response(500, text="pilot unavailable")
+
+
+def _teardown_incomplete(request: httpx.Request) -> httpx.Response:
+    """Handler simulating a structured teardown failure from the pilot."""
+    return httpx.Response(
+        409,
+        json={
+            "error": {
+                "code": "replica_teardown_incomplete",
+                "message": "model process group survived SIGKILL",
+                "info": {},
+            }
+        },
+    )
 
 
 def _make_controller(
@@ -71,6 +86,35 @@ def _make_controller(
     client._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
     ctrl.client = client
     return ctrl
+
+
+async def test_stop_on_manager_surfaces_structured_teardown_message() -> None:
+    ctrl = ReplicaDrainer.__new__(ReplicaDrainer)
+    client = PilotControlClient.__new__(PilotControlClient)
+    client._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(_teardown_incomplete)
+    )
+    ctrl.client = client
+    try:
+        with pytest.raises(
+            httpx.HTTPStatusError,
+            match="model process group survived SIGKILL",
+        ):
+            await ctrl._stop_on_manager(MANAGER_URL, "replica-a")
+    finally:
+        await client._client.aclose()
+
+
+async def test_stop_on_manager_uses_text_fallback_for_malformed_error() -> None:
+    ctrl = ReplicaDrainer.__new__(ReplicaDrainer)
+    client = PilotControlClient.__new__(PilotControlClient)
+    client._client = httpx.AsyncClient(transport=httpx.MockTransport(_server_error))
+    ctrl.client = client
+    try:
+        with pytest.raises(httpx.HTTPStatusError, match="pilot unavailable"):
+            await ctrl._stop_on_manager(MANAGER_URL, "replica-a")
+    finally:
+        await client._client.aclose()
 
 
 # ── Seed helpers ────────────────────────────────────────────────────────
@@ -437,16 +481,33 @@ async def test_reconcile_raises_on_manager_500(
         uid = await _insert_replica(sess, state=ReplicaState.launching)
 
     ctrl = _make_controller(db, _server_error)
-    try:
+    with pytest.raises(httpx.HTTPStatusError, match="pilot unavailable"):
         await ctrl.reconcile(uid)
-    except httpx.HTTPStatusError:
-        pass
-    else:
-        raise AssertionError("expected HTTPStatusError on 500")
 
     replica = await _get_replica(db, uid)
     assert replica.deleted_at is None
     assert replica.state == ReplicaState.launching.value
+
+
+async def test_reconcile_records_structured_teardown_message(
+    db: async_sessionmaker[AsyncSession],
+) -> None:
+    async with db.begin() as sess:
+        await _seed_parents(sess)
+        await _insert_deployment(sess)
+        await _insert_job(sess)
+        uid = await _insert_replica(sess, state=ReplicaState.launching)
+
+    ctrl = _make_controller(db, _teardown_incomplete)
+    await ctrl._reconcile_one(uid)
+
+    replica = await _get_replica(db, uid)
+    assert replica.deleted_at is None
+    assert replica.reconcile_failures == 1
+    assert replica.reconcile_last_error == (
+        "Pilot manager could not stop replica "
+        f"{replica.name}: model process group survived SIGKILL"
+    )
 
 
 # ── reconcile: ready eligibility gate ────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add bounded pre-stop and post-stop hooks.
- Report teardown success only after model and hook process groups are proven absent.
- Keep failed teardown attempts retryable while preventing signals to reused process-group IDs.
- Retain GPU claims until teardown succeeds.
- Bound stop-all and replica-stop execution.

## Why this is needed

A model leader can exit while child processes continue holding GPUs. Releasing claims at that point can place new work onto resources that are still occupied.

## Tests

- Replica lifecycle, manager lifecycle, and control suites passed
- 52 focused tests pass cumulatively through this stack
- Ruff, formatting, and MyPy passed