### PR TITLE
Document and test public model capability metadata

### DIFF
--- a/docs/admin-guide/gateway-setup/configuration.md
+++ b/docs/admin-guide/gateway-setup/configuration.md
@@ -66,10 +66,21 @@ All configuration is done through environment variables, typically stored in a `
 | `STREAMING_SERVER_HOST` | No | - | Internal streaming server host:port |
 | `INTERNAL_STREAMING_SECRET` | No | - | Secret for internal streaming authentication |
 | `MINERVA_AFFINITY_HMAC_KEY` | For Minerva inference | - | Dedicated secret of at least 32 bytes used to derive opaque Minerva session-affinity keys and per-user/model cache salts |
+| `MODEL_DETAILS_KEYS` | No | `[]` | JSON array of endpoint fixture `config` keys that the authenticated `/{cluster}/models` route may return |
 
 Rotating `MINERVA_AFFINITY_HMAC_KEY` remaps all Minerva sessions and cache
 namespaces. Treat rotation as a planned cold-cache event. See
 [Minerva Direct API Affinity](../inference-setup/minerva.md).
+
+`MODEL_DETAILS_KEYS` is a public-data allowlist. A typical deployment that
+publishes client-neutral model metadata uses:
+
+```dotenv
+MODEL_DETAILS_KEYS='["display_name","description","capabilities"]'
+```
+
+Never allowlist operational fixture fields such as `api_url`,
+`api_key_env_name`, `ca_cert_path`, `client_cert_path`, or `client_key_path`.
 
 ### Metis (Direct API) Configuration
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -32,6 +32,49 @@ POST /v1/completions
 POST /{cluster}/{framework}/v1/completions
 ```
 
