### PR TITLE
Renew inflight requests in AdmissionController

### DIFF
--- a/packages/gateway/first_gateway/apiserver/api.py
+++ b/packages/gateway/first_gateway/apiserver/api.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 
 from first_gateway.settings import Settings
 
+from ..database.redis.admission import AdmissionController
 from ..log_config import config_logging
 from .backend_client_manager import BackendClientManager
 from .error_handlers import register_error_handlers
@@ -30,11 +31,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         router_config_manager = RouterConfigManager(client_state.redis)
         router_config_manager.add_swap_callback(backend_client_manager.on_config_swap)
         await router_config_manager.start()
+        admission_controller = AdmissionController(client=client_state.redis)
+        await admission_controller.start()
         app.state.router_config_manager = router_config_manager
         app.state.backend_client_manager = backend_client_manager
+        app.state.admission_controller = admission_controller
         try:
             yield
         finally:
+            await admission_controller.stop()
             await router_config_manager.stop()
             await backend_client_manager.close_all()
 

--- a/packages/gateway/first_gateway/apiserver/dependencies.py
+++ b/packages/gateway/first_gateway/apiserver/dependencies.py
@@ -127,8 +127,8 @@ BackendClientManagerDep = Annotated[
 ]
 
 
-async def get_admission_controller(redis_client: RedisDep) -> _AdmissionController:
-    return _AdmissionController(client=redis_client)
+async def get_admission_controller(request: Request) -> _AdmissionController:
+    return cast(_AdmissionController, request.app.state.admission_controller)
 
 
 AdmissionControllerDep = Annotated[

--- a/packages/gateway/first_gateway/database/redis/admission.py
+++ b/packages/gateway/first_gateway/database/redis/admission.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import time
@@ -109,21 +110,28 @@ class AdmissionController:
         lease_sec: float = 30.0,
         max_request_sec: float = 3600.0,
         chunk_size: int = 500,
+        renew_interval_sec: float = 10.0,
     ) -> None:
         """
         - lease_sec: default reservation duration
         - max_request_sec: lease can be renewed for up to this long (backstop
           for stuck requests that never stop renewing the lease)
         - chunk_size: batch size for lease renewal and repair ops
+        - renew_interval_sec: period of the background lease-renewal loop
         """
         self.client = client
         self.lease_sec = lease_sec
         self.max_request_sec = max_request_sec
         self.chunk_size = chunk_size
+        self.renew_interval_sec = renew_interval_sec
         self._admit = client.register_script(_ADMIT_LUA)
         self._settle = client.register_script(_SETTLE_LUA)
         self._renew = client.register_script(_RENEW_LUA)
         self._record_error = client.register_script(_RECORD_ERROR_LUA)
+        # request_ids admitted by this worker and not yet settled; the renew
+        # loop keeps their leases alive so healthy workers hold their slots.
+        self._inflight: set[str] = set()
+        self._renew_task: asyncio.Task[None] | None = None
 
     async def admit(
         self,
@@ -187,7 +195,10 @@ class AdmissionController:
             args.extend([c.uid, c.max_backend_concurrency, c.cooldown_threshold])
 
         raw = await self._admit(keys=keys, args=args)
-        return AdmitResult.from_lua(raw)
+        result = AdmitResult.from_lua(raw)
+        if result.admitted:
+            self._inflight.add(request_id)
+        return result
 
     async def settle(
         self,
@@ -208,6 +219,7 @@ class AdmissionController:
         skip the pre-read round trip on the hot path.  The sweeper omits them
         and pays one extra GET to discover the reservation's identity.
         """
+        self._inflight.discard(request_id)
         reservation_key = Keys.reservation(request_id)
 
         if not model_name or not user_id or not backend_id:
@@ -269,6 +281,35 @@ class AdmissionController:
                 )
             )
         return renewed
+
+    async def start(self) -> None:
+        """Start the background loop renewing this worker's in-flight leases.
+
+        Call once from the app lifespan; pair with stop() on shutdown.
+        """
+        self._renew_task = asyncio.create_task(
+            self._renew_loop(), name="admission-renew"
+        )
+
+    async def stop(self) -> None:
+        if self._renew_task is None:
+            return
+        self._renew_task.cancel()
+        try:
+            await self._renew_task
+        except asyncio.CancelledError:
+            pass
+        self._renew_task = None
+
+    async def _renew_loop(self) -> None:
+        while True:
+            await asyncio.sleep(self.renew_interval_sec)
+            if not self._inflight:
+                continue
+            try:
+                await self.renew(list(self._inflight))
+            except Exception:
+                logger.warning("Inflight lease renewal failed", exc_info=True)
 
     async def sweep(self, batch: int = 100) -> int:
         """


### PR DESCRIPTION
This is adds a necessary final component to the AdmissionController without impacting the usage in the inference APIs.  Instead of creating a new `AdmissionController()` per request, a single instance is maintained on `app.state`.  

The instance can then keep track of all the inflight requests per uvicorn process.  This inflight set is passed to `renew()` every 10 seconds to extend the lease on inference requests that are still running.  

This prevents the sweeper from incorrectly expiring inflight requests that are still truly running.  

[Context: The sweeper, in turn, ensures that requests on crashed workers are correctly cleaned up: worker dies, doesn't renew lease for 30 seconds, sweeper removes the dead reservations from Redis, returning the model/user concurrency counts back to the correct level.]