### PR TITLE
Verify pilot readiness and account pre-manager failures

### DIFF
--- a/packages/common/first_common/schema/base_scheduler.py
+++ b/packages/common/first_common/schema/base_scheduler.py
@@ -114,27 +114,12 @@ class SchedulerAdapter(ABC):
     @abstractmethod
     async def get_job_statuses(self) -> list[JobStatusInfo]:
         """
-        List job statuses from the scheduler [qstat]
+        List all active job statuses from the scheduler [qstat]
         """
 
+    @abstractmethod
     async def get_exact_job_status(self, job_id: str) -> JobStatusInfo | None:
-        """Return one job, returning None only if it is definitively absent.
-
-        Adapters with an authoritative exact-ID lookup should override this and
-        may return ``None`` only when that lookup explicitly proves absence.
-        The default returns an exact match from the job listing
-        but fails closed if it is omitted (for example by pagination).
-        """
-        matches = [
-            status for status in await self.get_job_statuses() if status.id == job_id
-        ]
-        if len(matches) == 1:
-            return matches[0]
-        if len(matches) > 1:
-            raise RuntimeError(f"scheduler returned duplicate exact job ID {job_id!r}")
-        raise RuntimeError(
-            f"scheduler adapter cannot prove exact job {job_id!r} is absent"
-        )
+        """Return one job, returning None only if it is definitively absent."""
 
     @abstractmethod
     async def terminate_job(self, job_id: str) -> None:

--- a/packages/gateway/first_gateway/controllers/workers/pilot_job_observer.py
+++ b/packages/gateway/first_gateway/controllers/workers/pilot_job_observer.py
@@ -125,11 +125,8 @@ class PilotJobObserver(Worker):
         for job in db_jobs:
             assert job.scheduler_job_id is not None
             status = statuses.get(job.scheduler_job_id)
-            if status is None and isinstance(submitter.adapter, GraphQLPBSAdapter):
+            if status is None:
                 # Bulk scheduler listings can be truncated or active-only.
-                # Absence is lifecycle evidence only when the adapter's exact-ID
-                # lookup explicitly proves it. Other adapters retain their
-                # existing missing-means-gone behavior.
                 status = await submitter.adapter.get_exact_job_status(
                     job.scheduler_job_id
                 )

--- a/packages/gateway/first_gateway/controllers/workers/pilot_job_observer.py
+++ b/packages/gateway/first_gateway/controllers/workers/pilot_job_observer.py
@@ -10,7 +10,6 @@ from first_common.schema.types import HealthCheckResult, PilotConfig, ReplicaSta
 from ...database.models import Cluster, PilotDeployment, PilotJob, PilotReplica
 from ...database.redis.pubsub import Channel
 from ...platforms.schedulers import build_scheduler
-from ...platforms.schedulers.graphql_pbs import GraphQLPBSAdapter
 from ...services.pilot_control import PilotControlClient
 from ...services.pilot_submitter import PilotSubmitter
 from ...settings import ClientState
@@ -269,22 +268,19 @@ class PilotJobObserver(Worker):
             except Exception:
                 logger.exception("Failed to read endpoint for job %s", job_name)
                 continue
