### PR TITLE
compute_functions: fix qstat parsing edge case

### DIFF
--- a/compute-functions/qstat_register_function.py
+++ b/compute-functions/qstat_register_function.py
@@ -170,7 +170,8 @@ def qstat_inference_function():
                     jobs_raw.append(current)
                 current = [line]
             else:
-                current.append(line)
+                if current:
+                    current.append(line)
         if current:
             jobs_raw.append(current)
 


### PR DESCRIPTION
`qstat` outputs with leading data before a job ID will cause malformed chunks to populate `jobs_raw` and raise exceptions whilst attempting to parse the response.

Fixes errors from the health monitor of the form:
```py
Traceback (most recent call last):
   File ".../register_functions/qstat_register_function.py", line 267, in qstat_inference_function
     output = run_qstat()
              ^^^^^^^^^^^
   File ".../register_functions/qstat_register_function.py", line 179, in run_qstat
     job_id = job_lines[0].split()[2]
              ~~~~~~~~~~~~~~~~~~~~^^^
 IndexError: list index out of range
```