### PR TITLE
Guard gateway allocation lifecycle races

### DIFF
--- a/packages/gateway/first_gateway/controllers/workers/pilot_job_controller.py
+++ b/packages/gateway/first_gateway/controllers/workers/pilot_job_controller.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from first_common.schema.base_scheduler import JobSubmitResult, SchedulerJobState
 from first_common.schema.types import HealthCheckResult, PilotConfig
 
-from ...database.models import Cluster, PilotJob
+from ...database.models import Cluster, PilotJob, PilotReplica
 from ...database.redis.pubsub import Channel
 from ...platforms.schedulers import build_scheduler
 from ...services.pilot_submitter import PilotSubmitter
@@ -46,7 +46,10 @@ class PilotJobController(Controller):
                         SchedulerJobState.running.value,
                     ]
                 ),
-                PilotJob.idle_since.is_not(None),
+                sa.and_(
+                    PilotJob.idle_since.is_not(None),
+                    self._no_live_assigned_replicas(),
+                ),
                 PilotJob.manager_health == HealthCheckResult.unhealthy.value,
             ),
         )
@@ -89,9 +92,7 @@ class PilotJobController(Controller):
                     idle_min,
                     pilot_config.pilot_max_idle_time_min,
                 )
-                await self._mark_scheduled_deletion(
-                    job, PilotJob.idle_since.is_not(None)
-                )
+                await self._mark_idle_deletion(job)
                 return
 
         if (
@@ -218,6 +219,25 @@ class PilotJobController(Controller):
                 raise StaleReconcile(
                     f"PilotJob {job.name}: mark_scheduled_deletion stale"
                 )
+
+    @staticmethod
+    def _no_live_assigned_replicas() -> sa.ColumnElement[bool]:
+        """Return a correlated guard against deleting an assigned pilot."""
+        return ~sa.exists().where(
+            PilotReplica.pilot_job_name == PilotJob.name,
+            PilotReplica.deleted_at.is_(None),
+        )
+
+    async def _mark_idle_deletion(self, job: PilotJob) -> None:
+        # Placement and idle deletion run in separate controllers. Keep the
+        # assignment check in the UPDATE so a detached idle read cannot mark a
+        # pilot after a replica has been assigned to it.
+        assert job.idle_since is not None
+        await self._mark_scheduled_deletion(
+            job,
+            PilotJob.idle_since == job.idle_since,
+            self._no_live_assigned_replicas(),
+        )
 
     async def _submit(self, job: PilotJob, pilot_config: PilotConfig) -> None:
         async with self.client_state.db_sessionmaker() as sess:

--- a/packages/gateway/first_gateway/database/models.py
+++ b/packages/gateway/first_gateway/database/models.py
@@ -504,6 +504,22 @@ class PilotJob(ResourceRow, SoftDeletable):
         )
         assert job is not None and replica_row is not None
 
