### PR TITLE
Firstv2 streaming

### DIFF
--- a/packages/gateway/first_gateway/services/orchestration.py
+++ b/packages/gateway/first_gateway/services/orchestration.py
@@ -39,7 +39,7 @@ def get_candidates_from_deployments(
     deployments: list[DeploymentConfig],
 ) -> list[CandidateBackend]:
     if not deployments:
-        raise NotFound("Attempt to sort models with empty list of deployments.")
+        return []
 
     items = [
         (backend, d.router_params.weight, d.router_params)

--- a/packages/gateway/first_gateway/services/submit_inference.py
+++ b/packages/gateway/first_gateway/services/submit_inference.py
@@ -40,7 +40,7 @@ async def submit_inference_with_retry(
 
     backend_candidates = get_backend_candidates(model, deployment_name=deployment_name)
     if not backend_candidates:
-        raise ServiceUnavailable(f"No backend available for model {model}.")
+        raise ServiceUnavailable(f"No backend available for model {model.name}.")
 
     estimated_tokens = payload.estimate_tokens(model.max_model_len)
     streaming = getattr(payload, "stream", False) or False

--- a/packages/gateway/first_gateway/services/submit_inference.py
+++ b/packages/gateway/first_gateway/services/submit_inference.py
@@ -67,6 +67,8 @@ async def submit_inference_with_retry(
                     payload,
                     admission_controller,
                     request_id,
+                    user,
+                    model,
                 )
             else:
                 response = await submit_inference(
@@ -74,6 +76,8 @@ async def submit_inference_with_retry(
                     payload,
                     admission_controller,
                     request_id,
+                    user,
+                    model,
                 )
         except:
             # TODO: figure out a way to gather and report errors
@@ -98,6 +102,8 @@ async def submit_inference(
     payload: BasePayload,
     admission_controller: AdmissionController,
     request_id: str,
+    user: AuthUser,
+    model: ModelConfig,
 ) -> dict[str, Any]:
     """POST to an inference backend."""
 
@@ -110,6 +116,8 @@ async def submit_inference(
     body = cast(dict[str, Any], response.json())
     parser = USAGE_PARSERS.get(payload.endpoint)
     usage = parser.parse_unary(body) if parser else TokenUsage()
+    # TODO: emit structured log events (this is a placeholder for visibility):
+    logger.info(f"{payload.endpoint} - {model.name} - {user.username} - {usage}")
     await admission_controller.settle(request_id, actual_tokens=usage.total_tokens or 0)
     return body
 
@@ -119,6 +127,8 @@ async def submit_inference_streaming(
     payload: BasePayload,
     admission_controller: AdmissionController,
     request_id: str,
+    user: AuthUser,
+    model: ModelConfig,
 ) -> StreamingResponse:
     """POST to an inference backend and relay the SSE stream to the caller."""
 
@@ -145,6 +155,9 @@ async def submit_inference_streaming(
                 await response.aclose()
             usage = parser.parse_stream(tap.first, tap.last) if parser else TokenUsage()
             total_tokens = usage.total_tokens or 0
+            logger.info(
+                f"{payload.endpoint} - {model.name} - {user.username} - {usage}"
+            )
             await admission_controller.settle(request_id, actual_tokens=total_tokens)
 
     return StreamingResponse(

--- a/packages/gateway/first_gateway/services/submit_inference.py
+++ b/packages/gateway/first_gateway/services/submit_inference.py
@@ -1,7 +1,9 @@
 import logging
-from typing import Any, cast
+from typing import Any, AsyncIterator, cast
 
+import anyio
 from fastapi.responses import StreamingResponse
+from httpx import AsyncClient
 
 from first_common.errors import ServiceUnavailable
 from first_common.schema.endpoints.base import BasePayload
@@ -15,7 +17,7 @@ from .orchestration import (
     get_backend_candidates,
     get_deployment_from_backend_id,
 )
-from .usage import USAGE_PARSERS, TokenUsage
+from .usage import USAGE_PARSERS, TokenUsage, UsageTap
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +43,7 @@ async def submit_inference_with_retry(
         raise ServiceUnavailable(f"No backend available for model {model}.")
 
     estimated_tokens = payload.estimate_tokens(model.max_model_len)
+    streaming = getattr(payload, "stream", False) or False
 
     for attempt in range(min(3, len(backend_candidates))):
         backend_id = await admit_request(
@@ -51,31 +54,38 @@ async def submit_inference_with_retry(
             request_id,
             estimated_tokens=estimated_tokens,
         )
-        total_tokens = 0
+
+        client = backend_client_manager.get(backend_id)
+        if client is None:
+            raise ServiceUnavailable(f"No client exist for backend ID {backend_id}.")
 
         try:
-            response = await submit_inference(
-                backend_id, backend_client_manager, payload
-            )
+            response: StreamingResponse | dict[str, Any]
+            if streaming:
+                response = await submit_inference_streaming(
+                    client,
+                    payload,
+                    admission_controller,
+                    request_id,
+                )
+            else:
+                response = await submit_inference(
+                    client,
+                    payload,
+                    admission_controller,
+                    request_id,
+                )
         except:
             # TODO: figure out a way to gather and report errors
             deployment = get_deployment_from_backend_id(model.deployments, backend_id)
             await admission_controller.record_error(
                 backend_id, deployment.router_params
             )
+            await admission_controller.settle(request_id, actual_tokens=0)
             backend_candidates = [b for b in backend_candidates if b.uid != backend_id]
             logger.warning(f"Backend {backend_id} failed, trying next one.")
         else:
-            parser = USAGE_PARSERS.get(payload.endpoint)
-            usage = parser.parse_unary(response) if parser else TokenUsage()
-            total_tokens = usage.total_tokens or 0
-            # TODO: emit structured log events (this is a placeholder for visibility):
-            logger.info(
-                f"{payload.endpoint} - {model.name} - {user.username} - {usage}"
-            )
             return response
-        finally:
-            await admission_controller.settle(request_id, actual_tokens=total_tokens)
 
     # Error if none of the attempts worked
     raise ServiceUnavailable(
@@ -84,20 +94,61 @@ async def submit_inference_with_retry(
 
 
 async def submit_inference(
-    backend_id: str,
-    backend_client_manager: BackendClientManager,
+    client: AsyncClient,
     payload: BasePayload,
+    admission_controller: AdmissionController,
+    request_id: str,
 ) -> dict[str, Any]:
     """POST to an inference backend."""
 
-    client = backend_client_manager.get(backend_id)
-    if client is None:
-        raise ServiceUnavailable(f"No client exist for backend ID {backend_id}.")
-
-    # TODO: handle streaming
     response = await client.post(
         f"/v1/{payload.endpoint}",
         json=payload.model_dump(exclude_unset=True, mode="json"),
     )
     response.raise_for_status()
-    return cast(dict[str, Any], response.json())
+
+    body = cast(dict[str, Any], response.json())
+    parser = USAGE_PARSERS.get(payload.endpoint)
+    usage = parser.parse_unary(body) if parser else TokenUsage()
+    await admission_controller.settle(request_id, actual_tokens=usage.total_tokens or 0)
+    return body
+
+
+async def submit_inference_streaming(
+    client: AsyncClient,
+    payload: BasePayload,
+    admission_controller: AdmissionController,
+    request_id: str,
+) -> StreamingResponse:
+    """POST to an inference backend and relay the SSE stream to the caller."""
+
+    request = client.build_request(
+        "POST",
+        f"/v1/{payload.endpoint}",
+        json=payload.model_dump(exclude_unset=True, mode="json"),
+    )
+
+    response = await client.send(request, stream=True)
+    response.raise_for_status()
+
+    parser = USAGE_PARSERS.get(payload.endpoint)
+
+    async def _relay() -> AsyncIterator[bytes]:
+        tap = UsageTap()
+        try:
+            async for chunk in response.aiter_raw():
+                tap.feed(chunk)
+                yield chunk
+        finally:
+            tap.close()
+            with anyio.CancelScope(shield=True):
+                await response.aclose()
+            usage = parser.parse_stream(tap.first, tap.last) if parser else TokenUsage()
+            total_tokens = usage.total_tokens or 0
+            await admission_controller.settle(request_id, actual_tokens=total_tokens)
+
+    return StreamingResponse(
+        _relay(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )


### PR DESCRIPTION
Adding streaming option for submitting inference with retry. I am having a hard time keeping things clean, since I had to hardcode the try/finally block inside the async iterator. But now we have two self-contained functions to submit inference: submit_inference_streaming and submit_inference.

I was not able to test since my job is stuck in the queue for Tara. I'll make a test tomorrow, but @masalim2 I wanted you to be able to see where this is going to accelerate the process.

One little thing, in terms of generalizing this, should I rename the following?
submit_inference_streaming --> submit_streaming
submit_inference --> submit_unary

Thanks in advanced for the review!

Would close issue #294 