### PR TITLE
health_monitor: pull the executor from cache before every health check

### DIFF
--- a/cron_jobs/direct_health_monitor.py
+++ b/cron_jobs/direct_health_monitor.py
@@ -348,7 +348,6 @@ async def check_sophia_models() -> list[HealthRecord]:
 
     try:
         gcc = globus_utils.get_compute_client_from_globus_app()
-        gce = globus_utils.get_compute_executor(client=gcc)
     except Exception as e:
         return [
             HealthRecord(
@@ -463,6 +462,7 @@ async def check_sophia_models() -> list[HealthRecord]:
         )
         start = time.monotonic()
         try:
+            gce = globus_utils.get_compute_executor(client=gcc)
             result = await globus_utils.submit_and_get_result(
                 gce,
                 info.endpoint_uuid,


### PR DESCRIPTION
In the event the Globus executor encounters a `RequestTimeout` whilst performing a health check, the executor is shutdown, causing all subsequent health checks to fail. Instead, we should re-pull the executor from the cache prior to each health check.

I believe this is the only case where an Executor is reused after submitting a task that can potentially time out in the entire codebase.