+### Model Metadata
+
+```http
+GET /{cluster}/models
+GET /{cluster}/models?model_id={model}
+```
+
+The response contains only models the authenticated caller is authorized to
+use. Every model includes its identifier, cluster, and framework. Deployments
+may also expose explicitly allowlisted public metadata from the endpoint
+fixture, such as a display name, description, and a versioned capabilities
+object:
+
+```json
+[
+  {
+    "id": "example-model",
+    "object": "model",
+    "cluster": "example-cluster",
+    "framework": "api",
+    "display_name": "Example Model",
+    "description": "Example model served through FIRST",
+    "capabilities": {
+      "schema_version": 1,
+      "api_protocols": ["chat_completions", "responses"],
+      "context_window_tokens": 131072,
+      "input_modalities": ["text"],
+      "streaming": true,
+      "reasoning": {
+        "supported": true,
+        "separate_output": true
+      },
+      "tool_calling": {
+        "supported": true
+      }
+    }
+  }
+]
+```
+
+Capability metadata describes the deployed model API. It is intentionally
+client-neutral and must not contain backend connection details or secrets.
+
 ### Batch Processing
 
 ```http
@@ -44,4 +87,3 @@ For detailed API documentation, refer to the [OpenAI API Reference](https://plat
 ## Request Parameters
 
 See the [User Guide](../user-guide/index.md#request-parameters) for detailed parameter documentation.
-

--- a/env.example
+++ b/env.example
@@ -80,3 +80,9 @@ INTERNAL_STREAMING_SECRET="your-internal-streaming-secret-key"
 # Generate at least 32 random bytes and manage it separately from API keys and
 # Django's SECRET_KEY. Rotating it intentionally causes a Minerva cold-cache event.
 MINERVA_AFFINITY_HMAC_KEY="generate-a-dedicated-random-secret"
+
+# JSON array of endpoint fixture config keys that may be returned by the
+# authenticated /{cluster}/models route. Keep this allowlist limited to
+# intentionally public metadata; never add backend URLs, credential names, or
+# certificate/key paths.
+MODEL_DETAILS_KEYS='["display_name","description","capabilities"]'

--- a/inference_gateway/settings.py
+++ b/inference_gateway/settings.py
@@ -125,7 +125,7 @@ AUTHORIZED_GLOBUS_SERVICE_USERNAMES = json.loads(
     os.getenv("AUTHORIZED_GLOBUS_SERVICE_USERNAMES", "[]")
 )
 
-# Model details key for the models/ API route
+# Model detail keys that may be returned by the models/ API route
 MODEL_DETAILS_KEYS = json.loads(os.getenv("MODEL_DETAILS_KEYS", "[]"))
 
 # Load maintenance notices to be displayed for individual clusters

--- a/resource_server_async/tests/test_model_details.py
+++ b/resource_server_async/tests/test_model_details.py
@@ -1,0 +1,164 @@
+import ast
+from unittest.mock import patch
+
+from resource_server_async.endpoints.endpoint import BaseEndpoint
+from resource_server_async.models import Endpoint
+from resource_server_async.tests import (
+    CLIENT,
+    HEADERS,
+    PREMIUM_HEADERS,
+    ResourceServerTestCase,
+    get_response_json,
+    mock_utils,
+)
+
+PUBLIC_MODEL_DETAILS_KEYS = ["display_name", "description", "capabilities"]
+TEST_CAPABILITIES = {
+    "schema_version": 1,
+    "api_protocols": ["chat_completions", "responses"],
+    "context_window_tokens": 131072,
+    "input_modalities": ["text"],
+    "streaming": True,
+    "reasoning": {"supported": True, "separate_output": True},
+    "tool_calling": {"supported": True},
+}
+
+
+class ModelDetailsBuilderTests(ResourceServerTestCase):
+    def test_only_allowlisted_public_metadata_is_returned(self) -> None:
+        config = {
+            "display_name": "Test Model",
+            "description": "Public description",
+            "capabilities": TEST_CAPABILITIES,
+            "api_url": "https://private-backend.example.test/v1",
+            "api_key_env_name": "PRIVATE_API_KEY",
+            "ca_cert_path": "/private/ca.crt",
+            "client_cert_path": "/private/client.crt",
+            "client_key_path": "/private/client.key",
+        }
+
+        with patch(
+            "resource_server_async.endpoints.endpoint.MODEL_DETAILS_KEYS",
+            PUBLIC_MODEL_DETAILS_KEYS,
+        ):
+            details = BaseEndpoint.build_model_details(
+                "test-cluster", "api", "test-model", 0, 0, config
+            )
+
+        self.assertEqual(details["display_name"], "Test Model")
+        self.assertEqual(details["description"], "Public description")
+        self.assertEqual(details["capabilities"], TEST_CAPABILITIES)
+        for private_key in (
+            "api_url",
+            "api_key_env_name",
+            "ca_cert_path",
+            "client_cert_path",
+            "client_key_path",
+        ):
+            self.assertNotIn(private_key, details)
+
+    def test_missing_optional_metadata_remains_backward_compatible(self) -> None:
+        with patch(
+            "resource_server_async.endpoints.endpoint.MODEL_DETAILS_KEYS",
+            PUBLIC_MODEL_DETAILS_KEYS,
+        ):
+            details = BaseEndpoint.build_model_details(
+                "test-cluster",
+                "api",
+                "legacy-model",
+                0,
+                0,
+                {"api_url": "https://private-backend.example.test/v1"},
+            )
+
+        self.assertEqual(
+            details,
+            {
+                "id": "legacy-model",
+                "object": "model",
+                "cluster": "test-cluster",
+                "framework": "api",
+            },
+        )
+
+
+class ModelsViewTests(ResourceServerTestCase):
+    cluster = "your-other-cluster"
+    model = "Your-Model-120B"
+    url = f"/{cluster}/models?model_id={model}"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._clear_adapter_caches()
+
+    def tearDown(self) -> None:
+        self._clear_adapter_caches()
+        super().tearDown()
+
+    @staticmethod
+    def _clear_adapter_caches() -> None:
+        from resource_server_async.clusters.cluster import (
+            _adapter_cache as cluster_adapter_cache,
+        )
+        from resource_server_async.endpoints.endpoint import (
+            _adapter_cache as endpoint_adapter_cache,
+        )
+
+        cluster_adapter_cache.clear()
+        endpoint_adapter_cache.clear()
+
+    async def _add_public_metadata(self, *, restricted: bool = False) -> None:
+        endpoint = await Endpoint.objects.aget(cluster=self.cluster, model=self.model)
+        config = ast.literal_eval(endpoint.config)
+        config.update(
+            {
+                "display_name": "Test Model 120B",
+                "description": "unique-public-model-description",
+                "capabilities": TEST_CAPABILITIES,
+            }
+        )
+        endpoint.config = repr(config)
+        endpoint.allowed_globus_groups = (
+            [mock_utils.MOCK_GROUP_UUID] if restricted else []
+        )
+        await endpoint.asave(update_fields=["config", "allowed_globus_groups"])
+        self._clear_adapter_caches()
+
+    async def test_model_filter_returns_public_metadata_without_private_config(
+        self,
+    ) -> None:
+        await self._add_public_metadata()
+
+        with patch(
+            "resource_server_async.endpoints.endpoint.MODEL_DETAILS_KEYS",
+            PUBLIC_MODEL_DETAILS_KEYS,
+        ):
+            response = await CLIENT.get(self.url, headers=HEADERS)
+
+        response_data = get_response_json(response)
+        self.assertEqual(response.status_code, 200, str(response_data))
+        self.assertEqual(len(response_data), 1)
+        self.assertEqual(response_data[0]["id"], self.model)
+        self.assertEqual(response_data[0]["capabilities"], TEST_CAPABILITIES)
+        self.assertNotIn("api_url", response_data[0])
+        self.assertNotIn("api_key_env_name", response_data[0])
+
+    async def test_unauthorized_model_metadata_does_not_leak(self) -> None:
+        await self._add_public_metadata(restricted=True)
+
+        with patch(
+            "resource_server_async.endpoints.endpoint.MODEL_DETAILS_KEYS",
+            PUBLIC_MODEL_DETAILS_KEYS,
+        ):
+            unauthorized = await CLIENT.get(self.url, headers=HEADERS)
+            authorized = await CLIENT.get(self.url, headers=PREMIUM_HEADERS)
+
+        unauthorized_data = get_response_json(unauthorized)
+        self.assertEqual(unauthorized.status_code, 404, str(unauthorized_data))
+        self.assertNotIn("unique-public-model-description", str(unauthorized_data))
+
+        authorized_data = get_response_json(authorized)
+        self.assertEqual(authorized.status_code, 200, str(authorized_data))
+        self.assertEqual(
+            authorized_data[0]["description"], "unique-public-model-description"
+        )


### PR DESCRIPTION
## Summary

Adds documentation and regression tests for exposing client-neutral model metadata through FIRST’s existing authenticated /models endpoint.

Key behavior changes

- Allows display_name, description, and capabilities when explicitly configured in MODEL_DETAILS_KEYS.
- Preserves model-level authorization.
- Prevents backend URLs, credentials, and certificate paths from being returned.
- Models without the new metadata remain unchanged.

## Testing
All 252 FIRST tests, Ruff, Mypy, and the strict documentation build passed.