+        # Candidate selection precedes this locked transaction. Recheck the
+        # lifecycle state while holding the existing PilotJob lock so a job
+        # marked for deletion in that gap cannot receive a new GPU claim.
+        if (
+            job.scheduled_deletion_at is not None
+            or job.deleted_at is not None
+            or job.scheduler_state
+            not in {
+                SchedulerJobState.pending_submit.value,
+                SchedulerJobState.queued.value,
+                SchedulerJobState.starting.value,
+                SchedulerJobState.running.value,
+            }
+        ):
+            return False
+
         known_gpus = {
             (host_idx, gpu_idx)
             for host_idx in range(job.num_nodes)

--- a/tests/test_pilot_job_controller.py
+++ b/tests/test_pilot_job_controller.py
@@ -18,7 +18,14 @@ from first_common.schema.base_scheduler import (
 from first_common.schema.types import HealthCheckResult
 from first_gateway.controllers.controller import StaleReconcile
 from first_gateway.controllers.workers.pilot_job_controller import PilotJobController
-from first_gateway.database.models import Cluster, PilotJob
+from first_gateway.database.models import (
+    AccessGroup,
+    Cluster,
+    Model,
+    PilotDeployment,
+    PilotJob,
+    PilotReplica,
+)
 from first_gateway.services.certmanager import gen_ca_pem
 
 _PATCH_BUILD = "first_gateway.controllers.workers.pilot_job_controller.build_scheduler"
@@ -126,6 +133,51 @@ async def _seed_cluster(
             name="polaris",
             health_check={"url": "http://x/health", "debounce": 2},
             pilot_system=pilot_system if pilot_system is not None else PILOT_SYSTEM,
+        )
+    )
+    await sess.flush()
+
+
+async def _seed_replica_parents(sess: AsyncSession) -> None:
+    sess.add(AccessGroup(name="default-ag", allowed_groups=[], allowed_domains=[]))
+    await sess.flush()
+    sess.add(
+        Model(
+            name="test-model",
+            access_group_name="default-ag",
+            supported_endpoints=["chat/completions"],
+        )
+    )
+    await sess.flush()
+    sess.add(
+        PilotDeployment(
+            name="test-deployment",
+            cluster_name="polaris",
+            model_name="test-model",
+            router_params={},
+            prometheus_scrape_interval_sec=30,
+            min_replicas=0,
+            max_replicas=1,
+            launch_spec={},
+        )
+    )
+    await sess.flush()
+
+
+async def _insert_assigned_replica(
+    sess: AsyncSession,
+    job_name: str,
+    *,
+    name: str,
+    deleted_at: datetime | None = None,
+) -> None:
+    sess.add(
+        PilotReplica(
+            name=name,
+            pilot_deployment_name="test-deployment",
+            pilot_job_name=job_name,
+            state="placed",
+            deleted_at=deleted_at,
         )
     )
     await sess.flush()
@@ -642,11 +694,10 @@ async def test_exiting_job_does_not_delay_replacement_at_node_cap(
 # ---------------------------------------------------------------------------
 
 
-async def test_idle_premise_prevents_stale_mark(
+async def test_restarted_idle_period_prevents_stale_mark(
     db: async_sessionmaker[AsyncSession], ca_pair: tuple[str, str]
 ) -> None:
-    """If idle_since is cleared between the read and write phase, the
-    premised UPDATE correctly rejects the stale mark."""
+    """A newly restarted idle interval cannot inherit an old interval's age."""
     async with db.begin() as sess:
         await _seed_cluster(sess)
         uid = await _insert_pilot_job(
@@ -660,18 +711,97 @@ async def test_idle_premise_prevents_stale_mark(
         job = await sess.get(PilotJob, uid)
     assert job is not None
 
-    # Simulate the observer clearing idle_since concurrently
+    # Simulate activity clearing the old interval and a later observation
+    # starting a fresh one before this detached controller snapshot is used.
+    restarted_at = datetime.now(timezone.utc) - timedelta(minutes=1)
     async with db.begin() as sess:
         await sess.execute(
-            sa.update(PilotJob).where(PilotJob.uid == uid).values(idle_since=None)
+            sa.update(PilotJob)
+            .where(PilotJob.uid == uid)
+            .values(idle_since=restarted_at)
         )
 
     controller = _make_controller(db, ca_pair)
     with pytest.raises(StaleReconcile):
-        await controller._mark_scheduled_deletion(job, PilotJob.idle_since.is_not(None))
+        await controller._mark_idle_deletion(job)
 
     job = await _get_job(db, uid)
     assert job.scheduled_deletion is False
+    assert job.idle_since == restarted_at
+
+
+async def test_expired_idle_job_with_live_assignment_is_not_actionable(
+    db: async_sessionmaker[AsyncSession], ca_pair: tuple[str, str]
+) -> None:
+    async with db.begin() as sess:
+        await _seed_cluster(sess)
+        await _seed_replica_parents(sess)
+        uid = await _insert_pilot_job(
+            sess,
+            "idle-assigned",
+            idle_since=datetime.now(timezone.utc) - timedelta(hours=2),
+        )
+        await _insert_assigned_replica(
+            sess, "idle-assigned", name="test-deployment/replica/live"
+        )
+
+    controller = _make_controller(db, ca_pair)
+    async with db() as sess:
+        assert uid not in await controller.list_actionable(sess)
+    with pytest.raises(StaleReconcile):
+        await controller.reconcile(uid)
+    assert not (await _get_job(db, uid)).scheduled_deletion
+
+
+async def test_assignment_inserted_between_idle_read_and_update_blocks_delete(
+    db: async_sessionmaker[AsyncSession], ca_pair: tuple[str, str]
+) -> None:
+    async with db.begin() as sess:
+        await _seed_cluster(sess)
+        await _seed_replica_parents(sess)
+        uid = await _insert_pilot_job(
+            sess,
+            "idle-assignment-race",
+            idle_since=datetime.now(timezone.utc) - timedelta(hours=2),
+        )
+
+    async with db() as sess:
+        job = await sess.get(PilotJob, uid)
+    assert job is not None
+    async with db.begin() as sess:
+        await _insert_assigned_replica(
+            sess,
+            "idle-assignment-race",
+            name="test-deployment/replica/racing",
+        )
+
+    controller = _make_controller(db, ca_pair)
+    with pytest.raises(StaleReconcile):
+        await controller._mark_idle_deletion(job)
+    assert not (await _get_job(db, uid)).scheduled_deletion
+
+
+async def test_deleted_historical_assignment_does_not_block_idle_delete(
+    db: async_sessionmaker[AsyncSession], ca_pair: tuple[str, str]
+) -> None:
+    async with db.begin() as sess:
+        await _seed_cluster(sess)
+        await _seed_replica_parents(sess)
+        uid = await _insert_pilot_job(
+            sess,
+            "idle-historical",
+            idle_since=datetime.now(timezone.utc) - timedelta(hours=2),
+        )
+        await _insert_assigned_replica(
+            sess,
+            "idle-historical",
+            name="test-deployment/replica/historical",
+            deleted_at=datetime.now(timezone.utc),
+        )
+
+    controller = _make_controller(db, ca_pair)
+    await controller.reconcile(uid)
+    assert (await _get_job(db, uid)).scheduled_deletion
 
 
 async def test_unhealthy_premise_prevents_stale_mark(

--- a/tests/test_replica_placement.py
+++ b/tests/test_replica_placement.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -12,6 +13,7 @@ _replica_counter = itertools.count()
 
 from first_common.schema.base_scheduler import SchedulerJobState
 from first_common.schema.types import ReplicaState
+from first_gateway.controllers.controller import StaleReconcile
 from first_gateway.controllers.workers.replica_placement import (
     AT_CAPACITY,
     ReplicaPlacer,
@@ -365,6 +367,43 @@ async def test_place_on_pending_submit_job(
     replica = await _get_replica(db, uid)
     assert replica.pilot_job_name == "job-pending"
     assert await _count_jobs(db) == 1
+
+
+async def test_stale_selected_job_cannot_be_assigned_after_idle_delete_mark(
+    db: async_sessionmaker[AsyncSession],
+) -> None:
+    """Placement rechecks a candidate after acquiring its existing row lock."""
+    async with db.begin() as sess:
+        await _seed_parents(sess)
+        await _insert_deployment(sess, "dep", num_nodes=1, gpus_per_node=2)
+        await _insert_pilot_job(sess, "job-selected", num_nodes=1, gpus_per_node=4)
+        replica_uid = await _insert_replica(sess, "dep")
+
+    # ReplicaPlacer selected this detached candidate while it was placeable.
+    selected = await _get_job(db, "job-selected")
+
+    # PilotJobController wins the inter-controller gap and marks it deleting.
+    async with db.begin() as sess:
+        job = await sess.get(PilotJob, selected.uid)
+        assert job is not None
+        job.scheduled_deletion_at = NOW
+
+    ctrl = _make_controller(db)
+    with pytest.raises(StaleReconcile, match="lost race for GPUs"):
+        await ctrl._place(
+            replica_uid,
+            "dep/replica/stale-selection",
+            selected.uid,
+            selected.name,
+            {(0, 0), (0, 1)},
+        )
+
+    replica = await _get_replica(db, replica_uid)
+    assert replica.state == ReplicaState.pending.value
+    assert replica.pilot_job_name is None
+    assert replica.claimed_gpu_ids == []
+    job = await _get_job(db, "job-selected")
+    assert job.claimed_gpu_ids == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Recheck placement eligibility while holding the pilot-job lock.
- Prevent idle deletion when a live replica has been assigned concurrently.
- Keep exiting jobs in capacity accounting until exact scheduler absence.
- Retain GPU claims after failed manager cleanup and escalate repeated failures to parent allocation termination.
- Finalize replica deletion only after the parent allocation is gone.

## Why this is needed

Concurrent controllers can otherwise assign a replica while another controller deletes its pilot, or release GPU claims before cleanup is proven complete. These guards keep placement, draining, and scheduler termination consistent.

## Tests

- All 60 controller, drainer, and placement tests collect successfully
- Database execution is pending CI because local PostgreSQL/Redis could not be started
- Ruff, formatting, and MyPy passed