### PR TITLE
ci: add workflow for alcf-ai

### DIFF
--- a/.github/workflows/publish-alcf-ai.yml
+++ b/.github/workflows/publish-alcf-ai.yml
@@ -1,0 +1,36 @@
+name: Publish alcf-ai to PyPI
+
+on:
+  push:
+    tags:
+      - 'alcf_ai/*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/alcf-ai
+    permissions:
+      id-token: write
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "alcf_ai/pyproject.toml"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - name: Install deps
+        working-directory: alcf_ai
+        run: uv sync
+      - name: Build package
+        working-directory: alcf_ai
+        run: uv build
+      - name: Publish to PyPI
+        working-directory: alcf_ai
+        run: uv publish

--- a/.github/workflows/publish-alcf-ai.yml
+++ b/.github/workflows/publish-alcf-ai.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Install Python
         uses: actions/setup-python@v6
         with:

--- a/alcf_ai/pyproject.toml
+++ b/alcf_ai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "alcf-ai"
-version = "0.8.0"
+dynamic = ["version"]
 description = "ALCF Inference Gateway SDK"
 authors = [{ name = "Misha Salim", email = "msalim@anl.gov" }]
 requires-python = ">=3.12"
@@ -23,8 +23,15 @@ dependencies = [
 alcf-ai = "alcf_ai:cli"
 
 [build-system]
-requires = ["uv_build<0.10.0"]
-build-backend = "uv_build"
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^alcf_ai/v(?P<version>[^\\+]+)$"
+
+[tool.hatch.version.raw-options]
+search_parent_directories = true
 
 [tool.ruff]
 line-length = 88

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,6 @@ members = [
 
 [[package]]
 name = "alcf-ai"
-version = "0.8.0"
 source = { editable = "alcf_ai" }
 dependencies = [
     { name = "globus-sdk" },


### PR DESCRIPTION
Automatically publishes the `alcf-ai` package on version tag creation or manual trigger.

Requires this repository to be added as a [Trusted Publisher](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/).