-            if isinstance(submitter.adapter, GraphQLPBSAdapter):
-                # GraphQL exposes the allocated head-node IP as soon as PBS says
-                # the job is running.  It is only a candidate address: the pilot
-                # may still be validating its all-node GPU inventory (or may have
-                # failed before binding).  Do not wake the ReplicaLauncher until
-                # the mTLS control API has answered at least one /status request.
-                try:
-                    await self.client.get_status(addr.control_url)
-                except Exception as exc:
-                    logger.info(
-                        "GraphQL candidate endpoint for job %s is not ready at %s: %r",
-                        job_name,
-                        addr.control_url,
-                        exc,
-                    )
-                    continue
+
+            # Do not wake ReplicaLauncher until control API is live
+            try:
+                await self.client.get_status(addr.control_url)
+            except Exception as exc:
+                logger.info(
+                    "Job %s pilot manager is not ready at %s: %r",
+                    job_name,
+                    addr.control_url,
+                    exc,
+                )
+                continue
+
             logger.info(
                 "Discovered ready manager endpoint for job %s: %s",
                 job_name,

--- a/packages/gateway/first_gateway/controllers/workers/pilot_job_observer.py
+++ b/packages/gateway/first_gateway/controllers/workers/pilot_job_observer.py
@@ -160,61 +160,45 @@ class PilotJobObserver(Worker):
         await self._discover_endpoints(submitter, cluster_name)
 
     async def _update_job(self, db_job: PilotJob, status: JobStatusInfo | None) -> None:
-        if status is not None and (
-            status.state.value == db_job.scheduler_state
-            and status.started_at == db_job.time_started
-        ):
-            return
-
-        target_state = (
-            SchedulerJobState.gone.value if status is None else status.state.value
-        )
-        now = datetime.now(timezone.utc)
-
-        # Lock the row so a terminal transition and its launch-failure accounting
-        # are one atomic, exactly-once operation.  Multiple gateway observers (or
-        # an exiting -> gone transition) must not charge the same failed pilot
-        # allocation more than once.
         async with self.client_state.db_sessionmaker.begin() as sess:
-            job = await sess.scalar(
-                sa.select(PilotJob)
-                .where(PilotJob.uid == db_job.uid)
-                .with_for_update()
-                .execution_options(populate_existing=True)
-            )
-            if job is None:
+            current = await sess.get(PilotJob, db_job.uid)
+            if current is None:
                 return
 
-            previous_state = job.scheduler_state
-            pre_manager_failure = (
-                target_state in _TERMINAL_STATES
-                and previous_state not in _TERMINAL_STATES
-                and job.manager_url is None
-                and job.scheduled_deletion_at is None
-            )
+            prev_state = current.scheduler_state
 
-            job.scheduler_state = target_state
             if status is None:
-                job.scheduled_deletion_at = now
-                job.deleted_at = now
+                target_state = SchedulerJobState.gone.value
+                new_started = current.time_started
             else:
-                job.time_started = status.started_at
+                target_state = status.state.value
+                new_started = status.started_at
 
-            if pre_manager_failure:
-                await self._record_pre_manager_launch_failure(sess, job)
+            if prev_state == target_state and current.time_started == new_started:
+                return
 
-        if status is None:
-            logger.warning(
-                f"PilotJob {db_job.name}: {db_job.scheduler_job_id!r} is no longer in the scheduler. "
-                "Assuming gone; marking terminated."
+            charge = (
+                target_state in _TERMINAL_STATES
+                and prev_state not in _TERMINAL_STATES
+                and current.manager_url is None
+                and current.scheduled_deletion_at is None
             )
-        elif (
-            target_state != db_job.scheduler_state
-            or status.started_at != db_job.time_started
-        ):
-            logger.info(
-                f"PilotJob {db_job.name}: {db_job.scheduler_state} -> {target_state}"
-            )
+
+            current.scheduler_state = target_state
+            current.time_started = new_started
+            if status is None:
+                now = datetime.now(timezone.utc)
+                current.scheduled_deletion_at = now
+                current.deleted_at = now
+                logger.warning(
+                    f"PilotJob {current.name}: {current.scheduler_job_id!r} is no longer "
+                    "in the scheduler. Assuming gone; marking terminated."
+                )
+            else:
+                logger.info(f"PilotJob {current.name}: {prev_state} -> {target_state}")
+
+            if charge:
+                await self._record_pre_manager_launch_failure(sess, db_job)
 
     @staticmethod
     async def _record_pre_manager_launch_failure(
@@ -249,6 +233,7 @@ class PilotJobObserver(Worker):
             )
         )
         affected = result.rowcount  # type: ignore[attr-defined]
+
         if affected:
             logger.warning(
                 "PilotJob %s terminated before manager readiness; charged one "

--- a/packages/gateway/first_gateway/controllers/workers/pilot_job_observer.py
+++ b/packages/gateway/first_gateway/controllers/workers/pilot_job_observer.py
@@ -127,6 +127,9 @@ class PilotJobObserver(Worker):
             status = statuses.get(job.scheduler_job_id)
             if status is None:
                 # Bulk scheduler listings can be truncated or active-only.
+                logger.info(
+                    f"{job.scheduler_job_id} is missing in job status list; querying by exact job ID"
+                )
                 status = await submitter.adapter.get_exact_job_status(
                     job.scheduler_job_id
                 )

--- a/packages/gateway/first_gateway/controllers/workers/pilot_job_observer.py
+++ b/packages/gateway/first_gateway/controllers/workers/pilot_job_observer.py
@@ -125,10 +125,11 @@ class PilotJobObserver(Worker):
         for job in db_jobs:
             assert job.scheduler_job_id is not None
             status = statuses.get(job.scheduler_job_id)
-            if status is None:
+            if status is None and isinstance(submitter.adapter, GraphQLPBSAdapter):
                 # Bulk scheduler listings can be truncated or active-only.
                 # Absence is lifecycle evidence only when the adapter's exact-ID
-                # lookup explicitly proves it; conservative adapters raise.
+                # lookup explicitly proves it. Other adapters retain their
+                # existing missing-means-gone behavior.
                 status = await submitter.adapter.get_exact_job_status(
                     job.scheduler_job_id
                 )

--- a/packages/gateway/first_gateway/controllers/workers/pilot_job_observer.py
+++ b/packages/gateway/first_gateway/controllers/workers/pilot_job_observer.py
@@ -5,15 +5,21 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from first_common.schema.base_scheduler import JobStatusInfo, SchedulerJobState
-from first_common.schema.types import HealthCheckResult, PilotConfig
+from first_common.schema.types import HealthCheckResult, PilotConfig, ReplicaState
 
-from ...database.models import Cluster, PilotJob
+from ...database.models import Cluster, PilotDeployment, PilotJob, PilotReplica
 from ...database.redis.pubsub import Channel
 from ...platforms.schedulers import build_scheduler
+from ...platforms.schedulers.graphql_pbs import GraphQLPBSAdapter
+from ...services.pilot_control import PilotControlClient
 from ...services.pilot_submitter import PilotSubmitter
+from ...settings import ClientState
+from ..wakeup import WakeupDispatcher
 from ..worker import Worker
 
 logger = logging.getLogger(__name__)
+
+_TERMINAL_STATES = frozenset({SchedulerJobState.gone.value})
 
 
 class PilotJobObserver(Worker):
@@ -26,6 +32,26 @@ class PilotJobObserver(Worker):
     """
 
     poll_interval = 10.0
+
+    def __init__(
+        self,
+        name: str,
+        client_state: ClientState,
+        wakeup_dispatcher: WakeupDispatcher,
+        *,
+        restart_backoff: float = 1.0,
+        max_backoff: float = 30.0,
+        heartbeat_timeout: float = 120.0,
+    ) -> None:
+        super().__init__(
+            name,
+            client_state,
+            wakeup_dispatcher,
+            restart_backoff=restart_backoff,
+            max_backoff=max_backoff,
+            heartbeat_timeout=heartbeat_timeout,
+        )
+        self.client = PilotControlClient(client_state, cn="pilot-job-observer")
 
     async def run(self) -> None:
         hb = self.register_heartbeat("poll")
@@ -99,6 +125,13 @@ class PilotJobObserver(Worker):
         for job in db_jobs:
             assert job.scheduler_job_id is not None
             status = statuses.get(job.scheduler_job_id)
+            if status is None:
+                # Bulk scheduler listings can be truncated or active-only.
+                # Absence is lifecycle evidence only when the adapter's exact-ID
+                # lookup explicitly proves it; conservative adapters raise.
+                status = await submitter.adapter.get_exact_job_status(
+                    job.scheduler_job_id
+                )
             await self._update_job(job, status)
 
         now = datetime.now(timezone.utc)
@@ -111,6 +144,7 @@ class PilotJobObserver(Worker):
                 SchedulerJobState.queued,
                 SchedulerJobState.starting,
                 SchedulerJobState.running,
+                SchedulerJobState.exiting,
             )
         )
         orphan_job_ids = queued_steady - {db_job.scheduler_job_id for db_job in db_jobs}
@@ -125,49 +159,101 @@ class PilotJobObserver(Worker):
         await self._discover_endpoints(submitter, cluster_name)
 
     async def _update_job(self, db_job: PilotJob, status: JobStatusInfo | None) -> None:
+        if status is not None and (
+            status.state.value == db_job.scheduler_state
+            and status.started_at == db_job.time_started
+        ):
+            return
+
+        target_state = (
+            SchedulerJobState.gone.value if status is None else status.state.value
+        )
+        now = datetime.now(timezone.utc)
+
+        # Lock the row so a terminal transition and its launch-failure accounting
+        # are one atomic, exactly-once operation.  Multiple gateway observers (or
+        # an exiting -> gone transition) must not charge the same failed pilot
+        # allocation more than once.
+        async with self.client_state.db_sessionmaker.begin() as sess:
+            job = await sess.scalar(
+                sa.select(PilotJob)
+                .where(PilotJob.uid == db_job.uid)
+                .with_for_update()
+                .execution_options(populate_existing=True)
+            )
+            if job is None:
+                return
+
+            previous_state = job.scheduler_state
+            pre_manager_failure = (
+                target_state in _TERMINAL_STATES
+                and previous_state not in _TERMINAL_STATES
+                and job.manager_url is None
+                and job.scheduled_deletion_at is None
+            )
+
+            job.scheduler_state = target_state
+            if status is None:
+                job.scheduled_deletion_at = now
+                job.deleted_at = now
+            else:
+                job.time_started = status.started_at
+
+            if pre_manager_failure:
+                await self._record_pre_manager_launch_failure(sess, job)
+
         if status is None:
-            async with self.client_state.db_sessionmaker.begin() as sess:
-                await sess.execute(
-                    sa.update(PilotJob)
-                    .where(
-                        PilotJob.uid == db_job.uid,
-                        PilotJob.scheduler_state.is_distinct_from(
-                            SchedulerJobState.gone.value
-                        ),
-                    )
-                    .values(
-                        scheduler_state=SchedulerJobState.gone.value,
-                        scheduled_deletion_at=datetime.now(timezone.utc),
-                        deleted_at=datetime.now(timezone.utc),
-                    )
-                )
             logger.warning(
                 f"PilotJob {db_job.name}: {db_job.scheduler_job_id!r} is no longer in the scheduler. "
                 "Assuming gone; marking terminated."
             )
         elif (
-            status.state != db_job.scheduler_state
+            target_state != db_job.scheduler_state
             or status.started_at != db_job.time_started
         ):
-            async with self.client_state.db_sessionmaker.begin() as sess:
-                await sess.execute(
-                    sa.update(PilotJob)
-                    .where(
-                        PilotJob.uid == db_job.uid,
-                        sa.or_(
-                            PilotJob.scheduler_state.is_distinct_from(
-                                status.state.value
-                            ),
-                            PilotJob.time_started.is_distinct_from(status.started_at),
-                        ),
-                    )
-                    .values(
-                        scheduler_state=status.state.value,
-                        time_started=status.started_at,
-                    )
-                )
             logger.info(
-                f"PilotJob {db_job.name}: {db_job.scheduler_state} -> {status.state.value}"
+                f"PilotJob {db_job.name}: {db_job.scheduler_state} -> {target_state}"
+            )
+
+    @staticmethod
+    async def _record_pre_manager_launch_failure(
+        sess: AsyncSession, job: PilotJob
+    ) -> None:
+        """Charge each actively assigned deployment once for a dead pilot.
+
+        A PilotJob that reaches a scheduler terminal state before publishing its
+        manager endpoint never had an opportunity to launch its placed replicas.
+        Count the failed allocation against each distinct affected deployment so
+        ``max_consecutive_launch_failures`` bounds automatic replacements.  Rows
+        already draining are excluded: their allocation is being intentionally
+        retired, rather than replaced after a launch failure.
+        """
+        affected_deployments = (
+            sa.select(PilotReplica.pilot_deployment_name)
+            .where(
+                PilotReplica.pilot_job_name == job.name,
+                PilotReplica.state == ReplicaState.placed.value,
+                PilotReplica.scheduled_deletion_at.is_(None),
+                PilotReplica.deleted_at.is_(None),
+            )
+            .distinct()
+        )
+        result = await sess.execute(
+            sa.update(PilotDeployment)
+            .where(PilotDeployment.name.in_(affected_deployments))
+            .values(
+                consecutive_launch_failures=(
+                    PilotDeployment.consecutive_launch_failures + 1
+                )
+            )
+        )
+        affected = result.rowcount  # type: ignore[attr-defined]
+        if affected:
+            logger.warning(
+                "PilotJob %s terminated before manager readiness; charged one "
+                "launch failure to %d assigned deployment(s)",
+                job.name,
+                affected,
             )
 
     async def _discover_endpoints(
@@ -197,20 +283,40 @@ class PilotJobObserver(Worker):
             except Exception:
                 logger.exception("Failed to read endpoint for job %s", job_name)
                 continue
+            if isinstance(submitter.adapter, GraphQLPBSAdapter):
+                # GraphQL exposes the allocated head-node IP as soon as PBS says
+                # the job is running.  It is only a candidate address: the pilot
+                # may still be validating its all-node GPU inventory (or may have
+                # failed before binding).  Do not wake the ReplicaLauncher until
+                # the mTLS control API has answered at least one /status request.
+                try:
+                    await self.client.get_status(addr.control_url)
+                except Exception as exc:
+                    logger.info(
+                        "GraphQL candidate endpoint for job %s is not ready at %s: %r",
+                        job_name,
+                        addr.control_url,
+                        exc,
+                    )
+                    continue
             logger.info(
-                "Discovered manager endpoint for job %s: %s",
+                "Discovered ready manager endpoint for job %s: %s",
                 job_name,
                 addr.control_url,
             )
             async with self.client_state.db_sessionmaker.begin() as sess:
-                await sess.execute(
+                result = await sess.execute(
                     sa.update(PilotJob)
                     .where(
                         PilotJob.uid == actionable_by_name[job_name],
+                        PilotJob.scheduler_state == SchedulerJobState.running.value,
                         PilotJob.manager_url.is_(None),
                     )
                     .values(manager_url=addr.control_url)
                 )
+
+            if result.rowcount == 0:  # type: ignore[attr-defined]
+                continue
 
             await self.client_state.redis_pubsub.publish(
                 Channel.pilot_job_ready, job_name

--- a/packages/gateway/first_gateway/platforms/schedulers/globus_compute_functions.py
+++ b/packages/gateway/first_gateway/platforms/schedulers/globus_compute_functions.py
@@ -18,22 +18,30 @@ def qsub(args: list[str]) -> str:
     return p.stdout.strip()
 
 
-def qstat() -> dict[str, Any]:
+def qstat(job_id: str | None = None) -> dict[str, Any]:
     """
     Globus Compute Function to execute qstat and capture JSON Jobs output.
+    Lists all active jobs if job_id=None; otherwise retrieves one job.
     """
     import json
     import subprocess
 
+    if job_id is None:
+        args = ["qstat", "-fF", "JSON"]
+    else:
+        args = ["qstat", job_id, "-xfF", "JSON"]
+
     try:
         p = subprocess.run(
-            ["qstat", "-fF", "JSON"],
+            args,
             text=True,
             check=True,
             capture_output=True,
             timeout=15,
         )
     except subprocess.CalledProcessError as e:
+        if e.returncode == 153 and "Unknown Job Id" in e.stderr:
+            return {}
         raise RuntimeError(
             f"{e.cmd!r} failed (returncode {e.returncode}):\nStderr:\n{e.stderr.strip()}"
         ) from None

--- a/packages/gateway/first_gateway/platforms/schedulers/globus_compute_pbs.py
+++ b/packages/gateway/first_gateway/platforms/schedulers/globus_compute_pbs.py
@@ -193,6 +193,29 @@ class GlobusComputePBSAdapter(SchedulerAdapter):
             ) from None
         return _parse_qstat(raw)
 
+    async def get_exact_job_status(self, job_id: str) -> JobStatusInfo | None:
+        task_id = await asyncio.to_thread(
+            self.client.run,
+            job_id,
+            endpoint_id=self.endpoint_id,
+            function_id=self.func_ids["qstat"],
+        )
+        try:
+            raw: dict[str, Any] = await self._poll_for_result(task_id)
+        except TaskExecutionFailed as e:
+            raise RuntimeError(
+                f"GlobusCompute qstat failed:\n{e.remote_data}"
+            ) from None
+        jobs = _parse_qstat(raw)
+        if jobs:
+            job = jobs[0]
+            if job.id.partition(".")[0] != job_id.strip().partition(".")[0]:
+                raise AssertionError(
+                    f"qstat queried {job_id=!r} but returned {job.id=!r}"
+                )
+            return job
+        return None
+
     async def terminate_job(self, job_id: str) -> None:
         task_id = await asyncio.to_thread(
             self.client.run,

--- a/packages/gateway/first_gateway/services/pilot_control.py
+++ b/packages/gateway/first_gateway/services/pilot_control.py
@@ -28,6 +28,7 @@ DEFAULT_TIMEOUT = httpx.Timeout(connect=5.0, read=30.0, write=10.0, pool=5.0)
 # TERM/KILL process-group fallback (13s), a post-stop verifier (maximum 50s),
 # its cleanup (2s), and monitor join fit inside this bounded read deadline.
 STOP_TIMEOUT = httpx.Timeout(connect=5.0, read=120.0, write=10.0, pool=5.0)
+STATUS_TIMEOUT = httpx.Timeout(connect=5.0, read=5.0, write=3.0, pool=5.0)
 
 # Short retry to ride out ephemeral hiccups (a dropped connection, a manager
 # still binding its port, a momentary 503). A handful of quick attempts only;
@@ -112,7 +113,9 @@ class PilotControlClient:
         raise last_exc
 
     async def get_status(self, manager_url: str) -> PilotJobStatus:
-        resp = await self._request("GET", f"{manager_url}/status")
+        resp = await self._request(
+            "GET", f"{manager_url}/status", timeout=STATUS_TIMEOUT
+        )
         resp.raise_for_status()
         return PilotJobStatus.model_validate(resp.json())
 

--- a/tests/fixtures/local_scheduler.py
+++ b/tests/fixtures/local_scheduler.py
@@ -122,6 +122,12 @@ class LocalSchedulerAdapter(SchedulerAdapter):
             for name, t in self._jobs.items()
         ]
 
+    async def get_exact_job_status(self, job_id: str) -> JobStatusInfo | None:
+        for status in await self.get_job_statuses():
+            if status.id == job_id:
+                return status
+        return None
+
     async def terminate_job(self, job_id: str) -> None:
         for tracked in self._jobs.values():
             if str(tracked.proc.pid) == job_id:

--- a/tests/test_pilot_job_controller.py
+++ b/tests/test_pilot_job_controller.py
@@ -45,6 +45,9 @@ class FakeSchedulerAdapter(SchedulerAdapter):
     async def get_job_statuses(self) -> list[Any]:
         return []
 
+    async def get_exact_job_status(self, job_id: str) -> Any:
+        return None
+
     async def terminate_job(self, job_id: str) -> None:
         self.terminated.append(job_id)
 

--- a/tests/test_pilot_job_observer.py
+++ b/tests/test_pilot_job_observer.py
@@ -16,9 +16,13 @@ from first_common.schema.base_scheduler import (
     SchedulerJobState,
 )
 from first_common.schema.pilot import AddressInfo, PilotJobStatus, PilotResources
-from first_common.schema.types import HealthCheckResult, PilotConfig
+from first_common.schema.resources.runtime import AutoscalerModelRuntime, ModelRuntime
+from first_common.schema.types import HealthCheckResult, PilotConfig, ReplicaState
 from first_gateway.controllers.worker import Worker
+from first_gateway.controllers.workers.autoscaler import PilotAutoscaler
 from first_gateway.controllers.workers.pilot_job_observer import PilotJobObserver
+from first_gateway.controllers.workers.replica_placement import ReplicaPlacer
+from first_gateway.controllers.workers.replica_reconciler import ReplicaReconciler
 from first_gateway.database.models import (
     AccessGroup,
     Cluster,
@@ -639,6 +643,106 @@ async def test_pre_manager_terminal_jobs_count_once_per_assigned_deployment(
         assert dep_a.consecutive_launch_failures == 2
         assert dep_a.max_consecutive_launch_failures == 1
         assert dep_b.consecutive_launch_failures == 1
+
+
+async def test_autoscaler_latch_bounds_pre_manager_replacement_cycle(
+    db: async_sessionmaker[AsyncSession],
+) -> None:
+    """The real reconcile path cannot replace an unready pilot forever.
+
+    Each terminal pilot creates a capacity deficit, so ReplicaReconciler and
+    ReplicaPlacer produce a fresh allocation. After the replacement fails the
+    same way, an autoscaler pass lowers desired replicas to zero and the next
+    reconciliation does not create a third allocation.
+    """
+    async with db.begin() as sess:
+        await _seed_cluster(sess)
+        await _seed_deployment_parents(sess)
+        await _insert_deployment(
+            sess,
+            "dep-replacement-loop",
+            max_consecutive_launch_failures=1,
+        )
+        dep = await PilotDeployment.get_by_name(sess, "dep-replacement-loop")
+        dep.launch_spec = {"num_nodes": 1, "gpus_per_node": 4}
+        model = await Model.get_by_name(sess, "model")
+        dep_uid = dep.uid
+        model_uid = model.uid
+
+    client_state = _make_client_state(db)
+    client_state.redis_repo.get_autoscaler_model_runtime = AsyncMock(
+        return_value=AutoscalerModelRuntime()
+    )
+    client_state.redis_repo.get_model_runtime = AsyncMock(return_value=ModelRuntime())
+    client_state.redis_repo.set_autoscaler_model_runtime = AsyncMock()
+
+    reconciler = ReplicaReconciler("replica-reconciler", client_state, MagicMock())
+    placer = ReplicaPlacer("replica-placer", client_state, MagicMock())
+    autoscaler = PilotAutoscaler("pilot-autoscaler", client_state, MagicMock())
+    observer = _make_observer(db)
+
+    async def place_and_fail_next_pilot(cycle: int) -> None:
+        async with db() as sess:
+            replica = await sess.scalar(
+                select(PilotReplica)
+                .where(
+                    PilotReplica.pilot_deployment_name == "dep-replacement-loop",
+                    PilotReplica.state == ReplicaState.pending.value,
+                    PilotReplica.scheduled_deletion_at.is_(None),
+                )
+                .order_by(PilotReplica.uid.desc())
+            )
+        assert replica is not None
+
+        await placer.reconcile(replica.uid)
+
+        async with db.begin() as sess:
+            current_replica = await sess.get(PilotReplica, replica.uid)
+            assert current_replica is not None
+            assert current_replica.pilot_job_name is not None
+            job_name = current_replica.pilot_job_name
+            job = await PilotJob.get_by_name(sess, job_name)
+            job.scheduler_job_id = f"replacement-{cycle}.pbs"
+            job.scheduler_state = SchedulerJobState.running.value
+
+        async with db() as sess:
+            failed_job = await PilotJob.get_by_name(sess, job_name)
+        await observer._update_job(failed_job, None)
+
+    # The normal desired-count path creates and places the first allocation.
+    await reconciler.reconcile(dep_uid)
+    await place_and_fail_next_pilot(1)
+
+    # The first pre-manager death creates a replacement allocation.
+    await reconciler.reconcile(dep_uid)
+    await place_and_fail_next_pilot(2)
+
+    # The autoscaler's existing one-way latch closes the loop before another
+    # ReplicaReconciler pass can create a third allocation.
+    await autoscaler.reconcile(model_uid)
+    await reconciler.reconcile(dep_uid)
+
+    async with db() as sess:
+        dep = await PilotDeployment.get_by_name(sess, "dep-replacement-loop")
+        replicas = (
+            await sess.scalars(
+                select(PilotReplica).where(
+                    PilotReplica.pilot_deployment_name == "dep-replacement-loop"
+                )
+            )
+        ).all()
+        jobs = (
+            await sess.scalars(
+                select(PilotJob).where(PilotJob.cluster_name == "polaris")
+            )
+        ).all()
+
+    assert len(replicas) == 2  # no third replacement
+    assert len(jobs) == 2
+    assert dep.consecutive_launch_failures == 2
+    assert dep.max_consecutive_launch_failures == 1
+    assert dep.desired_replicas == 0
+    assert all(replica.scheduled_deletion_at is not None for replica in replicas)
 
 
 async def test_intentional_or_ready_terminal_job_is_not_charged(

--- a/tests/test_pilot_job_observer.py
+++ b/tests/test_pilot_job_observer.py
@@ -55,6 +55,9 @@ class FakeSchedulerAdapter(SchedulerAdapter):
     async def get_job_statuses(self) -> list[JobStatusInfo]:
         return list(self.statuses)
 
+    async def get_exact_job_status(self, job_id: str) -> JobStatusInfo | None:
+        return None
+
     async def terminate_job(self, job_id: str) -> None:
         self.terminated.append(job_id)
 

--- a/tests/test_pilot_job_observer.py
+++ b/tests/test_pilot_job_observer.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Self
+from typing import Any, Self, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from sqlalchemy import select
@@ -15,11 +15,20 @@ from first_common.schema.base_scheduler import (
     SchedulerAdapter,
     SchedulerJobState,
 )
-from first_common.schema.pilot import AddressInfo
+from first_common.schema.pilot import AddressInfo, PilotJobStatus, PilotResources
 from first_common.schema.types import HealthCheckResult, PilotConfig
+from first_gateway.controllers.worker import Worker
 from first_gateway.controllers.workers.pilot_job_observer import PilotJobObserver
-from first_gateway.database.models import Cluster, PilotJob
+from first_gateway.database.models import (
+    AccessGroup,
+    Cluster,
+    Model,
+    PilotDeployment,
+    PilotJob,
+    PilotReplica,
+)
 from first_gateway.database.redis.pubsub import Channel
+from first_gateway.platforms.schedulers.graphql_pbs import GraphQLPBSAdapter
 from first_gateway.services.pilot_submitter import PilotSubmitter
 
 _PATCH_BUILD = "first_gateway.controllers.workers.pilot_job_observer.build_scheduler"
@@ -98,7 +107,15 @@ def _make_client_state(
 def _make_observer(
     db: async_sessionmaker[AsyncSession],
 ) -> PilotJobObserver:
-    return PilotJobObserver("pilot-job-observer", _make_client_state(db), MagicMock())
+    # Bypass the production mTLS client constructor; individual tests control
+    # the candidate-endpoint /status result through this AsyncMock.
+    observer = PilotJobObserver.__new__(PilotJobObserver)
+    Worker.__init__(observer, "pilot-job-observer", _make_client_state(db), MagicMock())
+    observer.client = MagicMock()
+    observer.client.get_status = AsyncMock(
+        return_value=PilotJobStatus(resources=PilotResources(), replicas=[])
+    )
+    return observer
 
 
 async def _seed_cluster(sess: AsyncSession) -> None:
@@ -107,6 +124,36 @@ async def _seed_cluster(sess: AsyncSession) -> None:
             name="polaris",
             health_check={"url": "http://x/health", "debounce": 2},
             pilot_system=PILOT_SYSTEM,
+        )
+    )
+    await sess.flush()
+
+
+async def _seed_deployment_parents(sess: AsyncSession) -> None:
+    sess.add(AccessGroup(name="ag", allowed_groups=[], allowed_domains=[]))
+    await sess.flush()
+    sess.add(Model(name="model", access_group_name="ag", supported_endpoints=["chat"]))
+    await sess.flush()
+
+
+async def _insert_deployment(
+    sess: AsyncSession,
+    name: str,
+    *,
+    max_consecutive_launch_failures: int = 1,
+) -> None:
+    sess.add(
+        PilotDeployment(
+            name=name,
+            cluster_name="polaris",
+            model_name="model",
+            router_params={},
+            prometheus_scrape_interval_sec=30,
+            min_replicas=1,
+            max_replicas=1,
+            launch_spec={},
+            desired_replicas=1,
+            max_consecutive_launch_failures=max_consecutive_launch_failures,
         )
     )
     await sess.flush()
@@ -202,6 +249,193 @@ async def test_submitted_to_running_and_endpoint_discovery(
     publish.assert_not_awaited()
 
 
+async def test_graphql_head_ip_requires_live_manager_status(
+    db: async_sessionmaker[AsyncSession],
+) -> None:
+    """A scheduler-assigned head IP is not pilot-manager readiness evidence."""
+    async with db.begin() as sess:
+        await _seed_cluster(sess)
+        uid = await _insert_pilot_job(
+            sess,
+            "job-graphql",
+            "graphql.pbs",
+            state=SchedulerJobState.running,
+        )
+
+    scheduler_status = JobStatusInfo(
+        id="graphql.pbs",
+        name="__FIRST_PILOT_job-graphql",
+        state=SchedulerJobState.running,
+        created_at=NOW,
+        started_at=NOW,
+        walltime_minutes=60,
+        head_node_ip_address="10.1.2.3",
+        head_node_hostname="x3001",
+    )
+    adapter = GraphQLPBSAdapter(client=MagicMock(), owner="svc", url="https://gql")
+    submitter = PilotSubmitter(
+        PilotConfig.model_validate(PILOT_SYSTEM),
+        adapter,
+        "fake-ca-crt",
+        "fake-ca-key",
+    )
+    observer = _make_observer(db)
+    get_status = cast(AsyncMock, observer.client.get_status)
+    publish = cast(AsyncMock, observer.client_state.redis_pubsub.publish)
+    get_status.side_effect = RuntimeError("manager not bound")
+
+    with patch.object(
+        adapter,
+        "get_job_statuses",
+        new=AsyncMock(return_value=[scheduler_status]),
+    ):
+        await observer._discover_endpoints(submitter, "polaris")
+
+        async with db() as sess:
+            job = await sess.get(PilotJob, uid)
+            assert job is not None
+            assert job.manager_url is None
+        publish.assert_not_awaited()
+
+        # Once the exact candidate answers /status over mTLS, publish it and
+        # wake launchers.  This is the first point at which manager_url is set.
+        get_status.side_effect = None
+        get_status.return_value = PilotJobStatus(
+            resources=PilotResources(), replicas=[]
+        )
+        await observer._discover_endpoints(submitter, "polaris")
+
+    candidate = "https://10.1.2.3:8443/control/"
+    get_status.assert_awaited_with(candidate)
+    async with db() as sess:
+        job = await sess.get(PilotJob, uid)
+        assert job is not None
+        assert job.manager_url == candidate
+    publish.assert_awaited_once_with(Channel.pilot_job_ready, "job-graphql")
+
+
+async def test_graphql_known_job_omitted_from_bulk_page_uses_exact_truth(
+    db: async_sessionmaker[AsyncSession],
+) -> None:
+    async with db.begin() as sess:
+        await _seed_cluster(sess)
+        uid = await _insert_pilot_job(
+            sess,
+            "job-omitted",
+            "omitted.pbs",
+            state=SchedulerJobState.queued,
+        )
+
+    exact = JobStatusInfo(
+        id="omitted.pbs",
+        name="__FIRST_PILOT_job-omitted",
+        state=SchedulerJobState.running,
+        created_at=NOW,
+        started_at=NOW,
+        walltime_minutes=60,
+        head_node_ip_address="10.1.2.7",
+        head_node_hostname="x3007",
+    )
+    adapter = GraphQLPBSAdapter(client=MagicMock(), owner="svc", url="https://gql")
+    bulk = AsyncMock(return_value=[])
+    exact_lookup = AsyncMock(return_value=exact)
+    adapter.get_job_statuses = bulk  # type: ignore[method-assign]
+    adapter.get_exact_job_status = exact_lookup  # type: ignore[method-assign]
+    submitter = PilotSubmitter(
+        PilotConfig.model_validate(PILOT_SYSTEM),
+        adapter,
+        "fake-ca-crt",
+        "fake-ca-key",
+    )
+    observer = _make_observer(db)
+    await observer._poll_cluster(submitter, "polaris")
+
+    async with db() as sess:
+        job = await sess.get(PilotJob, uid)
+        assert job is not None
+        assert job.scheduler_state == SchedulerJobState.running.value
+        assert job.deleted_at is None
+    exact_lookup.assert_awaited_once_with("omitted.pbs")
+
+
+async def test_graphql_unready_terminal_allocation_is_charged_once(
+    db: async_sessionmaker[AsyncSession],
+) -> None:
+    """A PALS-era failure behind a synthesized head IP gets one replacement."""
+    async with db.begin() as sess:
+        await _seed_cluster(sess)
+        await _seed_deployment_parents(sess)
+        await _insert_deployment(sess, "dep-a")
+        uid = await _insert_pilot_job(
+            sess,
+            "job-inventory-failed",
+            "inventory-failed.pbs",
+            state=SchedulerJobState.running,
+        )
+        sess.add(
+            PilotReplica(
+                name="dep-a/replica/inventory-failed",
+                pilot_deployment_name="dep-a",
+                pilot_job_name="job-inventory-failed",
+                state="placed",
+            )
+        )
+
+    scheduler_status = JobStatusInfo(
+        id="inventory-failed.pbs",
+        name="__FIRST_PILOT_job-inventory-failed",
+        state=SchedulerJobState.running,
+        created_at=NOW,
+        started_at=NOW,
+        walltime_minutes=60,
+        head_node_ip_address="10.1.2.4",
+        head_node_hostname="x3002",
+    )
+    adapter = GraphQLPBSAdapter(client=MagicMock(), owner="svc", url="https://gql")
+    submitter = PilotSubmitter(
+        PilotConfig.model_validate(PILOT_SYSTEM),
+        adapter,
+        "fake-ca-crt",
+        "fake-ca-key",
+    )
+    observer = _make_observer(db)
+    get_status = cast(AsyncMock, observer.client.get_status)
+    get_status.side_effect = RuntimeError("PALS inventory failed before bind")
+    with patch.object(
+        adapter,
+        "get_job_statuses",
+        new=AsyncMock(return_value=[scheduler_status]),
+    ):
+        await observer._discover_endpoints(submitter, "polaris")
+
+    async with db() as sess:
+        job = await sess.get(PilotJob, uid)
+        assert job is not None
+        assert job.manager_url is None
+
+    terminal = JobStatusInfo(
+        id="inventory-failed.pbs",
+        name="__FIRST_PILOT_job-inventory-failed",
+        state=SchedulerJobState.exiting,
+        created_at=NOW,
+        started_at=NOW,
+        walltime_minutes=60,
+    )
+    await observer._update_job(job, terminal)
+    await observer._update_job(job, terminal)
+
+    async with db() as sess:
+        dep = await PilotDeployment.get_by_name(sess, "dep-a")
+        assert dep.consecutive_launch_failures == 0
+
+    await observer._update_job(job, None)
+    await observer._update_job(job, None)
+
+    async with db() as sess:
+        dep = await PilotDeployment.get_by_name(sess, "dep-a")
+        assert dep.consecutive_launch_failures == 1
+
+
 async def test_orphan_scheduler_job_reaped(
     db: async_sessionmaker[AsyncSession],
 ) -> None:
@@ -221,6 +455,14 @@ async def test_orphan_scheduler_job_reaped(
             started_at=NOW,
             walltime_minutes=60,
         ),
+        JobStatusInfo(
+            id="998.pbs",
+            name=f"{prefix}orphan-exiting",
+            state=SchedulerJobState.exiting,
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=4),
+            started_at=NOW,
+            walltime_minutes=60,
+        ),
     ]
 
     observer = _make_observer(db)
@@ -229,6 +471,7 @@ async def test_orphan_scheduler_job_reaped(
         await observer._poll_all_clusters()
 
     assert "999.pbs" in adapter.terminated
+    assert "998.pbs" in adapter.terminated
 
 
 async def test_no_update_when_state_unchanged(
@@ -288,6 +531,165 @@ async def test_missing_exiting_job_completes_nonblocking_termination(
         job = (await sess.scalars(select(PilotJob).where(PilotJob.uid == uid))).one()
     assert job.scheduler_state == SchedulerJobState.gone.value
     assert job.deleted_at is not None
+
+
+async def test_pre_manager_terminal_jobs_count_once_per_assigned_deployment(
+    db: async_sessionmaker[AsyncSession],
+) -> None:
+    """A failed allocation is charged once, even across exiting/gone polls.
+
+    With a configured maximum of one launch failure, the first dead allocation
+    permits one replacement and the replacement's failure advances the counter
+    to two, which the autoscaler treats as over the bound.
+    """
+    async with db.begin() as sess:
+        await _seed_cluster(sess)
+        await _seed_deployment_parents(sess)
+        await _insert_deployment(sess, "dep-a")
+        await _insert_deployment(sess, "dep-b")
+        first_uid = await _insert_pilot_job(
+            sess,
+            "job-first",
+            "first.pbs",
+            state=SchedulerJobState.running,
+        )
+        sess.add_all(
+            [
+                # Two replicas from dep-a must still count as one allocation
+                # failure for that deployment.
+                PilotReplica(
+                    name="dep-a/replica/one",
+                    pilot_deployment_name="dep-a",
+                    pilot_job_name="job-first",
+                    state="placed",
+                ),
+                PilotReplica(
+                    name="dep-a/replica/two",
+                    pilot_deployment_name="dep-a",
+                    pilot_job_name="job-first",
+                    state="placed",
+                ),
+                PilotReplica(
+                    name="dep-b/replica/one",
+                    pilot_deployment_name="dep-b",
+                    pilot_job_name="job-first",
+                    state="placed",
+                ),
+            ]
+        )
+
+    async with db() as sess:
+        first_job = await sess.get(PilotJob, first_uid)
+    assert first_job is not None
+
+    observer = _make_observer(db)
+    exiting = JobStatusInfo(
+        id="first.pbs",
+        name="__FIRST_PILOT_job-first",
+        state=SchedulerJobState.exiting,
+        created_at=NOW,
+        started_at=NOW,
+        walltime_minutes=60,
+    )
+    await observer._update_job(first_job, exiting)
+    # Repeat with the intentionally stale object, then advance exiting -> gone.
+    # The locked current row is the exactly-once guard, not caller freshness.
+    await observer._update_job(first_job, exiting)
+    await observer._update_job(first_job, None)
+
+    async with db() as sess:
+        dep_a = await PilotDeployment.get_by_name(sess, "dep-a")
+        dep_b = await PilotDeployment.get_by_name(sess, "dep-b")
+        first_job_current = await sess.get(PilotJob, first_uid)
+        assert dep_a.consecutive_launch_failures == 1
+        assert dep_b.consecutive_launch_failures == 1
+        assert first_job_current is not None
+        assert first_job_current.scheduler_state == SchedulerJobState.gone.value
+
+    # A single fresh replacement allocation for dep-a fails the same way.  It
+    # is charged once and moves 1 -> 2; repeat observation remains idempotent.
+    async with db.begin() as sess:
+        second_uid = await _insert_pilot_job(
+            sess,
+            "job-replacement",
+            "replacement.pbs",
+            state=SchedulerJobState.running,
+        )
+        sess.add(
+            PilotReplica(
+                name="dep-a/replica/replacement",
+                pilot_deployment_name="dep-a",
+                pilot_job_name="job-replacement",
+                state="placed",
+            )
+        )
+
+    async with db() as sess:
+        replacement = await sess.get(PilotJob, second_uid)
+    assert replacement is not None
+    await observer._update_job(replacement, None)
+    await observer._update_job(replacement, None)
+
+    async with db() as sess:
+        dep_a = await PilotDeployment.get_by_name(sess, "dep-a")
+        dep_b = await PilotDeployment.get_by_name(sess, "dep-b")
+        assert dep_a.consecutive_launch_failures == 2
+        assert dep_a.max_consecutive_launch_failures == 1
+        assert dep_b.consecutive_launch_failures == 1
+
+
+async def test_intentional_or_ready_terminal_job_is_not_charged(
+    db: async_sessionmaker[AsyncSession],
+) -> None:
+    """Only an unready, not-already-draining allocation is a launch failure."""
+    async with db.begin() as sess:
+        await _seed_cluster(sess)
+        await _seed_deployment_parents(sess)
+        await _insert_deployment(sess, "dep-a")
+        ready_uid = await _insert_pilot_job(
+            sess,
+            "job-was-ready",
+            "ready.pbs",
+            state=SchedulerJobState.running,
+            manager_url="https://10.0.0.1/control",
+        )
+        draining_uid = await _insert_pilot_job(
+            sess,
+            "job-draining",
+            "draining.pbs",
+            state=SchedulerJobState.running,
+        )
+        draining = await sess.get(PilotJob, draining_uid)
+        assert draining is not None
+        draining.scheduled_deletion_at = NOW
+        sess.add_all(
+            [
+                PilotReplica(
+                    name="dep-a/replica/ready",
+                    pilot_deployment_name="dep-a",
+                    pilot_job_name="job-was-ready",
+                    state="ready",
+                ),
+                PilotReplica(
+                    name="dep-a/replica/draining",
+                    pilot_deployment_name="dep-a",
+                    pilot_job_name="job-draining",
+                    state="placed",
+                ),
+            ]
+        )
+
+    observer = _make_observer(db)
+    async with db() as sess:
+        ready = await sess.get(PilotJob, ready_uid)
+        draining = await sess.get(PilotJob, draining_uid)
+    assert ready is not None and draining is not None
+    await observer._update_job(ready, None)
+    await observer._update_job(draining, None)
+
+    async with db() as sess:
+        dep = await PilotDeployment.get_by_name(sess, "dep-a")
+        assert dep.consecutive_launch_failures == 0
 
 
 async def test_cluster_without_pilot_system_skipped(

--- a/tests/test_pilot_submitter.py
+++ b/tests/test_pilot_submitter.py
@@ -46,6 +46,9 @@ class FakeSchedulerAdapter(SchedulerAdapter):
     async def get_job_statuses(self) -> list[JobStatusInfo]:
         return list(self.statuses)
 
+    async def get_exact_job_status(self, job_id: str) -> JobStatusInfo | None:
+        return None
+
     async def terminate_job(self, _job_id: str) -> None:
         raise NotImplementedError
 


### PR DESCRIPTION
## Summary

- Confirm GraphQL candidate endpoints through the pilot control API before publishing readiness.
- Use exact scheduler lookup when a job is absent from the bulk listing.
- Atomically count pilot allocations that terminate before manager readiness.
- Exclude intentional deletion and ensure each failure is counted once.

## Why this is needed

The scheduler can expose a head-node address before the pilot validates its resources or binds its control API. Publishing that address early causes premature launches, while uncounted startup failures can create an unlimited replacement loop.

## Tests

- All 9 observer tests collect successfully
- Database execution is pending CI because local PostgreSQL/Redis could not be started
- Ruff, formatting, and MyPy passed